### PR TITLE
[relay-compiler-language-graphitation] optimize AST size

### DIFF
--- a/examples/apollo-watch-fragments/src/__generated__/AppQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/AppQuery.graphql.ts
@@ -108,8 +108,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Boolean"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -129,8 +128,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Int"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -150,11 +148,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "String"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -181,7 +177,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -190,26 +185,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "Field",
                     "name": {
                       "kind": "Name",
                       "value": "totalCount"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "FragmentSpread",
                     "name": {
                       "kind": "Name",
                       "value": "TodoListFooter_todosFragment"
-                    },
-                    "directives": []
+                    }
                   }
                 ]
               }
@@ -219,8 +209,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "TodoList_queryFragment"
-              },
-              "directives": []
+              }
             }
           ]
         }
@@ -238,7 +227,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "TodosConnection"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -247,18 +235,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "uncompletedCount"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             }
           ]
         }
@@ -276,7 +260,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Query"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -348,8 +331,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "edges"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -359,8 +340,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "node"
                           },
-                          "arguments": [],
-                          "directives": [],
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -369,35 +348,28 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                 "name": {
                                   "kind": "Name",
                                   "value": "id"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "isCompleted"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "FragmentSpread",
                                 "name": {
                                   "kind": "Name",
                                   "value": "Todo_todoFragment"
-                                },
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "__typename"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               }
                             ]
                           }
@@ -407,9 +379,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "cursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -420,8 +390,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "pageInfo"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -430,18 +398,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "endCursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "hasNextPage"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -451,9 +415,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   }
                 ]
               }
@@ -474,7 +436,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Todo"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -483,27 +444,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "description"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "isCompleted"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
@@ -511,7 +466,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "someOtherField"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",
@@ -572,8 +526,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Boolean"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -593,8 +546,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Int"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -614,11 +566,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "String"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -645,7 +595,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -654,18 +603,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "Field",
                     "name": {
                       "kind": "Name",
                       "value": "totalCount"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "InlineFragment",
@@ -676,7 +621,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                         "value": "Node"
                       }
                     },
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -686,15 +630,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "__fragments"
                           },
-                          "arguments": [],
                           "directives": [
                             {
                               "kind": "Directive",
                               "name": {
                                 "kind": "Name",
                                 "value": "client"
-                              },
-                              "arguments": []
+                              }
                             }
                           ]
                         }
@@ -710,15 +652,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "__fragments"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",
                   "name": {
                     "kind": "Name",
                     "value": "client"
-                  },
-                  "arguments": []
+                  }
                 }
               ]
             }

--- a/examples/apollo-watch-fragments/src/__generated__/TodoListFooter_todosWatchNodeQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoListFooter_todosWatchNodeQuery.graphql.ts
@@ -51,11 +51,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "ID"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -81,7 +79,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -90,26 +87,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "__typename"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "FragmentSpread",
                     "name": {
                       "kind": "Name",
                       "value": "TodoListFooter_todosFragment"
-                    },
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "Field",
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "InlineFragment",
@@ -120,7 +112,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                         "value": "Node"
                       }
                     },
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -130,15 +121,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "__fragments"
                           },
-                          "arguments": [],
                           "directives": [
                             {
                               "kind": "Directive",
                               "name": {
                                 "kind": "Name",
                                 "value": "client"
-                              },
-                              "arguments": []
+                              }
                             }
                           ]
                         }
@@ -164,7 +153,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "TodosConnection"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -173,18 +161,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "uncompletedCount"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             }
           ]
         }

--- a/examples/apollo-watch-fragments/src/__generated__/TodoListPaginationQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoListPaginationQuery.graphql.ts
@@ -105,8 +105,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "String"
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -126,8 +125,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Int"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -144,11 +142,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "Boolean"
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -157,8 +153,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "TodoList_queryFragment"
-              },
-              "directives": []
+              }
             }
           ]
         }
@@ -176,7 +171,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Query"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -248,8 +242,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "edges"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -259,8 +251,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "node"
                           },
-                          "arguments": [],
-                          "directives": [],
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -269,35 +259,28 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                 "name": {
                                   "kind": "Name",
                                   "value": "id"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "isCompleted"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "FragmentSpread",
                                 "name": {
                                   "kind": "Name",
                                   "value": "Todo_todoFragment"
-                                },
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "__typename"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               }
                             ]
                           }
@@ -307,9 +290,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "cursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -320,8 +301,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "pageInfo"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -330,18 +309,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "endCursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "hasNextPage"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -351,9 +326,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   }
                 ]
               }
@@ -374,7 +347,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Todo"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -383,27 +355,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "description"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "isCompleted"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
@@ -411,7 +377,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "someOtherField"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",
@@ -469,8 +434,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "String"
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -490,8 +454,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "Int"
                 }
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -508,11 +471,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "Boolean"
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -521,8 +482,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "TodoList_queryFragment"
-              },
-              "directives": []
+              }
             },
             {
               "kind": "Field",
@@ -530,15 +490,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "__fragments"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",
                   "name": {
                     "kind": "Name",
                     "value": "client"
-                  },
-                  "arguments": []
+                  }
                 }
               ]
             }
@@ -558,7 +516,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Query"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -630,8 +587,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "edges"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -641,8 +596,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "node"
                           },
-                          "arguments": [],
-                          "directives": [],
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -651,27 +604,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                 "name": {
                                   "kind": "Name",
                                   "value": "id"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "isCompleted"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "__typename"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "InlineFragment",
@@ -682,7 +629,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                     "value": "Node"
                                   }
                                 },
-                                "directives": [],
                                 "selectionSet": {
                                   "kind": "SelectionSet",
                                   "selections": [
@@ -692,15 +638,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                         "kind": "Name",
                                         "value": "__fragments"
                                       },
-                                      "arguments": [],
                                       "directives": [
                                         {
                                           "kind": "Directive",
                                           "name": {
                                             "kind": "Name",
                                             "value": "client"
-                                          },
-                                          "arguments": []
+                                          }
                                         }
                                       ]
                                     }
@@ -715,9 +659,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "cursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -728,8 +670,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "pageInfo"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -738,18 +678,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "endCursor"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "hasNextPage"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -759,9 +695,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   }
                 ]
               }

--- a/examples/apollo-watch-fragments/src/__generated__/TodoRefetchQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoRefetchQuery.graphql.ts
@@ -83,8 +83,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "Boolean"
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -104,11 +103,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "ID"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -134,7 +131,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -143,26 +139,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "__typename"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "FragmentSpread",
                     "name": {
                       "kind": "Name",
                       "value": "Todo_todoFragment"
-                    },
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "Field",
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   }
                 ]
               }
@@ -183,7 +174,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Todo"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -192,27 +182,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "description"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "isCompleted"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
@@ -220,7 +204,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "someOtherField"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",
@@ -278,8 +261,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "Boolean"
               }
-            },
-            "directives": []
+            }
           },
           {
             "kind": "VariableDefinition",
@@ -299,11 +281,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "ID"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -329,7 +309,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -338,26 +317,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                     "name": {
                       "kind": "Name",
                       "value": "__typename"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "FragmentSpread",
                     "name": {
                       "kind": "Name",
                       "value": "Todo_todoFragment"
-                    },
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "Field",
                     "name": {
                       "kind": "Name",
                       "value": "id"
-                    },
-                    "arguments": [],
-                    "directives": []
+                    }
                   },
                   {
                     "kind": "InlineFragment",
@@ -368,7 +342,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                         "value": "Node"
                       }
                     },
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -378,15 +351,13 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "__fragments"
                           },
-                          "arguments": [],
                           "directives": [
                             {
                               "kind": "Directive",
                               "name": {
                                 "kind": "Name",
                                 "value": "client"
-                              },
-                              "arguments": []
+                              }
                             }
                           ]
                         }
@@ -412,7 +383,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
             "value": "Todo"
           }
         },
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -421,27 +391,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
               "name": {
                 "kind": "Name",
                 "value": "id"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "description"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
               "name": {
                 "kind": "Name",
                 "value": "isCompleted"
-              },
-              "arguments": [],
-              "directives": []
+              }
             },
             {
               "kind": "Field",
@@ -449,7 +413,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                 "kind": "Name",
                 "value": "someOtherField"
               },
-              "arguments": [],
               "directives": [
                 {
                   "kind": "Directive",

--- a/examples/apollo-watch-fragments/src/__generated__/useAddTodoMutation.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/useAddTodoMutation.graphql.ts
@@ -102,11 +102,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "AddTodoInput"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -132,7 +130,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -142,8 +139,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todoEdge"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -152,9 +147,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "__typename"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
@@ -162,8 +155,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "node"
                           },
-                          "arguments": [],
-                          "directives": [],
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -172,27 +163,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                 "name": {
                                   "kind": "Name",
                                   "value": "id"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "isCompleted"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "description"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               }
                             ]
                           }
@@ -206,8 +191,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todos"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -216,27 +199,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "totalCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "uncompletedCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -278,11 +255,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "AddTodoInput"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -308,7 +283,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -318,8 +292,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todoEdge"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -328,9 +300,7 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "__typename"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
@@ -338,8 +308,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                             "kind": "Name",
                             "value": "node"
                           },
-                          "arguments": [],
-                          "directives": [],
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -348,27 +316,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                                 "name": {
                                   "kind": "Name",
                                   "value": "id"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "isCompleted"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               },
                               {
                                 "kind": "Field",
                                 "name": {
                                   "kind": "Name",
                                   "value": "description"
-                                },
-                                "arguments": [],
-                                "directives": []
+                                }
                               }
                             ]
                           }
@@ -382,8 +344,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todos"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -392,27 +352,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "totalCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "uncompletedCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }

--- a/examples/apollo-watch-fragments/src/__generated__/useChangeTodoStatusMutation.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/useChangeTodoStatusMutation.graphql.ts
@@ -91,11 +91,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "ChangeTodoStatusInput"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -121,7 +119,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -131,8 +128,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todo"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -141,18 +136,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "isCompleted"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -163,8 +154,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todos"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -173,27 +162,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "totalCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "uncompletedCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -235,11 +218,9 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   "value": "ChangeTodoStatusInput"
                 }
               }
-            },
-            "directives": []
+            }
           }
         ],
-        "directives": [],
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
@@ -265,7 +246,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                   }
                 }
               ],
-              "directives": [],
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
@@ -275,8 +255,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todo"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -285,18 +263,14 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "isCompleted"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }
@@ -307,8 +281,6 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                       "kind": "Name",
                       "value": "todos"
                     },
-                    "arguments": [],
-                    "directives": [],
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -317,27 +289,21 @@ export const documents: import("relay-compiler-language-graphitation").CompiledA
                           "name": {
                             "kind": "Name",
                             "value": "id"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "totalCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         },
                         {
                           "kind": "Field",
                           "name": {
                             "kind": "Name",
                             "value": "uncompletedCount"
-                          },
-                          "arguments": [],
-                          "directives": []
+                          }
                         }
                       ]
                     }

--- a/packages/relay-compiler-language-graphitation/package.json
+++ b/packages/relay-compiler-language-graphitation/package.json
@@ -21,12 +21,12 @@
     "just": "monorepo-scripts"
   },
   "dependencies": {
+    "@graphql-tools/optimize": "^1.1.1",
     "relay-compiler-language-typescript": "^14.0.0",
     "typescript": "^4.2.3"
   },
   "devDependencies": {
     "@graphitation/graphql-js-tag": "^0.5.4",
-    "@graphql-tools/optimize": "^1.1.1",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.22",
     "@types/relay-compiler": "^8.0.0",

--- a/packages/relay-compiler-language-graphitation/package.json
+++ b/packages/relay-compiler-language-graphitation/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@graphitation/graphql-js-tag": "^0.5.4",
+    "@graphql-tools/optimize": "^1.1.1",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.22",
     "@types/relay-compiler": "^8.0.0",

--- a/packages/relay-compiler-language-graphitation/src/formatModule.ts
+++ b/packages/relay-compiler-language-graphitation/src/formatModule.ts
@@ -5,6 +5,7 @@
 
 import { FormatModule } from "relay-compiler/lib/language/RelayLanguagePluginInterface";
 import { DocumentNode, parse, print } from "graphql";
+import { optimizeDocumentNode } from "@graphql-tools/optimize";
 import { reduceNodeWatchQueryTransform } from "./formatModuleTransforms/reduceNodeWatchQueryTransform";
 import { schema } from "./schema";
 import invariant from "invariant";
@@ -19,17 +20,18 @@ function printDocumentComment(document: DocumentNode) {
 function generateExports(moduleName: string, docText: string) {
   const exports: CompiledArtefactModule = {};
   const originalDocument = parse(docText, { noLocation: true });
+  const optimizedDocument = optimizeDocumentNode(originalDocument);
 
   if (!moduleName.endsWith("WatchNodeQuery.graphql")) {
     exports.executionQueryDocument = stripFragmentReferenceFieldSelectionTransform(
-      originalDocument
+      optimizedDocument
     );
   }
 
   invariant(schema, "Expected a schema to be passed in or set in the env");
   exports.watchQueryDocument = reduceNodeWatchQueryTransform(
     schema,
-    originalDocument
+    optimizedDocument
   );
 
   exports.metadata = extractMetadataTransform(exports.watchQueryDocument);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,6 +1670,13 @@
   dependencies:
     tslib "~2.3.0"
 
+"@graphql-tools/optimize@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.1.1.tgz#dcd59ba1ee34431e5e9b086b57fe0bdb1a176669"
+  integrity sha512-y0TEfPyGmJaQjnsTRs/UP7/ZHaB3i68VAsXW4H2doUFKY6rIOUz+ruME/uWsfy/VeTWBNqGX8/m/X7YFEi5OJQ==
+  dependencies:
+    tslib "~2.3.0"
+
 "@graphql-tools/prisma-loader@^7.0.6":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-7.1.0.tgz#790dd29ad682f6c1fc7ceb3cf48b04cb1064b7f4"


### PR DESCRIPTION
# Description

Support [@graphql-tools/optimize](https://github.com/ardatan/graphql-tools/tree/master/packages/optimize) for smaller AST size. By default optimizers will: remove descriptions, remove empty optional properties (like `arguments: []` or `directives: []`) and remove locations if they exist.

One minor issue with this package is that each optimizer does a separate `visit` pass over a document, so it will perform 3 additional passes. I think it's OK-ish for build-time tools though.