### PR TITLE
HOTFIX: fragment-naming-conventions file checks the filename conventions AND uses this filename for checking the fragment name instead of building in from the lastDirectory name

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-2bdfe3d9-6013-4737-9b33-b6c24a2bbeb0.json
+++ b/change/@graphitation-graphql-eslint-rules-2bdfe3d9-6013-4737-9b33-b6c24a2bbeb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "HOTFIX: fragment-naming-conventions file checks the filename conventions AND uses this filename for checking the fragment name instead of building in from the lastDirectory name",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/fragment-naming-conventions.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/fragment-naming-conventions.test.ts.snap
@@ -19,3 +19,13 @@ exports[` 4`] = `
 "> 1 | fragment UserFragment on User { id name }
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment should follow the naming conventions, the expected name is GraphqlEslintRulesUserFragment OR GraphqlEslintRulesUserFragment_optionalSuffix It's possible to chain suffixes using underscore"
 `;
+
+exports[` 5`] = `
+"> 1 | fragment GraphqlEslintRulesUserFragment on User { id name }
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Filename should start with the package directory name: \\"graphql-eslint-rules\\""
+`;
+
+exports[` 6`] = `
+"> 1 | fragment GraphqlEslintRulesUserFragment on User { id name }
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Filename should end with the operation name (query/mutation/subscription) e.g. foo-query.graphql"
+`;

--- a/packages/graphql-eslint-rules/src/__tests__/fragment-naming-conventions.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/fragment-naming-conventions.test.ts
@@ -32,24 +32,24 @@ ruleTester.runGraphQLTests(
     valid: [
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment GraphqlEslintRulesUserFragment on User { id name }`,
       },
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment GraphqlEslintRulesUserFragment_optionalSuffix on User { id name }`,
       },
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment GraphqlEslintRulesUserFragment_optionalSuffix_anotherOptionalSuffix on User { id name }`,
       },
     ],
     invalid: [
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment graphql_eslint_rules_user_fragment on User { id name }`,
         output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
         errors: [
@@ -60,7 +60,7 @@ ruleTester.runGraphQLTests(
       },
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment GraphqlEslintRulesUserFragment_ on User { id name }`,
         output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
         errors: [
@@ -71,7 +71,7 @@ ruleTester.runGraphQLTests(
       },
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment GraphqlEslintRulesUser on User { id name }`,
         output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
         errors: [
@@ -82,12 +82,30 @@ ruleTester.runGraphQLTests(
       },
       {
         ...WITH_SCHEMA,
-        filename: "src/user-query.graphql",
+        filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment UserFragment on User { id name }`,
         output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
         errors: [
           {
             message: errorMessage,
+          },
+        ],
+      },
+      {
+        filename: "src/user-query.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment on User { id name }`,
+        errors: [
+          {
+            message: `Filename should start with the package directory name: "graphql-eslint-rules"`,
+          },
+        ],
+      },
+      {
+        filename: "src/user.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment on User { id name }`,
+        errors: [
+          {
+            message: `Filename should end with the operation name (query/mutation/subscription) e.g. foo-query.graphql`,
           },
         ],
       },

--- a/packages/graphql-eslint-rules/src/fragment-naming-conventions.ts
+++ b/packages/graphql-eslint-rules/src/fragment-naming-conventions.ts
@@ -10,6 +10,13 @@ import { checkDirForPkg } from "./utils";
 import path from "path";
 import camelCase from "lodash.camelcase";
 import { RuleFixer } from "@typescript-eslint/utils/dist/ts-eslint";
+import {
+  getMissingLastDirectoryPrefixErrorMessage,
+  MISSING_OPERATION_NAME_ERROR_MESSAGE,
+  isFilenameSuffixValid,
+  isFilenamePrefixValid,
+  reportError,
+} from "./operation-naming-conventions";
 
 const RULE_NAME = "fragment-naming-convention";
 const OPERATIONS = ["Query", "Mutation", "Subscription"];
@@ -29,37 +36,6 @@ function cutOperationName(pascalFilename: string) {
   }
 
   return pascalFilename;
-}
-
-function reportError(
-  context: GraphQLESLintRuleContext,
-  node: GraphQLESTreeNode<FragmentDefinitionNode>,
-  expectedName: string,
-) {
-  const newNode = {
-    ...node,
-    loc: {
-      start: {
-        line: node.loc.start.line,
-        column: node.loc.start.column - 1,
-      },
-      end: {
-        line: node.loc.end.line,
-        column: node.loc.end.column - 1,
-      },
-    },
-  };
-
-  context.report({
-    node: newNode,
-    message: `Fragment should follow the naming conventions, the expected name is ${expectedName} OR ${expectedName}_optionalSuffix It's possible to chain suffixes using underscore`,
-    fix(fixer: RuleFixer) {
-      if (!expectedName) {
-        return;
-      }
-      return fixer.replaceText(node.name as any, expectedName);
-    },
-  });
 }
 
 const rule: GraphQLESLintRule = {
@@ -109,18 +85,39 @@ const rule: GraphQLESLintRule = {
         }
 
         const lastDirectory = path.basename(path.dirname(packageJsonPath));
+        const filename = path.parse(path.basename(filepath)).name;
+
+        if (!isFilenameSuffixValid(filename)) {
+          return reportError(
+            context,
+            node,
+            MISSING_OPERATION_NAME_ERROR_MESSAGE,
+          );
+        }
+
+        if (!isFilenamePrefixValid(filename, lastDirectory)) {
+          return reportError(
+            context,
+            node,
+            getMissingLastDirectoryPrefixErrorMessage(lastDirectory),
+          );
+        }
+
         const pascalFilenameWithoutOperation = cutOperationName(
           pascalCase(path.parse(path.basename(filepath)).name),
         );
-        const expectedPrefix = pascalCase(lastDirectory);
 
-        const expectedName =
-          expectedPrefix + pascalFilenameWithoutOperation + "Fragment";
+        const expectedName = pascalFilenameWithoutOperation + "Fragment";
 
         const [name, ...optionalSuffix] = documentName.split("_");
 
         if (expectedName !== name) {
-          return reportError(context, node, expectedName);
+          return reportError(
+            context,
+            node,
+            `Fragment should follow the naming conventions, the expected name is ${expectedName} OR ${expectedName}_optionalSuffix It's possible to chain suffixes using underscore`,
+            expectedName,
+          );
         }
 
         if (
@@ -129,7 +126,12 @@ const rule: GraphQLESLintRule = {
             (item: string) => !CONDITIONAL_SUFFIX_REGEXP.test(item),
           )
         ) {
-          return reportError(context, node, expectedName);
+          return reportError(
+            context,
+            node,
+            `Fragment should follow the naming conventions, the expected name is ${expectedName} OR ${expectedName}_optionalSuffix It's possible to chain suffixes using underscore`,
+            expectedName,
+          );
         }
       },
     };

--- a/packages/graphql-eslint-rules/src/operation-naming-conventions.ts
+++ b/packages/graphql-eslint-rules/src/operation-naming-conventions.ts
@@ -3,7 +3,7 @@ import {
   GraphQLESTreeNode,
   GraphQLESLintRuleContext,
 } from "@graphql-eslint/eslint-plugin";
-import { OperationDefinitionNode } from "graphql";
+import { OperationDefinitionNode, FragmentDefinitionNode } from "graphql";
 import { RuleFixer } from "@typescript-eslint/utils/dist/ts-eslint";
 import { Kind } from "graphql";
 import { relative } from "path";
@@ -15,14 +15,35 @@ import kebabCase from "lodash.kebabcase";
 const RULE_NAME = "operation-naming-convention";
 const OPERATIONS = ["query", "mutation", "subscription"];
 
+export const MISSING_OPERATION_NAME_ERROR_MESSAGE = `Filename should end with the operation name (query/mutation/subscription) e.g. foo-query.graphql`;
+
+export function getMissingLastDirectoryPrefixErrorMessage(
+  lastDirectory: string,
+) {
+  return `Filename should start with the package directory name: "${lastDirectory}"`;
+}
+
+export function isFilenamePrefixValid(filename: string, lastDirectory: string) {
+  return filename.startsWith(`${lastDirectory}-`);
+}
+
+export function isFilenameSuffixValid(filename: string) {
+  return OPERATIONS.some((operation) =>
+    filename.endsWith(`-${operation.toLowerCase()}`),
+  );
+}
+
 function pascalCase(text: string) {
   const camelCaseText = camelCase(text);
   return camelCaseText.charAt(0).toUpperCase() + camelCaseText.slice(1);
 }
 
-function reportError(
+export function reportError(
   context: GraphQLESLintRuleContext,
-  node: GraphQLESTreeNode<OperationDefinitionNode, true>,
+  node: GraphQLESTreeNode<
+    OperationDefinitionNode | FragmentDefinitionNode,
+    true
+  >,
   message: string,
   expectedName?: string,
 ) {


### PR DESCRIPTION
Fixing a bug in the `fragment-naming-conventions` rule. The rule was checking/autofixing the name in the following way.
[LastDirectoryPrefix][PascalCasedFileName]Fragment. Nonetheless, [PascalCasedFileName] was fixed by the `operation-naming-conventions` rule to contain lastDirectory prefix too, so as result the lastDirectoryPrefix was autofix twice =>
[LastDirectoryPrefix][LastDirectoryPrefix][PascalCasedFileNameWithoutPrefix]Fragment