### PR TITLE
Force parser not to generate locations for AST nodes

### DIFF
--- a/change/@graphitation-graphql-js-tag-2ba458f3-ff85-44c7-9822-a3825707d79c.json
+++ b/change/@graphitation-graphql-js-tag-2ba458f3-ff85-44c7-9822-a3825707d79c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "force parser not to generate locations for AST nodes",
+  "packageName": "@graphitation/graphql-js-tag",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-js-tag/src/index.ts
+++ b/packages/graphql-js-tag/src/index.ts
@@ -49,7 +49,7 @@ export function graphql(
     document.map((s) => s.trim()).filter((s) => s.length > 0).length === 1,
     "Interpolations are only allowed at the end of the template.",
   );
-  const documentNode = parse(document[0]);
+  const documentNode = parse(document[0], { noLocation: true });
   const definitions = new Set(documentNode.definitions);
   fragments.forEach((doc) =>
     doc.definitions.forEach((def) => definitions.add(def)),


### PR DESCRIPTION
This change is required because of Apollo 3.5.x, which isn't able to dedupe queries that contain location data.