### PR TITLE
[example] Configure source-maps for React Render Tracker to open editor

### DIFF
--- a/examples/apollo-watch-fragments/public/index.html
+++ b/examples/apollo-watch-fragments/public/index.html
@@ -10,9 +10,7 @@
     <script
       src="https://cdn.jsdelivr.net/npm/react-render-tracker"
       data-config="
-        openSourceLoc: {
-          pattern: 'vscode://file/[file]'
-        }
+        openSourceLoc: 'vscode://file/[file]'
       "
     ></script>
   </head>

--- a/examples/apollo-watch-fragments/public/index.html
+++ b/examples/apollo-watch-fragments/public/index.html
@@ -9,9 +9,7 @@
     <link rel="stylesheet" href="loading-spinner.css" />
     <script
       src="https://cdn.jsdelivr.net/npm/react-render-tracker"
-      data-config="
-        openSourceLoc: 'vscode://file/[file]'
-      "
+      data-config="openSourceLoc: 'vscode://file/[file]'"
     ></script>
   </head>
   <body>

--- a/examples/apollo-watch-fragments/public/index.html
+++ b/examples/apollo-watch-fragments/public/index.html
@@ -7,7 +7,14 @@
     <link rel="stylesheet" href="base.css" />
     <link rel="stylesheet" href="index.css" />
     <link rel="stylesheet" href="loading-spinner.css" />
-    <script src="https://cdn.jsdelivr.net/npm/react-render-tracker"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/react-render-tracker"
+      data-config="
+        openSourceLoc: {
+          pattern: 'vscode://file/[file]'
+        }
+      "
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/apollo-watch-fragments/webpack.config.ts
+++ b/examples/apollo-watch-fragments/webpack.config.ts
@@ -6,7 +6,7 @@ import { createImportDocumentsTransform } from "@graphitation/apollo-react-relay
 const config: webpack.Configuration = {
   mode: "development",
   entry: "./src/index.tsx",
-  devtool: "inline-source-map",
+  devtool: false,
   devServer: {
     static: "./public",
     client: {
@@ -46,6 +46,20 @@ const config: webpack.Configuration = {
     filename: "bundle.js",
     path: path.resolve(__dirname, "public"),
   },
+  plugins: [
+    /**
+     * Configure source-maps to use absolute file:// paths, so tooling like React Render Tracker
+     * does not need (user) specific configuration.
+     *
+     * NOTE: You would only want to do this in a dev env -- which this example app always is.
+     */
+    new webpack.SourceMapDevToolPlugin({
+      // Set absolute path to source root of this repo
+      sourceRoot: path.resolve(__dirname, "../.."),
+      // Override template to replace the webpack:// protocol with file:// (and remove namespace)
+      moduleFilenameTemplate: "file://[resource-path]?[loaders]",
+    }),
+  ],
 };
 
 export default config;


### PR DESCRIPTION
This sets up React Render Tracker in the example to work for anyone.

@lahmatiy Do you think this is an acceptable generic solution that we can add to your README?