### PR TITLE
Apollo devtools script building fix

### DIFF
--- a/change/@graphitation-rempl-apollo-devtools-9459664f-a3c5-4ee1-bde1-3e871bd5d9c2.json
+++ b/change/@graphitation-rempl-apollo-devtools-9459664f-a3c5-4ee1-bde1-3e871bd5d9c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": " Hotfix: set subscriber format to iife in build-separated-bundles.js",
+  "packageName": "@graphitation/rempl-apollo-devtools",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/rempl-apollo-devtools/scripts/build-separated-bundles.js
+++ b/packages/rempl-apollo-devtools/scripts/build-separated-bundles.js
@@ -20,7 +20,7 @@ if (require.main === module) {
         minify: true,
         bundle: true,
         outfile: "dist/apollo-devtools-subscriber.js",
-        format: "esm",
+        format: "iife",
         sourcemap: false,
         define: {
           __GRAPHIQL_CSS__: JSON.stringify(


### PR DESCRIPTION
set subscriber bundle format to iife in build-separated-bundles.js