### PR TITLE
persist git extra header credentials for publishing purposes

### DIFF
--- a/.azure-devops/graphitation-release.yml
+++ b/.azure-devops/graphitation-release.yml
@@ -29,6 +29,8 @@ jobs:
       - template: ./steps/service-tree.yml
         parameters:
           serviceTreeID: $(serviceTreeID)
+      - checkout: self
+        persistCredentials: true
       - script: yarn
         displayName: yarn
       - script: |

--- a/change/@graphitation-graphql-eslint-rules-1e6635e6-c781-449f-8f98-a5da413773c7.json
+++ b/change/@graphitation-graphql-eslint-rules-1e6635e6-c781-449f-8f98-a5da413773c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixing publishing",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/graphql-eslint-rules/package.json
+++ b/packages/graphql-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphitation/graphql-eslint-rules",
   "license": "MIT",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "main": "./src/index.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This *should* allow for publishes to go through when pushing changes to git. It also fixes out-of-sync versions.