### PR TITLE
[ARRDT] Dispose any refetch query on unmount

### DIFF
--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks.test.tsx
@@ -691,7 +691,7 @@ describe("compiledHooks", () => {
         expect(client.getObservableQueries().has(query.queryId)).toBeFalsy();
       });
 
-      it.only("cancels when unmounting", async () => {
+      it("cancels when unmounting", async () => {
         await act(async () => {
           const query = last(activeQueries(client));
           testRenderer.unmount();

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks.test.tsx
@@ -691,6 +691,15 @@ describe("compiledHooks", () => {
         expect(client.getObservableQueries().has(query.queryId)).toBeFalsy();
       });
 
+      it.only("cancels when unmounting", async () => {
+        await act(async () => {
+          const query = last(activeQueries(client));
+          testRenderer.unmount();
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(client.getObservableQueries().has(query.queryId)).toBeFalsy();
+        });
+      });
+
       describe("successfully", () => {
         beforeEach(async () => {
           await act(() => {

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
@@ -44,16 +44,6 @@ function useLoadMore({
   updater,
 }: PaginationParams): [loadPage: PaginationFn, isLoadingMore: boolean] {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const disposable = useRef<Disposable>();
-  useEffect(
-    () => () => {
-      if (disposable.current) {
-        disposable.current.dispose();
-        disposable.current = undefined;
-      }
-    },
-    [] // On unmount
-  );
   const loadPage = useCallback<PaginationFn>(
     (countValue, options) => {
       invariant(
@@ -83,7 +73,6 @@ function useLoadMore({
           // NOTE: We can do this now already, because `refetch` wraps the
           //       onCompleted callback in a batchedUpdates callback.
           setIsLoadingMore(false);
-          disposable.current = undefined;
 
           if (!error) {
             invariant(
@@ -139,9 +128,9 @@ function useLoadMore({
       // TODO: Measure if invoking `refetch` leads to React updates and if it
       //       makes sense to wrap it and the following setIsLoadingMore(true)
       //       call in a batchedUpdates callback.
-      disposable.current = refetch(newVariables, refetchOptions);
+      const disposable = refetch(newVariables, refetchOptions);
       setIsLoadingMore(true);
-      return disposable.current;
+      return disposable;
     },
     [
       fragmentReference.id,

--- a/website/docs/apollo-react-relay-duct-tape/use-pagination-fragment.md
+++ b/website/docs/apollo-react-relay-duct-tape/use-pagination-fragment.md
@@ -137,3 +137,4 @@ Object containing the following properties:
 ### Behavior
 
 - The component is automatically subscribed to updates to the fragment data: if the data for this particular `User` is updated anywhere in the app (e.g. via fetching new data, or mutating existing data), the component will automatically re-render with the latest updated data.
+- An in-flight pagination request will automatically be disposed when the component unmounts.

--- a/website/docs/apollo-react-relay-duct-tape/use-refetchable-fragment.md
+++ b/website/docs/apollo-react-relay-duct-tape/use-refetchable-fragment.md
@@ -92,3 +92,4 @@ Tuple containing the following values
 ### Behavior
 
 - The component is automatically subscribed to updates to the fragment data: if the data for this particular `Comment` is updated anywhere in the app (e.g. via fetching new data, or mutating existing data), the component will automatically re-render with the latest updated data.
+- An in-flight refetch request will automatically be disposed when the component unmounts.


### PR DESCRIPTION
Fixes #105 

I had missed in Relay's source that this is done for any refetch query. Also adding it to the [upstream] docs.