### PR TITLE
Support explicit concrete type selection

### DIFF
--- a/change/@graphitation-graphql-js-operation-payload-generator-39874ff5-a602-4cdc-8aa3-307ef52c0045.json
+++ b/change/@graphitation-graphql-js-operation-payload-generator-39874ff5-a602-4cdc-8aa3-307ef52c0045.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[operation-payload-generator] Let user choose concrete type",
+  "packageName": "@graphitation/graphql-js-operation-payload-generator",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
@@ -290,10 +290,11 @@ xtest("generate mock using custom mock functions", () => {
   );
 });
 
-xtest("generate mock using custom mock functions for object type", () => {
-  graphql`
+test("generate mock using custom mock functions for object type", () => {
+  const fragment = graphql`
     fragment RelayMockPayloadGeneratorTest8Fragment on Page {
       actor {
+        __typename
         id
         name
       }
@@ -307,9 +308,12 @@ xtest("generate mock using custom mock functions for object type", () => {
     graphql`
       query RelayMockPayloadGeneratorTest8Query {
         node(id: "my-id") {
+          __typename
           ...RelayMockPayloadGeneratorTest8Fragment
+          id
         }
       }
+      ${fragment}
     `,
     {
       Image: () => {
@@ -323,10 +327,13 @@ xtest("generate mock using custom mock functions for object type", () => {
   );
 });
 
-xtest("generate mock for objects without concrete type", () => {
-  graphql`
+// NOTE: The snapshot here is different becuase we can better
+// resolve the possible concrete type that an interface can implement.
+test("generate mock for objects without concrete type", () => {
+  const fragment = graphql`
     fragment RelayMockPayloadGeneratorTest9Fragment on Page {
       actor {
+        __typename
         id
         name
       }
@@ -336,9 +343,12 @@ xtest("generate mock for objects without concrete type", () => {
     graphql`
       query RelayMockPayloadGeneratorTest9Query {
         node(id: "my-id") {
+          __typename
           ...RelayMockPayloadGeneratorTest9Fragment
+          id
         }
       }
+      ${fragment}
     `,
     {
       Actor: () => {
@@ -924,11 +934,12 @@ describe("with @relay_test_operation", () => {
     );
   });
 
-  xtest("generate mock with Mock Resolvers for Interface Type with multiple fragment spreads", () => {
+  test("generate mock with Mock Resolvers for Interface Type with multiple fragment spreads", () => {
     testGeneratedData(
       graphql`
-        query RelayMockPayloadGeneratorTest25Query @relay_test_operation {
+        query RelayMockPayloadGeneratorTest25Query {
           node(id: "my-id") {
+            __typename
             ... on User {
               id
               name
@@ -937,6 +948,7 @@ describe("with @relay_test_operation", () => {
               id
               pageName: name
             }
+            id
           }
         }
       `,

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
@@ -233,8 +233,8 @@ xtest("generate mock with connection", () => {
   `);
 });
 
-xtest("generate basic mock data", () => {
-  graphql`
+test("generate basic mock data", () => {
+  const fragment = graphql`
     fragment RelayMockPayloadGeneratorTest6Fragment on User {
       id
       name
@@ -248,9 +248,12 @@ xtest("generate basic mock data", () => {
     graphql`
       query RelayMockPayloadGeneratorTest6Query {
         node(id: "my-id") {
+          __typename
           ...RelayMockPayloadGeneratorTest6Fragment
+          id
         }
       }
+      ${fragment}
     `,
     null // Mock Resolvers
   );

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
@@ -63,11 +63,13 @@ fragment RelayMockPayloadGeneratorTest6Fragment on User {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "User",
-      "id": "<mock-id-1>",
+      "id": "<mock-id-3>",
       "name": "<mock-value-for-field-\\"name\\">",
       "author": {
+        "__typename": "User",
         "id": "<User-mock-id-2>",
         "name": "<mock-value-for-field-\\"name\\">"
       }
@@ -525,11 +527,13 @@ fragment RelayMockPayloadGeneratorTest7Fragment on User {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "User",
-      "id": "my-id-1001",
+      "id": "my-id-1002",
       "name": "<mock-value-for-field-\\"name\\">",
       "profile_picture": {
+        "__typename": "Image",
         "uri": "http://my-uri"
       }
     }
@@ -615,6 +619,7 @@ fragment RelayMockPayloadGeneratorTest8Fragment on Page {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "Page",
       "actor": {
@@ -623,6 +628,7 @@ fragment RelayMockPayloadGeneratorTest8Fragment on Page {
         "name": "<mock-value-for-field-\\"name\\">"
       },
       "backgroundImage": {
+        "__typename": "Image",
         "width": 200,
         "uri": "http://my-image"
       },
@@ -1338,7 +1344,7 @@ query RelayMockPayloadGeneratorTest23Query {
 
 exports[`with @relay_test_operation generate mock with Mock Resolvers for Interface Type 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
-query RelayMockPayloadGeneratorTest24Query {
+query RelayMockPayloadGeneratorTest24Query @relay_test_operation {
   node(id: "my-id") {
     __typename
     ... on User {
@@ -1352,6 +1358,7 @@ query RelayMockPayloadGeneratorTest24Query {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "User",
       "id": "my-id",

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
@@ -255,12 +255,13 @@ fragment RelayMockPayloadGeneratorTest9Fragment on Page {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "Page",
       "actor": {
-        "__typename": "__MockObject",
+        "__typename": "User",
         "id": "<mock-id-1>",
-        "name": "<mock-value-for-field-\\"name\\">"
+        "name": "Mark"
       },
       "id": "<mock-id-2>"
     }
@@ -671,9 +672,9 @@ fragment RelayMockPayloadGeneratorTest1Fragment on Actor {
     "viewer": {
       "__typename": "Viewer",
       "actor": {
+        "__typename": "User",
         "id": "<mock-id-2>",
         "name": "<mock-value-for-field-\\"name\\">",
-        "__typename": "User",
         "firstName": "<mock-value-for-field-\\"firstName\\">",
         "lastName": "<mock-value-for-field-\\"lastName\\">"
       }
@@ -1413,6 +1414,7 @@ query RelayMockPayloadGeneratorTest25Query {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 {
   "data": {
+    "__typename": "Query",
     "node": {
       "__typename": "Page",
       "id": "my-page-id",

--- a/packages/graphql-js-operation-payload-generator/src/vendor/RelayMockPayloadGenerator.ts
+++ b/packages/graphql-js-operation-payload-generator/src/vendor/RelayMockPayloadGenerator.ts
@@ -22,7 +22,10 @@ type MockResolver = (
 
 export type MockResolvers = Record<string, MockResolver>;
 
-export type MockData = Record<string, unknown>;
+export interface MockData {
+  __typename?: string;
+  [fieldName: string]: unknown;
+}
 
 export type ValueResolver = (
   typeName: string | null,


### PR DESCRIPTION
In case of an abstract type the user can specify a mock that returns a specific typename, in which case the appropriate fragment spread should be selected.