### PR TITLE
chore: package.json fixes for supermassive

### DIFF
--- a/change/@graphitation-supermassive-23b2314a-ae06-4bc4-8602-23a1db17c751.json
+++ b/change/@graphitation-supermassive-23b2314a-ae06-4bc4-8602-23a1db17c751.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unpin typescript dependency",
+  "packageName": "@graphitation/supermassive",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/package.json
+++ b/packages/supermassive/package.json
@@ -17,7 +17,7 @@
     "test": "monorepo-scripts test",
     "types": "monorepo-scripts types",
     "just": "monorepo-scripts",
-    "benchmark": "ts-node -T -O '{\"module\":\"commonjs\"}' ./src/benchmarks/index.ts"
+    "benchmark": "ts-node -T ./src/benchmarks/index.ts"
   },
   "devDependencies": {
     "@graphitation/graphql-js-tag": "*",
@@ -47,6 +47,6 @@
     "@graphql-tools/schema": "^7.1.5",
     "commander": "^8.3.0",
     "graphql": "^15.6.1",
-    "typescript": "4.4.3"
+    "typescript": "^4.4.3"
   }
 }

--- a/packages/supermassive/tsconfig.json
+++ b/packages/supermassive/tsconfig.json
@@ -8,5 +8,10 @@
     "jsx": "react"
   },
   "include": ["src"],
-  "references": []
+  "references": [],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,11 +7245,6 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.4.3, typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
-
 typescript@>=4.2.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
@@ -7259,6 +7254,11 @@ typescript@^3.0.0:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 typescript@~3.7.2:
   version "3.7.7"


### PR DESCRIPTION
# Description

This PR does two things for the `supermassive` package: 

1. "Unpins" `typescript` dependency from a fixed version. Now it is the same as in: 
https://github.com/microsoft/graphitation/blob/62cc911d8b0a6bea8cab19ad35f2b672a14a7a4d/packages/ts-transform-graphql-js-tag/package.json#L39

2. Allows running `benchmark` command on Windows (it currently fails)