### PR TITLE
Supermassive get argument values fix

### DIFF
--- a/change/@graphitation-supermassive-55603d20-15bc-448f-bb08-929dfa343306.json
+++ b/change/@graphitation-supermassive-55603d20-15bc-448f-bb08-929dfa343306.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "getArgumentValues fix",
+  "packageName": "@graphitation/supermassive",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/subscribe.test.ts
+++ b/packages/supermassive/src/__tests__/subscribe.test.ts
@@ -30,6 +30,20 @@ const testCases: Array<TestCase> = [
       limit: 5,
     },
   },
+  {
+    name: "basic subscription with unused non-required variable",
+    document: `
+  subscription emitPersons($limit: Int!, $throwError: Boolean) {
+    emitPersons(limit: $limit, throwError: $throwError) {
+      name
+      gender
+    }
+  }
+ `,
+    variables: {
+      limit: 5,
+    },
+  },
 ];
 
 const errorTestCases: Array<TestCase> = [

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -221,6 +221,8 @@ export function getArgumentValues(
             valueNode as GraphQLValueNode,
           );
         }
+
+        continue;
       }
       isNull = !variableValues || variableValues[variableName] == null;
     }


### PR DESCRIPTION
When the `variableValues` doesn't contain variableName, which is specified in function arguments AND it isn't `isNonNullType` (it's not required) we just want to skip it