### PR TITLE
[ado] Pierce ADO NPM feed cache for published packages

### DIFF
--- a/.azure-devops/graphitation-release.yml
+++ b/.azure-devops/graphitation-release.yml
@@ -8,6 +8,8 @@ variables:
     value: production,externalfacing
   - name: serviceTreeID
     value: 6F8CD842-E117-412F-BAE4-56A3B6166594
+  - name: adoNpmFeedBaseUrl
+    value: https://pkgs.dev.azure.com/domoreexp/_apis/packaging/feeds/npm-mirror
 
 jobs:
   - job: compliance
@@ -41,3 +43,7 @@ jobs:
         displayName: Configure git for release
       - script: yarn release -y -n $(ossNpmToken) --access public
         displayName: Release
+      - template: ./steps/pierce-ado-npm-mirror-cache.yml
+        parameters:
+          adoNpmFeedPat: $(adoNpmFeedPat)
+          adoNpmFeedBaseUrl: $(adoNpmFeedBaseUrl)

--- a/.azure-devops/steps/pierce-ado-npm-mirror-cache.yml
+++ b/.azure-devops/steps/pierce-ado-npm-mirror-cache.yml
@@ -1,0 +1,22 @@
+# Pierces the ADO npm feed cache in order to pull in new versions published to
+# the public npm feed.
+#
+# Expects the last git commit to contain all package.json files for packages
+# that have been published.
+
+parameters:
+  - name: adoNpmFeedPat
+    type: string
+    default: "PROVIDE AN ADO NPM FEED PAT THAT HAS CONTRIBUTOR PERMISSION"
+  # Base URL looks like: https://pkgs.dev.azure.com/[ORG]/_apis/packaging/feeds/[NPM FEED NAME]
+  - name: adoNpmFeedBaseUrl
+    type: string
+    default: "PROVIDE BASE URL TO ADO NPM FEED"
+
+steps:
+  - bash: |
+      git diff --name-only HEAD HEAD~1 | grep package.json | while read line ; do
+        pkgAndVersion = `cat $line | jq '. | "\(.name)/versions/\(.version)"'`
+        curl -Ivu $(adoNpmFeedPat) $(adoNpmFeedBaseUrl)/npm/packages/$(pkgAndVersion);
+      done
+    displayName: "Pierce ADO NPM feed cache"


### PR DESCRIPTION
Still need to add the PAT to the secrets group, looking into ADO CLI now.