### PR TITLE
supermassive packages fixes

### DIFF
--- a/change/@graphitation-supermassive-61be3252-828c-40e6-ab42-e1b52abdc2e8.json
+++ b/change/@graphitation-supermassive-61be3252-828c-40e6-ab42-e1b52abdc2e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin TS dependency",
+  "packageName": "@graphitation/supermassive",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-transform-graphql-js-tag-6f2150d2-a26a-4f98-be67-070997c04d43.json
+++ b/change/@graphitation-ts-transform-graphql-js-tag-6f2150d2-a26a-4f98-be67-070997c04d43.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixes test suite",
+  "packageName": "@graphitation/ts-transform-graphql-js-tag",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/examples/supermassive-todomvc/package.json
+++ b/examples/supermassive-todomvc/package.json
@@ -1,6 +1,7 @@
 {
   "name": "supermassive-todomvc",
   "main": "index.js",
+  "private": true,
   "version": "1.0.0",
   "scripts": {
     "start": "concurrently 'yarn relay --watch' 'yarn serve --progress --color --mode=development'",

--- a/packages/supermassive/package.json
+++ b/packages/supermassive/package.json
@@ -50,6 +50,6 @@
   "dependencies": {
     "commander": "^8.3.0",
     "graphql": "^15.6.1",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.3 <4.5.0"
   }
 }

--- a/packages/ts-transform-graphql-js-tag/package.json
+++ b/packages/ts-transform-graphql-js-tag/package.json
@@ -16,7 +16,7 @@
     "just": "monorepo-scripts"
   },
   "devDependencies": {
-    "@ts-morph/bootstrap": "^0.11.0",
+    "@ts-morph/bootstrap": "^0.13.0",
     "@types/jest": "^26.0.22",
     "graphql": "^15.0.0",
     "monorepo-scripts": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,6 +1598,13 @@
   dependencies:
     "@ts-morph/common" "~0.11.0"
 
+"@ts-morph/bootstrap@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.13.0.tgz#f08f3f3c4c930c79275eb2be40196b8b04956902"
+  integrity sha512-pvzBE1ub6T+JZqqCzF+bHwM8LsT0T0tAwrYTaNOX9pKEJamzjQzg2owWcQTLeY3dXK0gIQpNKN/EDdY7tQmobQ==
+  dependencies:
+    "@ts-morph/common" "~0.13.0"
+
 "@ts-morph/bootstrap@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.3.0.tgz#3f77ff50f09fe9a27bf1b0997888259a182f2bca"
@@ -1612,6 +1619,16 @@
   dependencies:
     fast-glob "^3.2.7"
     minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
+"@ts-morph/common@~0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.13.0.tgz#77dea1565baaf002d1bc2c20e05d1fb3349008a9"
+  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
+  dependencies:
+    fast-glob "^3.2.11"
+    minimatch "^5.0.1"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
@@ -2637,6 +2654,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -3646,7 +3670,7 @@ fast-glob@^3.1.1, fast-glob@^3.2.2, fast-glob@^3.2.5:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -5589,10 +5613,17 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass@^3.0.0:
   version "3.1.5"
@@ -7237,20 +7268,20 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@>=4.2.3:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@>=4.2.3, typescript@^4.4.3:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 typescript@^3.0.0:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+"typescript@^4.4.3 <4.5.0":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 typescript@~3.7.2:
   version "3.7.7"


### PR DESCRIPTION
In [current](https://github.com/microsoft/graphitation/blob/dfa894cf781629179c5905adb8fb263035a07e3f/packages/supermassive/package.json#L53) `main` the TS dep is listed as ^4.4.3 , but then it uses a compiler API, which was changed in a breaking manner in [TS 4.5](https://github.com/microsoft/TypeScript/pull/45998), but it uses it in the old manner—i.e. [it passes 2 arguments](https://github.com/microsoft/graphitation/blob/dfa894cf781629179c5905adb8fb263035a07e3f/packages/supermassive/src/extractImplicitTypesToTypescript.ts#L132-L135) instead of 3. For now pinning supermassive to < 4.5, but we should probably be consistent and on latest.