### PR TITLE
Make variables optional

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-838deb81-9ef0-4dce-9e3a-6d889258223c.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-838deb81-9ef0-4dce-9e3a-6d889258223c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make variables param optional in mutations",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-react-relay-duct-tape/src/hooks.ts
+++ b/packages/apollo-react-relay-duct-tape/src/hooks.ts
@@ -178,7 +178,7 @@ export function useSubscription<TSubscriptionPayload extends OperationType>(
 }
 
 interface IMutationCommitterOptions<TMutationPayload extends OperationType> {
-  variables: TMutationPayload["variables"];
+  variables?: TMutationPayload["variables"];
   optimisticResponse?: Partial<TMutationPayload["response"]> | null;
 }
 


### PR DESCRIPTION
Make variables param optional in mutations to make it simpler to type.