### PR TITLE
adding a single package jest watch mode

### DIFF
--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -14,6 +14,7 @@ export const test = () => {
   return jestTask({
     config: path.join(__dirname, "config", "jest.config.js"),
     watch: argv().watch,
+    _: argv()._
   });
 };
 


### PR DESCRIPTION
This adds a way you can run --watch and pass test names to run tests:

# 1. Per Package

Inside a package, like `bar`

```
cd bar
yarn test --watch
```

Or run a test against a single test

```
cd bar
yarn test index
```

# 2. Per Repo

So far, there isn't a repo-wide jest.config.js. Therefore, the defaults of how tests work will work THROUGH `lage test`:

```
# at root
yarn test --watch
```

You'll see all package's `test` script will get triggered.

This is probably not ideal for more than a handful of packages, and will need to be tweaked... but it works


