### PR TITLE
auto release on merge of main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
This will enable the release to occur every time the main is merged. The release job will only actually release things when change files are detected. Otherwise, it will simply run a build & test on the main branch at that time.