### PR TITLE
Exclude generated files from linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "es6": true,
     "node": true
   },
-  "ignorePatterns": ["**/coverage", "**/lib", "**/temp"],
+  "ignorePatterns": ["**/coverage", "**/lib", "**/temp", "**/__generated__"],
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": "error"


### PR DESCRIPTION
On machines with many cores, `lint` and `test` can run in parralel for `@graphitation/supermassive` project.

This makes sures that __generated__ folders are excluded from lint. As they are part of `.gitignore` already.