### PR TITLE
[ts-transform-graphql-js-tag] Make TS req compatible with TMP

### DIFF
--- a/change/@graphitation-ts-transform-graphql-js-tag-f621899b-7494-4ed4-93aa-fbaa7d4e3bec.json
+++ b/change/@graphitation-ts-transform-graphql-js-tag-f621899b-7494-4ed4-93aa-fbaa7d4e3bec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[ts-transform-graphql-js-tag] Make TS req compatible with TMP",
+  "packageName": "@graphitation/ts-transform-graphql-js-tag",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ts-transform-graphql-js-tag/package.json
+++ b/packages/ts-transform-graphql-js-tag/package.json
@@ -16,11 +16,12 @@
     "just": "monorepo-scripts"
   },
   "devDependencies": {
-    "@ts-morph/bootstrap": "^0.13.0",
+    "@ts-morph/bootstrap": "0.10.1",
     "@types/jest": "^26.0.22",
-    "graphql": "^15.0.0",
+    "graphql": "^15.6.1",
     "monorepo-scripts": "*",
-    "ts-transformer-testing-library": "^1.0.0-alpha.7"
+    "ts-transformer-testing-library": "^1.0.0-alpha.7",
+    "typescript": "4.3.5"
   },
   "publishConfig": {
     "main": "./lib/index",
@@ -34,11 +35,8 @@
       }
     }
   },
-  "dependencies": {
-    "graphql": "^15.6.1",
-    "typescript": "^4.4.3"
-  },
   "peerDependencies": {
-    "graphql": "^15.0.0"
+    "graphql": "^15.0.0",
+    "typescript": ">=4.3.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,19 +2697,19 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@ts-morph/bootstrap@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.10.1.tgz#6638dadd65f6fa0a84df41fa70f1ed8499390065"
+  integrity sha512-/lqMUS7LRQh5oFK2FFJnUuuPbVPHCd03+6ovqvGnFm+Qf5Ah/nHNKVLeXU/9/GBZPBT0zvnRjcOKuzDYANT2Zw==
+  dependencies:
+    "@ts-morph/common" "~0.10.1"
+
 "@ts-morph/bootstrap@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.11.0.tgz#4025725798b60acffe0a50187e58ae9233ddba18"
   integrity sha512-wS75U9u5Xb8PD5KdE9lsQUB4SnQBH63Mhoi/ISJ/E+kEQiz9pjnFsydQGrJIIe+IdkzT++nk7iwHLQ4PBpoDFw==
   dependencies:
     "@ts-morph/common" "~0.11.0"
-
-"@ts-morph/bootstrap@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.13.0.tgz#f08f3f3c4c930c79275eb2be40196b8b04956902"
-  integrity sha512-pvzBE1ub6T+JZqqCzF+bHwM8LsT0T0tAwrYTaNOX9pKEJamzjQzg2owWcQTLeY3dXK0gIQpNKN/EDdY7tQmobQ==
-  dependencies:
-    "@ts-morph/common" "~0.13.0"
 
 "@ts-morph/bootstrap@^0.3.0":
   version "0.3.0"
@@ -2718,6 +2718,16 @@
   dependencies:
     "@ts-morph/common" "~0.2.0"
 
+"@ts-morph/common@~0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.10.1.tgz#be15b9ab13a32bbc1f6a6bd7dc056b2247b272eb"
+  integrity sha512-rKN/VtZUUlW4M+6vjLFSaFc1Z9sK+1hh0832ucPtPkXqOw/mSWE80Lau4z2zTPNTqtxAjfZbvKpQcEwJy0KIEg==
+  dependencies:
+    fast-glob "^3.2.5"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
 "@ts-morph/common@~0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.11.0.tgz#df94af35f42d01d9d389bfdefc8bcc3f6a59a192"
@@ -2725,16 +2735,6 @@
   dependencies:
     fast-glob "^3.2.7"
     minimatch "^3.0.4"
-    mkdirp "^1.0.4"
-    path-browserify "^1.0.1"
-
-"@ts-morph/common@~0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.13.0.tgz#77dea1565baaf002d1bc2c20e05d1fb3349008a9"
-  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
-  dependencies:
-    fast-glob "^3.2.11"
-    minimatch "^5.0.1"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
@@ -3955,13 +3955,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
@@ -5574,7 +5567,7 @@ fast-glob@^3.1.1, fast-glob@^3.2.2, fast-glob@^3.2.5:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -8224,13 +8217,6 @@ minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -10559,7 +10545,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@>=4.2.3, typescript@^4.4.3:
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@>=4.2.3:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==


### PR DESCRIPTION
TMP's webpack/ts-loader setup uses TS 4.3.5, which means we need to target that too or the AST and compiler APIs would be incompatible.