### PR TITLE
SuperMassive: AST Error Message fix

### DIFF
--- a/change/@graphitation-supermassive-3ef8cba5-b4e7-44a5-9be9-fcb9b2e39fe0.json
+++ b/change/@graphitation-supermassive-3ef8cba5-b4e7-44a5-9be9-fcb9b2e39fe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Better error message",
+  "packageName": "@graphitation/supermassive",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
+++ b/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
@@ -208,5 +208,21 @@ describe(addTypesToRequestDocument, () => {
         }
       `);
     });
+
+    it("errors nicely for unknown fields", () => {
+      expect(() => {
+        addTypesToRequestDocument(
+          schema,
+          graphql`
+            query {
+              film(id: 42) {
+                title
+                format
+              }
+            }
+          `,
+        );
+      }).toThrowError("Unhandled node: format");
+    });
   });
 });

--- a/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
+++ b/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
@@ -214,6 +214,22 @@ describe(addTypesToRequestDocument, () => {
         addTypesToRequestDocument(
           schema,
           graphql`
+            query filmQuery {
+              film(id: 42) {
+                title
+                format
+              }
+            }
+          `,
+        );
+      }).toThrowError(
+        "Cannot find type for field: query filmQuery.film.format",
+      );
+
+      expect(() => {
+        addTypesToRequestDocument(
+          schema,
+          graphql`
             query {
               film(id: 42) {
                 title
@@ -222,7 +238,7 @@ describe(addTypesToRequestDocument, () => {
             }
           `,
         );
-      }).toThrowError("Unhandled node: format");
+      }).toThrowError("Cannot find type for field: query.film.format");
     });
   });
 });

--- a/packages/supermassive/src/ast/addTypesToRequestDocument.ts
+++ b/packages/supermassive/src/ast/addTypesToRequestDocument.ts
@@ -52,7 +52,8 @@ export function addTypesToRequestDocument(
           };
           return newNode;
         }
-        throw new Error(`Unhandled: ${type}`);
+        // This happens whenever a new field is requested that hasn't been defined in schema
+        throw new Error(`Unhandled node: ${node.name.value}, type: ${type}`);
       },
     }),
   );

--- a/packages/supermassive/src/ast/addTypesToRequestDocument.ts
+++ b/packages/supermassive/src/ast/addTypesToRequestDocument.ts
@@ -53,7 +53,7 @@ export function addTypesToRequestDocument(
           return newNode;
         }
         // This happens whenever a new field is requested that hasn't been defined in schema
-        throw new Error(`Unhandled node: ${node.name.value}, type: ${type}`);
+        throw new Error(`Unhandled node: ${node.name.value}`);
       },
     }),
   );

--- a/packages/supermassive/src/ast/addTypesToRequestDocument.ts
+++ b/packages/supermassive/src/ast/addTypesToRequestDocument.ts
@@ -9,6 +9,7 @@ import {
   visit,
   print,
   visitWithTypeInfo,
+  Kind,
 } from "graphql";
 
 import * as TypelessAST from "graphql/language/ast";
@@ -23,37 +24,68 @@ export function addTypesToRequestDocument(
   return visit(
     document as any,
     visitWithTypeInfo(typeInfo, {
-      Argument(node) {
-        const argument = typeInfo.getArgument()!;
-        if (argument) {
-          const typeNode = generateTypeNode(argument.type);
-          const newNode: TypedAST.ArgumentNode = {
-            ...node,
-            __type: typeNode,
-            __defaultValue: argument.defaultValue
-              ? parseValue(JSON.stringify(argument.defaultValue))
-              : undefined,
-          };
-          return newNode;
-        }
+      Argument: {
+        leave(node) {
+          const argument = typeInfo.getArgument()!;
+          if (argument) {
+            const typeNode = generateTypeNode(argument.type);
+            const newNode: TypedAST.ArgumentNode = {
+              ...node,
+              __type: typeNode,
+              __defaultValue: argument.defaultValue
+                ? parseValue(JSON.stringify(argument.defaultValue))
+                : undefined,
+            };
+            return newNode;
+          }
+        },
       },
-      Field(
-        node: Omit<
-          TypelessAST.FieldNode,
-          "selectionSet" | "arguments" | "directives"
-        >,
-      ) {
-        const type = typeInfo.getType();
-        if (type) {
-          const typeNode = generateTypeNode(type);
-          const newNode: TypedAST.FieldNode = {
-            ...node,
-            __type: typeNode,
-          };
-          return newNode;
-        }
-        // This happens whenever a new field is requested that hasn't been defined in schema
-        throw new Error(`Unhandled node: ${node.name.value}`);
+      Field: {
+        leave(
+          node: Omit<
+            TypelessAST.FieldNode,
+            "selectionSet" | "arguments" | "directives"
+          >,
+          _key,
+          _parent,
+          _path,
+          ancestors,
+        ) {
+          const type = typeInfo.getType();
+          if (type) {
+            const typeNode = generateTypeNode(type);
+            const newNode: TypedAST.FieldNode = {
+              ...node,
+              __type: typeNode,
+            };
+            return newNode;
+          }
+          const path: string[] = [];
+          ancestors.forEach((ancestorOrArray) => {
+            let ancestor: TypelessAST.ASTNode;
+            if (!Array.isArray(ancestorOrArray)) {
+              ancestor = ancestorOrArray as TypelessAST.ASTNode;
+              if (ancestor && ancestor.kind === Kind.FIELD) {
+                path.push(ancestor.name.value);
+              } else if (
+                ancestor &&
+                ancestor.kind === Kind.OPERATION_DEFINITION
+              ) {
+                let name;
+                if (ancestor.name) {
+                  name = `${ancestor.operation} ${ancestor.name.value}`;
+                } else {
+                  name = ancestor.operation;
+                }
+                path.push(name);
+              }
+            }
+          });
+          // This happens whenever a new field is requested that hasn't been defined in schema
+          throw new Error(
+            `Cannot find type for field: ${path.join(".")}.${node.name.value}`,
+          );
+        },
       },
     }),
   );


### PR DESCRIPTION
When running against an updated package, the compiler generated a message to indicate a field was queried that was unknown: "Unhandled: undefined".

This message is not useful - updating the message to output the name of the field makes it possible to find the query with the field and correctly update schema for the new fields.

It would be even better if there was some more metadata that could be added here - the parent type for the field, or the file in which the field occurred. 