### PR TITLE
[duct-tape] Add ability to provide custom apollo client

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-07e031f6-0a02-4bf5-bcf9-612af3b991a3.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-07e031f6-0a02-4bf5-bcf9-612af3b991a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[duct-tape] Allow overriding of ApolloClient instance to be used",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/useOverridenOrDefaultApolloClient.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/useOverridenOrDefaultApolloClient.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { create as createTestRenderer } from "react-test-renderer";
+import {
+  ApolloClient,
+  ApolloProvider,
+  InMemoryCache,
+  useApolloClient as useDefaultApolloClient,
+} from "@apollo/client";
+import {
+  ApolloReactRelayDuctTapeProvider,
+  useOverridenOrDefaultApolloClient,
+} from "../useOverridenOrDefaultApolloClient";
+
+describe(useOverridenOrDefaultApolloClient, () => {
+  it("defaults to the client provided by ApolloProvider", () => {
+    const expectedClient = new ApolloClient({ cache: new InMemoryCache() });
+    let yieldedClient: ApolloClient<any> | undefined;
+    const Subject = () => {
+      yieldedClient = useOverridenOrDefaultApolloClient();
+      return null;
+    };
+    createTestRenderer(
+      <ApolloProvider client={expectedClient}>
+        <Subject />
+      </ApolloProvider>
+    );
+    expect(yieldedClient).toBe(expectedClient);
+  });
+
+  it("returns the explicitly overriden client provided by ApolloReactRelayDuctTapeProvider", () => {
+    const overridenClient = new ApolloClient({ cache: new InMemoryCache() });
+    const defaultClient = new ApolloClient({ cache: new InMemoryCache() });
+    let yieldedOverridenClient: ApolloClient<any> | undefined;
+    let yieldedDefaultClient: ApolloClient<any> | undefined;
+    const OverridenSubject = () => {
+      yieldedOverridenClient = useOverridenOrDefaultApolloClient();
+      return null;
+    };
+    const DefaultSubject = () => {
+      yieldedDefaultClient = useDefaultApolloClient();
+      return null;
+    };
+    createTestRenderer(
+      <ApolloProvider client={defaultClient}>
+        <ApolloReactRelayDuctTapeProvider client={overridenClient}>
+          <OverridenSubject />
+          <DefaultSubject />
+        </ApolloReactRelayDuctTapeProvider>
+      </ApolloProvider>
+    );
+    expect(yieldedOverridenClient).toBe(overridenClient);
+    expect(yieldedDefaultClient).toBe(defaultClient);
+  });
+});

--- a/packages/apollo-react-relay-duct-tape/src/hooks.ts
+++ b/packages/apollo-react-relay-duct-tape/src/hooks.ts
@@ -22,6 +22,7 @@ import {
   useCompiledPaginationFragment,
 } from "./storeObservation/compiledHooks";
 import { convertFetchPolicy } from "./convertFetchPolicy";
+import { useOverridenOrDefaultApolloClient } from "./useOverridenOrDefaultApolloClient";
 
 /**
  * Executes a GraphQL query.
@@ -52,7 +53,8 @@ export function useLazyLoadQuery<TQuery extends OperationType>(
       ...apolloOptions,
     });
   } else {
-    return useApolloQuery(query, { variables, ...apolloOptions });
+    const client = useOverridenOrDefaultApolloClient();
+    return useApolloQuery(query, { client, variables, ...apolloOptions });
   }
 }
 
@@ -171,10 +173,12 @@ interface GraphQLSubscriptionConfig<
 export function useSubscription<TSubscriptionPayload extends OperationType>(
   config: GraphQLSubscriptionConfig<TSubscriptionPayload>
 ): void {
+  const client = useOverridenOrDefaultApolloClient();
   const { error } = useApolloSubscription(
     // TODO: Right now we don't replace mutation documents with imported artefacts.
     config.subscription as DocumentNode,
     {
+      client,
       variables: config.variables,
       onSubscriptionData: ({ subscriptionData }) => {
         // Supposedly this never gets triggered for an error by design:
@@ -218,9 +222,11 @@ type MutationCommiter<TMutationPayload extends OperationType> = (
 export function useMutation<TMutationPayload extends OperationType>(
   mutation: GraphQLTaggedNode
 ): [MutationCommiter<TMutationPayload>, boolean] {
+  const client = useOverridenOrDefaultApolloClient();
   const [apolloUpdater, { loading: mutationLoading }] = useApolloMutation(
     // TODO: Right now we don't replace mutation documents with imported artefacts.
-    mutation as DocumentNode
+    mutation as DocumentNode,
+    { client }
   );
 
   return [

--- a/packages/apollo-react-relay-duct-tape/src/index.ts
+++ b/packages/apollo-react-relay-duct-tape/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./hooks";
 export * from "./types";
 export * from "./storeObservation";
+export { ApolloReactRelayDuctTapeProvider } from "./useOverridenOrDefaultApolloClient";

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -1,9 +1,9 @@
 import { useEffect, useMemo } from "react";
-import { useApolloClient } from "@apollo/client";
 import invariant from "invariant";
 import { CompiledArtefactModule } from "relay-compiler-language-graphitation";
 import { FragmentReference } from "./types";
 import { useForceUpdate } from "./useForceUpdate";
+import { useOverridenOrDefaultApolloClient } from "../../useOverridenOrDefaultApolloClient";
 
 /**
  * @param documents Compiled watch query document that is used to setup a narrow
@@ -27,7 +27,7 @@ export function useCompiledFragment(
       "extracted. Did you forget to invoke the compiler?"
   );
 
-  const client = useApolloClient();
+  const client = useOverridenOrDefaultApolloClient();
   const forceUpdate = useForceUpdate();
 
   const observableQuery = useMemo(

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
@@ -1,14 +1,11 @@
 import { useRef, useEffect } from "react";
-import {
-  useApolloClient,
-  useQuery as useApolloQuery,
-  ObservableQuery,
-} from "@apollo/client";
+import { useQuery as useApolloQuery, ObservableQuery } from "@apollo/client";
 import invariant from "invariant";
 import { useDeepCompareMemoize } from "./useDeepCompareMemoize";
 import { CompiledArtefactModule } from "relay-compiler-language-graphitation";
 import { DocumentNode } from "graphql";
 import { useForceUpdate } from "./useForceUpdate";
+import { useOverridenOrDefaultApolloClient } from "../../useOverridenOrDefaultApolloClient";
 
 class ExecutionQueryHandler {
   public status: [loading: boolean, error?: Error];
@@ -54,7 +51,7 @@ function useExecutionQuery(
   executionQueryDocument: DocumentNode,
   variables: Record<string, any>
 ): [loading: boolean, error?: Error] {
-  const client = useApolloClient();
+  const client = useOverridenOrDefaultApolloClient();
   const forceUpdate = useForceUpdate();
   const execution = useRef(new ExecutionQueryHandler(() => forceUpdate()));
   useEffect(() => {

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
@@ -1,11 +1,5 @@
-import { useState, useRef, useEffect, useCallback } from "react";
-import {
-  ApolloCache,
-  DataProxy,
-  InMemoryCache,
-  StoreValue,
-  useApolloClient,
-} from "@apollo/client";
+import { useState, useCallback } from "react";
+import { ApolloCache, DataProxy, StoreValue } from "@apollo/client";
 import invariant from "invariant";
 import { CompiledArtefactModule } from "relay-compiler-language-graphitation";
 import { useCompiledRefetchableFragment } from "./useCompiledRefetchableFragment";
@@ -18,6 +12,7 @@ import type {
 } from "./useCompiledRefetchableFragment";
 import type { Metadata } from "relay-compiler-language-graphitation";
 import type { DocumentNode } from "graphql";
+import { useOverridenOrDefaultApolloClient } from "../../useOverridenOrDefaultApolloClient";
 
 export type PaginationFn = (
   count: number,
@@ -49,7 +44,7 @@ function useLoadMore({
   cursorValue,
   updater,
 }: PaginationParams): [loadPage: PaginationFn, isLoadingMore: boolean] {
-  const apolloClient = useApolloClient();
+  const apolloClient = useOverridenOrDefaultApolloClient();
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const loadPage = useCallback<PaginationFn>(
     (countValue, options) => {
@@ -246,7 +241,7 @@ export function useCompiledPaginationFragment(
     refetch,
     metadata,
     executionQueryDocument,
-    cache: useApolloClient().cache,
+    cache: useOverridenOrDefaultApolloClient().cache,
     connectionSelectionPath: connectionMetadata.selectionPath,
   };
   const pageInfo = getPageInfo(data, connectionMetadata.selectionPath);

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { unstable_batchedUpdates } from "react-dom";
-import { useApolloClient } from "@apollo/client";
 import invariant from "invariant";
 import { CompiledArtefactModule } from "relay-compiler-language-graphitation";
 import { useCompiledFragment } from "./useCompiledFragment";
@@ -8,6 +7,7 @@ import { FragmentReference } from "./types";
 import { isEqual } from "lodash";
 import { FetchPolicy } from "../../types";
 import { convertFetchPolicy } from "../../convertFetchPolicy";
+import { useOverridenOrDefaultApolloClient } from "../../useOverridenOrDefaultApolloClient";
 
 export interface Disposable {
   dispose(): void;
@@ -57,7 +57,7 @@ export function useCompiledRefetchableFragment(
     metadata.mainFragment.name
   );
 
-  const client = useApolloClient();
+  const client = useOverridenOrDefaultApolloClient();
 
   // We use state for this, so that...
   const [

--- a/packages/apollo-react-relay-duct-tape/src/useOverridenOrDefaultApolloClient.ts
+++ b/packages/apollo-react-relay-duct-tape/src/useOverridenOrDefaultApolloClient.ts
@@ -1,0 +1,38 @@
+import {
+  ApolloClient,
+  useApolloClient as useDefaultApolloClient,
+} from "@apollo/client";
+import React from "react";
+
+/**
+ * @internal
+ */
+export function useOverridenOrDefaultApolloClient(): ApolloClient<any> {
+  const client = React.useContext(ApolloReactRelayDuctTapeContext);
+  if (client) {
+    return client;
+  }
+  return useDefaultApolloClient();
+}
+
+const ApolloReactRelayDuctTapeContext = React.createContext<
+  ApolloClient<any> | undefined
+>(undefined);
+
+/**
+ * A context provider that allows passing an explicit ApolloClient instance to
+ * the apollo-react-relay-duct-tape hooks. If this provider is not used, the
+ * hooks will default to one provided by @apollo/client's ApolloProvider.
+ *
+ * This allows a subset of a tree to use apollo-react-relay-duct-tape using a
+ * different ApolloClient instance than the rest of the tree above and below it.
+ */
+export const ApolloReactRelayDuctTapeProvider: React.FC<{
+  client: ApolloClient<any>;
+}> = (props) => {
+  return React.createElement(
+    ApolloReactRelayDuctTapeContext.Provider,
+    { value: props.client },
+    props.children
+  );
+};


### PR DESCRIPTION
This allows a subset of a tree to use apollo-react-relay-duct-tape using a different ApolloClient instance than the rest of the tree above and below it.