### PR TITLE
Devtools HOTFIXES: empty cache, activity monitor recording and window opener support

### DIFF
--- a/change/@graphitation-rempl-apollo-devtools-db8f1eac-f13f-4bf8-884d-ac884c389a06.json
+++ b/change/@graphitation-rempl-apollo-devtools-db8f1eac-f13f-4bf8-884d-ac884c389a06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[REMPL_APOLLO_DEVTOOLS] empty cache fixed during client change",
+  "packageName": "@graphitation/rempl-apollo-devtools",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-cache-duplicates-publisher.ts
+++ b/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-cache-duplicates-publisher.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
-import { RemplWrapper } from "../rempl-wrapper";
+import { RemplWrapper, browserWindow } from "../rempl-wrapper";
 import {
   CacheDuplicates,
   ClientObject,
@@ -25,7 +25,7 @@ export class ApolloCacheDuplicatesPublisher {
     );
     this.apolloPublisher = remplWrapper.publisher;
     this.attachMethodsToPublisher();
-    this.apolloKeyFields = window.__APOLLO_KEY_FIELDS__ || {};
+    this.apolloKeyFields = browserWindow.__APOLLO_KEY_FIELDS__ || {};
   }
 
   private cacheDuplicatesHandler({ activeClient }: WrapperCallbackParams) {

--- a/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-cache-publisher.ts
+++ b/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-cache-publisher.ts
@@ -31,23 +31,6 @@ export class ApolloCachePublisher {
     return client.cache.extract(true);
   }
 
-  private diffCaches(
-    currentCache: NormalizedCacheObject,
-    previousCache: NormalizedCacheObject,
-  ) {
-    return Object.fromEntries(
-      Object.entries(currentCache).filter(([key, value]) => {
-        if (
-          !previousCache[key] ||
-          JSON.stringify(previousCache[key]) !== JSON.stringify(value)
-        ) {
-          return true;
-        }
-        return false;
-      }),
-    );
-  }
-
   private serializeCacheObject = (client?: ClientObject) => {
     if (!client) {
       return;
@@ -61,18 +44,17 @@ export class ApolloCachePublisher {
       return;
     }
 
-    if (this.activeClient?.clientId !== activeClient.clientId) {
-      this.lastCacheHistory = {};
-    }
-    this.activeClient = activeClient;
-
     const serializedCacheObject = this.serializeCacheObject(activeClient);
 
     if (!serializedCacheObject) {
       return;
     }
 
-    if (!this.hasCacheChanged(this.lastCacheHistory, serializedCacheObject)) {
+    if (this.activeClient?.clientId !== activeClient.clientId) {
+      this.activeClient = activeClient;
+    } else if (
+      !this.hasCacheChanged(this.lastCacheHistory, serializedCacheObject)
+    ) {
       return;
     }
 

--- a/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-global-operations-publisher.ts
+++ b/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-global-operations-publisher.ts
@@ -1,4 +1,4 @@
-import { RemplWrapper } from "../rempl-wrapper";
+import { RemplWrapper, browserWindow } from "../rempl-wrapper";
 
 export class ApolloGlobalOperationsPublisher {
   private apolloPublisher;
@@ -15,13 +15,13 @@ export class ApolloGlobalOperationsPublisher {
   }
 
   private globalOperationsFetcherHandler() {
-    if (!window.__APOLLO_GLOBAL_OPERATIONS__) {
+    if (!browserWindow.__APOLLO_GLOBAL_OPERATIONS__) {
       return;
     }
 
     this.apolloPublisher
       .ns("apollo-global-operations")
-      .publish(window.__APOLLO_GLOBAL_OPERATIONS__);
+      .publish(browserWindow.__APOLLO_GLOBAL_OPERATIONS__);
 
     this.remplWrapper.unSubscribeToRemplStatus("global-operations");
   }

--- a/packages/rempl-apollo-devtools/src/publisher/rempl-wrapper.ts
+++ b/packages/rempl-apollo-devtools/src/publisher/rempl-wrapper.ts
@@ -9,6 +9,8 @@ type RemplStatusHook = {
   callback: (wrapperCallbackParams: WrapperCallbackParams) => void;
 };
 
+export const browserWindow =
+  !window.__APOLLO_CLIENTS__ && window.opener ? window.opener : window;
 export class RemplWrapper {
   private isRemplActive = false;
   private remplStatusHooks: RemplStatusHook[] = [];
@@ -23,7 +25,7 @@ export class RemplWrapper {
     this.publisher = createPublisher("apollo-devtools", () => {
       return {
         type: "url",
-        value: window.__REMPL_APOLLO_DEVTOOLS_URL__ || "",
+        value: browserWindow.__REMPL_APOLLO_DEVTOOLS_URL__ || "",
       };
     });
 
@@ -61,11 +63,11 @@ export class RemplWrapper {
   }
 
   private getClientById(activeClientId: string) {
-    if (!window.__APOLLO_CLIENTS__?.length) {
+    if (!browserWindow.__APOLLO_CLIENTS__?.length) {
       return null;
     }
 
-    const activeClient = window.__APOLLO_CLIENTS__.find(
+    const activeClient = browserWindow.__APOLLO_CLIENTS__.find(
       (client: ClientObject) => client.clientId === activeClientId,
     );
 
@@ -81,7 +83,7 @@ export class RemplWrapper {
   }
 
   public runAllHooks() {
-    if (!window.__APOLLO_CLIENTS__?.length) {
+    if (!browserWindow.__APOLLO_CLIENTS__?.length) {
       return;
     }
 
@@ -91,7 +93,7 @@ export class RemplWrapper {
       }
 
       callback({
-        clientObjects: window.__APOLLO_CLIENTS__,
+        clientObjects: browserWindow.__APOLLO_CLIENTS__,
         activeClient: this.activeClient,
       });
 
@@ -99,7 +101,7 @@ export class RemplWrapper {
         id: id,
         interval: setInterval(() => {
           callback({
-            clientObjects: window.__APOLLO_CLIENTS__,
+            clientObjects: browserWindow.__APOLLO_CLIENTS__,
             activeClient: this.activeClient,
           });
         }, timeout),

--- a/packages/rempl-apollo-devtools/src/subscriber/apollo-recent-activity/recent-activity-container.tsx
+++ b/packages/rempl-apollo-devtools/src/subscriber/apollo-recent-activity/recent-activity-container.tsx
@@ -79,7 +79,7 @@ export const RecentActivityContainer = React.memo(() => {
 
     return () => {
       remplSubscriber.callRemote("recordRecentActivity", {
-        shouldRecord: true,
+        shouldRecord: false,
       });
       unsubscribe();
     };


### PR DESCRIPTION
If apollo-client's cache is empty and you switched from non-empty client. Then the empty client cache in UI is not updated