### PR TITLE
Relay compiler language graphitation/dependency update

### DIFF
--- a/change/relay-compiler-language-graphitation-76b539a4-8840-4406-adb6-0a246d482c46.json
+++ b/change/relay-compiler-language-graphitation-76b539a4-8840-4406-adb6-0a246d482c46.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "We were facing an error in relay-compiler-language-typescript: 14.0.0. issue described here, which caused a syntax error in generated files. With >=14.0.0 in this update we wanted to not force apps which use the graphitation plugin to have TS version 4.5 or greater.",
+  "packageName": "relay-compiler-language-graphitation",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/relay-compiler-language-graphitation/package.json
+++ b/packages/relay-compiler-language-graphitation/package.json
@@ -15,7 +15,7 @@
     "just": "monorepo-scripts"
   },
   "dependencies": {
-    "relay-compiler-language-typescript": "^14.0.0",
+    "relay-compiler-language-typescript": ">=14.0.0",
     "typescript": "^4.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,11 +4081,6 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immutable@^4.0.0-rc.12:
-  version "4.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
-  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
-
 immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
@@ -6192,12 +6187,11 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
-relay-compiler-language-typescript@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-14.0.0.tgz#53a256d2da9656ded7bb43b465cde61c361027b5"
-  integrity sha512-/x9WvwTcO/wNxzRnegzWI0T5eggd0zI0/e6C08lQe4djtzzSlydTLM3Aa9P5piiZYrcrkVwD/Kbc90cifDtb2w==
+relay-compiler-language-typescript@>=14.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-15.0.0.tgz#565900106eeb7150d70c5792ef092a2807a8e25e"
+  integrity sha512-vx6V+uBJLIyzTFz1fFiuS0J+L81juGUComb5emKNaYGZRWOPSalxyS+0/I6umrNChNDFB5uLuTnAqxia4+ZMBg==
   dependencies:
-    immutable "^4.0.0-rc.12"
     invariant "^2.2.4"
 
 relay-compiler@11.0.2, relay-compiler@^11.0.2:


### PR DESCRIPTION
We were facing an error in `relay-compiler-language-typescript: 14.0.0.` issue described [here](https://github.com/relay-tools/relay-compiler-language-typescript/issues/513), which caused a syntax error in generated files.

With `>=14.0.0` in this update we wanted to not force apps which use the graphitation plugin to have TS version 4.5 or greater.  