### PR TITLE
Support explicit concrete type selection across mutliple fragment spreads

### DIFF
--- a/change/@graphitation-graphql-js-operation-payload-generator-593b7df5-c7f3-468b-829e-bb9d4b183be2.json
+++ b/change/@graphitation-graphql-js-operation-payload-generator-593b7df5-c7f3-468b-829e-bb9d4b183be2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[operation-payload-generator] Add test case that visits across multiple fragment boundaries",
+  "packageName": "@graphitation/graphql-js-operation-payload-generator",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/RelayMockPayloadGenerator.test.ts
@@ -327,7 +327,7 @@ test("generate mock using custom mock functions for object type", () => {
   );
 });
 
-// NOTE: The snapshot here is different becuase we can better
+// NOTE: The snapshot here is different because we can better
 // resolve the possible concrete type that an interface can implement.
 test("generate mock for objects without concrete type", () => {
   const fragment = graphql`
@@ -934,23 +934,34 @@ describe("with @relay_test_operation", () => {
     );
   });
 
+  // Added more fragments here to test resolving across fragment definition boundaries.
   test("generate mock with Mock Resolvers for Interface Type with multiple fragment spreads", () => {
+    const fragment1 = graphql`
+      fragment RelayMockPayloadGeneratorTest25Fragment1 on Page {
+        id
+        pageName: name
+      }
+    `;
+    const fragment2 = graphql`
+      fragment RelayMockPayloadGeneratorTest25Fragment2 on Node {
+        __typename
+        ... on User {
+          id
+          name
+        }
+        ...RelayMockPayloadGeneratorTest25Fragment1
+        id
+      }
+      ${fragment1}
+    `;
     testGeneratedData(
       graphql`
         query RelayMockPayloadGeneratorTest25Query {
           node(id: "my-id") {
-            __typename
-            ... on User {
-              id
-              name
-            }
-            ... on Page {
-              id
-              pageName: name
-            }
-            id
+            ...RelayMockPayloadGeneratorTest25Fragment2
           }
         }
+        ${fragment2}
       `,
       {
         Node() {

--- a/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
+++ b/packages/graphql-js-operation-payload-generator/src/__tests__/__snapshots__/RelayMockPayloadGenerator.test.ts.snap
@@ -1398,17 +1398,23 @@ exports[`with @relay_test_operation generate mock with Mock Resolvers for Interf
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query RelayMockPayloadGeneratorTest25Query {
   node(id: "my-id") {
-    __typename
-    ... on User {
-      id
-      name
-    }
-    ... on Page {
-      id
-      pageName: name
-    }
-    id
+    ...RelayMockPayloadGeneratorTest25Fragment2
   }
+}
+
+fragment RelayMockPayloadGeneratorTest25Fragment2 on Node {
+  __typename
+  ... on User {
+    id
+    name
+  }
+  ...RelayMockPayloadGeneratorTest25Fragment1
+  id
+}
+
+fragment RelayMockPayloadGeneratorTest25Fragment1 on Page {
+  id
+  pageName: name
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~


### PR DESCRIPTION
The existing test case didn’t cover what we actually do in TMP.