### PR TITLE
Fix losing identity of import

### DIFF
--- a/change/@graphitation-ts-transform-graphql-js-tag-f2a39913-1495-4b07-b4ec-956c2cb435e6.json
+++ b/change/@graphitation-ts-transform-graphql-js-tag-f2a39913-1495-4b07-b4ec-956c2cb435e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Identity of import was lost when recreating it, changing to update to fix",
+  "packageName": "@graphitation/ts-transform-graphql-js-tag",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ts-transform-graphql-js-tag/src/index.test.ts
+++ b/packages/ts-transform-graphql-js-tag/src/index.test.ts
@@ -168,6 +168,24 @@ describe("transformer tests", () => {
         "
       `);
     });
+    it("should keep different single import but remove itself", () => {
+      expect.assertions(1);
+      const transformer = new Transformer()
+        .addTransformer((program: ts.Program) => getTransformer({}))
+        .addMock({
+          name: "@graphitation/graphql-js-tag",
+          content: `export const graphql:any = () => {}, someOtherExport: any = 1;`,
+        })
+        .setFilePath("/index.tsx");
+
+      const actual = transformer.transform(`
+      import { someOtherExport, graphql } from "@graphitation/graphql-js-tag"
+      `);
+      expect(actual).toMatchInlineSnapshot(`
+        "import { someOtherExport } from \\"@graphitation/graphql-js-tag\\";
+        "
+      `);
+    });
     it("should keep different default import", () => {
       expect.assertions(1);
       const transformer = new Transformer()

--- a/packages/ts-transform-graphql-js-tag/src/index.test.ts
+++ b/packages/ts-transform-graphql-js-tag/src/index.test.ts
@@ -196,11 +196,15 @@ describe("transformer tests", () => {
         })
         .setFilePath("/index.tsx");
 
+      // Needs usage to not be eliminated for some reason
       const actual = transformer.transform(`
         import someOtherDefault from "@graphitation/graphql-js-tag"
+
+        someOtherDefault;
         `);
       expect(actual).toMatchInlineSnapshot(`
         "import someOtherDefault from \\"@graphitation/graphql-js-tag\\";
+        someOtherDefault;
         "
       `);
     });

--- a/packages/ts-transform-graphql-js-tag/src/index.ts
+++ b/packages/ts-transform-graphql-js-tag/src/index.ts
@@ -121,7 +121,8 @@ function getVisitor(
             }
           }
           if (newImportSpecifiers.length || node.importClause.name) {
-            const result = ts.factory.createImportDeclaration(
+            const result = ts.factory.updateImportDeclaration(
+              node,
               node.decorators,
               node.modifiers,
               ts.factory.updateImportClause(
@@ -133,6 +134,7 @@ function getVisitor(
                   : undefined,
               ),
               node.moduleSpecifier,
+              node.assertClause,
             );
             return result;
           } else {

--- a/packages/ts-transform-graphql-js-tag/src/index.ts
+++ b/packages/ts-transform-graphql-js-tag/src/index.ts
@@ -134,7 +134,6 @@ function getVisitor(
                   : undefined,
               ),
               node.moduleSpecifier,
-              node.assertClause,
             );
             return result;
           } else {

--- a/packages/ts-transform-graphql-js-tag/src/index.ts
+++ b/packages/ts-transform-graphql-js-tag/src/index.ts
@@ -129,8 +129,11 @@ function getVisitor(
                 node.importClause,
                 node.importClause.isTypeOnly,
                 node.importClause.name,
-                newImportSpecifiers.length
-                  ? ts.factory.createNamedImports(newImportSpecifiers)
+                node.importClause.namedBindings && newImportSpecifiers.length
+                  ? ts.factory.updateNamedImports(
+                      node.importClause.namedBindings,
+                      newImportSpecifiers,
+                    )
                   : undefined,
               ),
               node.moduleSpecifier,


### PR DESCRIPTION
Seems webpack in some cases might compare imports by reference, causing weird duplicate imports.