### PR TITLE
Memoize fragment document for apollo readFragment

### DIFF
--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
@@ -40,7 +40,7 @@ export const nodeFromCacheFieldPolicy: FieldReadFunction = (
     fragmentName
   );
 
-  let fragmentDocument = fragmentDocumentCache.get(options.query);
+  let fragmentDocument = FRAGMENT_DOCUMENT_CACHE.get(options.query);
 
   if (!fragmentDocument) {
     fragmentDocument = {

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
@@ -2,7 +2,7 @@ import { FieldReadFunction } from "@apollo/client";
 import { FragmentSpreadNode, FragmentDefinitionNode } from "graphql";
 import invariant from "invariant";
 
-const fragmentDocumentCache = new WeakMap();
+const FRAGMENT_DOCUMENT_CACHE = new WeakMap();
 
 /**
  * Use this as the field policy function for the node root field, which is what

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
@@ -49,7 +49,7 @@ export const nodeFromCacheFieldPolicy: FieldReadFunction = (
         (def) => def.kind === "FragmentDefinition"
       ),
     };
-    fragmentDocumentCache.set(options.query, fragmentDocument);
+    FRAGMENT_DOCUMENT_CACHE.set(options.query, fragmentDocument);
   }
 
   const id = `${fragment.typeCondition.name.value}:${nodeId}`;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/nodeFromCacheFieldPolicy.ts
@@ -2,6 +2,8 @@ import { FieldReadFunction } from "@apollo/client";
 import { FragmentSpreadNode, FragmentDefinitionNode } from "graphql";
 import invariant from "invariant";
 
+const fragmentDocumentCache = new WeakMap();
+
 /**
  * Use this as the field policy function for the node root field, which is what
  * gets invoked when using relay-compiler's refetch query. Queries that use a
@@ -38,17 +40,24 @@ export const nodeFromCacheFieldPolicy: FieldReadFunction = (
     fragmentName
   );
 
+  let fragmentDocument = fragmentDocumentCache.get(options.query);
+
+  if (!fragmentDocument) {
+    fragmentDocument = {
+      kind: "Document",
+      definitions: options.query.definitions.filter(
+        (def) => def.kind === "FragmentDefinition"
+      ),
+    };
+    fragmentDocumentCache.set(options.query, fragmentDocument);
+  }
+
   const id = `${fragment.typeCondition.name.value}:${nodeId}`;
   const data = options.cache.readFragment({
     id,
     variables: options.variables,
     fragmentName,
-    fragment: {
-      kind: "Document",
-      definitions: options.query.definitions.filter(
-        (def) => def.kind === "FragmentDefinition"
-      ),
-    },
+    fragment: fragmentDocument,
   });
   invariant(data, "Expected to find cached data with id `%s`", id);
 


### PR DESCRIPTION
This will help us re-use the same optimism cache key (vs creating a new cache entry on each `readFragment` call)

The solution is not great as it introduces a global variable but don't see how to handle this better with the current setup.

Relates to #113

Note: it is only a partial fix - it leads to 2 vs 4 entries of optimism cache added on click in our example project. But not sure yet where those remaining 2 entries come from. It warrants another round of investigation at some point.