### PR TITLE
fix(graphql-codegen-typescript-typemap-plugin): correctly handle types with prefix and underscore

### DIFF
--- a/change/@graphitation-graphql-codegen-typescript-typemap-plugin-2a07ab88-494f-4c59-be10-b7d2a05cba77.json
+++ b/change/@graphitation-graphql-codegen-typescript-typemap-plugin-2a07ab88-494f-4c59-be10-b7d2a05cba77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: correctly handle types with prefix and underscore",
+  "packageName": "@graphitation/graphql-codegen-typescript-typemap-plugin",
+  "email": "sjwilczynski@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-codegen-typescript-typemap-plugin/src/index.test.ts
+++ b/packages/graphql-codegen-typescript-typemap-plugin/src/index.test.ts
@@ -6,12 +6,16 @@ describe(plugin, () => {
     const schema = buildSchema(`
       type Query {
         lowerCaseTypeName: lowerCaseTypeName!
+        field: TypeWITHUnderscore_AndSomeCapitalCharacters
       }
       type lowerCaseTypeName {
         id: ID!
       }
       type HTML {
         text: String
+      }
+      type TypeWITHUnderscore_AndSomeCapitalCharacters {
+        someField: String
       }
     `);
     const result = plugin(schema, [], null);
@@ -22,6 +26,7 @@ describe(plugin, () => {
         \"ID\": Scalars[\"ID\"];
         \"Query\": Query;
         \"String\": Scalars[\"String\"];
+        \"TypeWITHUnderscore_AndSomeCapitalCharacters\": TypeWithUnderscore_AndSomeCapitalCharacters;
         \"lowerCaseTypeName\": LowerCaseTypeName;
       };
       "

--- a/packages/graphql-codegen-typescript-typemap-plugin/src/index.ts
+++ b/packages/graphql-codegen-typescript-typemap-plugin/src/index.ts
@@ -17,7 +17,10 @@ const graphqlCodegenTypeMapPlugin: PluginFunction = (
           `  "${typeName}": ${
             isScalarType(typesMap[typeName])
               ? `Scalars["${typeName}"]`
-              : pascalCase(typeName)
+              : typeName
+                  .split("_")
+                  .map((part) => pascalCase(part))
+                  .join("_")
           };`,
       ),
     "};\n",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,7 +3090,7 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@ts-morph/bootstrap@0.19.0":
+"@ts-morph/bootstrap@0.18.0":
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.18.0.tgz#23f886caa87575e48b07c9905ddbd56a33ee33f4"
   integrity sha512-LmYkdorZT7UonhVuATqj8jFBVz/4ykuFdbrA5szk19OAVxEWaytg7TsngC2waUDLfdc93aJrCF9Gs8Extc1Pfg==


### PR DESCRIPTION
Add a small fix to be able to generate type map for types with prefix ending with underscore like `OneGQL__`