### PR TITLE
Relay compiler language graphitation/typescript update

### DIFF
--- a/change/relay-compiler-language-graphitation-6550d47d-e88f-494e-ac11-b1f462a9b7d1.json
+++ b/change/relay-compiler-language-graphitation-6550d47d-e88f-494e-ac11-b1f462a9b7d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "typecript version changed from ^4.2.3 to >=4.2.3 based on https://github.com/microsoft/graphitation/pull/78",
+  "packageName": "relay-compiler-language-graphitation",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/relay-compiler-language-graphitation/package.json
+++ b/packages/relay-compiler-language-graphitation/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "relay-compiler-language-typescript": ">=14.0.0",
-    "typescript": "^4.2.3"
+    "typescript": ">=4.2.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7250,6 +7250,11 @@ typescript@4.4.3, typescript@^4.4.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
+typescript@>=4.2.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
 typescript@^3.0.0:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"


### PR DESCRIPTION
typecript version changed from ^4.2.3 to >=4.2.3 based on [PR #78 ](https://github.com/microsoft/graphitation/pull/78)