### PR TITLE
[SUPERMASSIVE] Initial execution hooks implementation

### DIFF
--- a/change/@graphitation-supermassive-502bf69b-8df9-4b68-82a3-c86b0a4d6081.json
+++ b/change/@graphitation-supermassive-502bf69b-8df9-4b68-82a3-c86b0a4d6081.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[SUPERMASSIVE] Initial execution hooks implementation",
+  "packageName": "@graphitation/supermassive",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/hooks.test.ts
+++ b/packages/supermassive/src/__tests__/hooks.test.ts
@@ -1,0 +1,276 @@
+import { parse, DocumentNode } from "graphql";
+import { executeWithoutSchema, executeWithSchema } from "..";
+import schema, { typeDefs } from "../benchmarks/swapi-schema";
+import models from "../benchmarks/swapi-schema/models";
+import resolvers from "../benchmarks/swapi-schema/resolvers";
+import { addTypesToRequestDocument } from "../ast/addTypesToRequestDocument";
+import { Resolvers, UserResolvers } from "../types";
+import { resolvers as extractedResolvers } from "../benchmarks/swapi-schema/__generated__/schema";
+import {
+  AfterFieldCompleteHookArgs,
+  AfterFieldResolveHookArgs,
+  BeforeFieldResolveHookArgs,
+  ExecutionHooks,
+} from "../hooks/types";
+import { pathToArray } from "../jsutils/Path";
+
+interface TestCase {
+  name: string;
+  query: string;
+  resolvers: Resolvers;
+  expectedHookCalls: string[];
+}
+
+describe.each([
+  {
+    name: "executeWithoutSchema",
+    execute: (
+      document: DocumentNode,
+      resolvers: UserResolvers,
+      hooks: ExecutionHooks,
+    ) => {
+      return executeWithoutSchema({
+        document: addTypesToRequestDocument(schema, document),
+        resolvers,
+        schemaResolvers: extractedResolvers,
+        contextValue: {
+          models,
+        },
+        hooks,
+      });
+    },
+  },
+  {
+    name: "executeWithSchema",
+    execute: (
+      document: DocumentNode,
+      resolvers: UserResolvers,
+      hooks: ExecutionHooks,
+    ) => {
+      return executeWithSchema({
+        typeDefs,
+        resolvers,
+        document,
+        contextValue: {
+          models,
+        },
+        hooks,
+      });
+    },
+  },
+])("$name", ({ execute }) => {
+  let hookCalls: string[];
+
+  // Used hook acronyms:
+  //   BFR: beforeFieldResolve
+  //   AFR: afterFieldResolve
+  //   AFC: afterFieldComplete
+  const hooks: ExecutionHooks = {
+    beforeFieldResolve: jest
+      .fn()
+      .mockImplementation(({ path }: BeforeFieldResolveHookArgs) => {
+        hookCalls.push(`BFR|${pathToArray(path).join(".")}`);
+      }),
+    afterFieldResolve: jest
+      .fn()
+      .mockImplementation(
+        ({ path, result, error }: AfterFieldResolveHookArgs) => {
+          const resultValue =
+            typeof result === "object" && result !== null ? "[object]" : result;
+          hookCalls.push(
+            `AFR|${pathToArray(path).join(".")}|${resultValue}|${
+              error?.message
+            }`,
+          );
+        },
+      ),
+    afterFieldComplete: jest
+      .fn()
+      .mockImplementation(
+        ({ path, result, error }: AfterFieldCompleteHookArgs) => {
+          const resultValue =
+            typeof result === "object" && result !== null ? "[object]" : result;
+          hookCalls.push(
+            `AFC|${pathToArray(path).join(".")}|${resultValue}|${
+              error?.message
+            }`,
+          );
+        },
+      ),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hookCalls = [];
+  });
+
+  describe("Execution hooks are invoked", () => {
+    const testCases: Array<TestCase> = [
+      {
+        name: "succeeded sync resolver",
+        query: `
+        {
+          person(id: 1) {
+            name
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Person: {
+            name: (parent: any, _args: {}, _context: any) => {
+              return parent.name;
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|person",
+          "AFR|person|[object]|undefined",
+          "BFR|person.name",
+          "AFR|person.name|Luke Skywalker|undefined",
+          "AFC|person.name|Luke Skywalker|undefined",
+          "AFC|person|[object]|undefined",
+        ],
+      },
+      {
+        name: "succeeded async resolver",
+        query: `
+        {
+          person(id: 1) {
+            name
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Person: {
+            name: async (parent: any, _args: {}, _context: any) => {
+              return Promise.resolve(parent.name);
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|person",
+          "AFR|person|[object]|undefined",
+          "BFR|person.name",
+          "AFR|person.name|Luke Skywalker|undefined",
+          "AFC|person.name|Luke Skywalker|undefined",
+          "AFC|person|[object]|undefined",
+        ],
+      },
+      {
+        name: "error in sync resolver for nullable field",
+        query: `
+        {
+          film(id: 1) {
+            producer
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Film: {
+            producer: (_parent: any, _args: {}, _context: any) => {
+              throw new Error("Resolver error");
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|film",
+          "AFR|film|[object]|undefined",
+          "BFR|film.producer",
+          "AFR|film.producer|undefined|Resolver error",
+          "AFC|film.producer|undefined|Resolver error",
+          "AFC|film|[object]|undefined",
+        ],
+      },
+      {
+        name: "error in async resolver for nullable field",
+        query: `
+        {
+          film(id: 1) {
+            producer
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Film: {
+            producer: async (_parent: any, _args: {}, _context: any) => {
+              return Promise.reject(new Error("Resolver error"));
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|film",
+          "AFR|film|[object]|undefined",
+          "BFR|film.producer",
+          "AFR|film.producer|undefined|Resolver error",
+          "AFC|film.producer|undefined|Resolver error",
+          "AFC|film|[object]|undefined",
+        ],
+      },
+      {
+        name: "error in sync resolver for non-nullable field",
+        query: `
+        {
+          film(id: 1) {
+            title
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Film: {
+            title: (_parent: any, _args: {}, _context: any) => {
+              throw new Error("Resolver error");
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|film",
+          "AFR|film|[object]|undefined",
+          "BFR|film.title",
+          "AFR|film.title|undefined|Resolver error",
+          "AFC|film.title|undefined|Resolver error",
+          "AFC|film|undefined|Resolver error",
+        ],
+      },
+      {
+        name: "error in async resolver for non-nullable field",
+        query: `
+        {
+          film(id: 1) {
+            title
+          }
+        }`,
+        resolvers: {
+          ...resolvers,
+          Film: {
+            title: async (_parent: any, _args: {}, _context: any) => {
+              return Promise.reject(new Error("Resolver error"));
+            },
+          },
+        } as UserResolvers,
+        expectedHookCalls: [
+          "BFR|film",
+          "AFR|film|[object]|undefined",
+          "BFR|film.title",
+          "AFR|film.title|undefined|Resolver error",
+          "AFC|film.title|undefined|Resolver error",
+          "AFC|film|undefined|Resolver error",
+        ],
+      },
+    ];
+
+    it.each(testCases)(
+      "$name",
+      async ({ query, resolvers, expectedHookCalls }) => {
+        expect.assertions(2);
+        const document = parse(query);
+
+        await execute(document, resolvers, hooks);
+
+        // for async resolvers order of resolving isn't strict,
+        // so just verify whether corresponding hook calls happened
+        expect(hookCalls).toHaveLength(expectedHookCalls.length);
+        expect(hookCalls).toEqual(expect.arrayContaining(expectedHookCalls));
+      },
+    );
+  });
+});

--- a/packages/supermassive/src/__tests__/hooks.test.ts
+++ b/packages/supermassive/src/__tests__/hooks.test.ts
@@ -36,7 +36,7 @@ describe.each([
         contextValue: {
           models,
         },
-        hooks,
+        fieldExecutionHooks: hooks,
       });
     },
   },
@@ -54,7 +54,7 @@ describe.each([
         contextValue: {
           models,
         },
-        hooks,
+        fieldExecutionHooks: hooks,
       });
     },
   },

--- a/packages/supermassive/src/executeWithSchema.ts
+++ b/packages/supermassive/src/executeWithSchema.ts
@@ -18,6 +18,7 @@ export function executeWithSchema({
   operationName,
   fieldResolver,
   typeResolver,
+  hooks,
 }: ExecutionWithSchemaArgs): PromiseOrValue<ExecutionResult> {
   const schema = buildASTSchema(typeDefs);
   let extractedResolvers: Resolvers = {};
@@ -42,5 +43,6 @@ export function executeWithSchema({
     operationName,
     fieldResolver,
     typeResolver,
+    hooks,
   });
 }

--- a/packages/supermassive/src/executeWithSchema.ts
+++ b/packages/supermassive/src/executeWithSchema.ts
@@ -18,7 +18,7 @@ export function executeWithSchema({
   operationName,
   fieldResolver,
   typeResolver,
-  hooks,
+  fieldExecutionHooks,
 }: ExecutionWithSchemaArgs): PromiseOrValue<ExecutionResult> {
   const schema = buildASTSchema(typeDefs);
   let extractedResolvers: Resolvers = {};
@@ -43,6 +43,6 @@ export function executeWithSchema({
     operationName,
     fieldResolver,
     typeResolver,
-    hooks,
+    fieldExecutionHooks,
   });
 }

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -94,7 +94,7 @@ export interface ExecutionContext {
   fieldResolver: FunctionFieldResolver<any, any>;
   typeResolver: TypeResolver<any, any>;
   errors: Array<GraphQLError>;
-  hooks?: ExecutionHooks;
+  fieldExecutionHooks?: ExecutionHooks;
 }
 
 /**
@@ -120,7 +120,7 @@ export function executeWithoutSchema(
     operationName,
     fieldResolver,
     typeResolver,
-    hooks,
+    fieldExecutionHooks,
   } = args;
 
   const combinedResolvers = mergeResolvers(resolvers, schemaResolvers);
@@ -138,7 +138,7 @@ export function executeWithoutSchema(
     operationName,
     fieldResolver,
     typeResolver,
-    hooks,
+    fieldExecutionHooks,
   );
 
   // Return early errors if execution context failed.
@@ -211,7 +211,7 @@ export function buildExecutionContext(
   operationName: Maybe<string>,
   fieldResolver: Maybe<FunctionFieldResolver<unknown, unknown>>,
   typeResolver?: Maybe<TypeResolver<unknown, unknown>>,
-  hooks?: ExecutionHooks,
+  fieldExecutionHooks?: ExecutionHooks,
 ): Array<GraphQLError> | ExecutionContext {
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
@@ -268,7 +268,7 @@ export function buildExecutionContext(
     fieldResolver: fieldResolver ?? defaultFieldResolver,
     typeResolver: typeResolver ?? defaultTypeResolver,
     errors: [],
-    hooks,
+    fieldExecutionHooks,
   };
 }
 
@@ -955,7 +955,7 @@ function invokeBeforeFieldResolveHook(
   path: Path,
   exeContext: ExecutionContext,
 ): void {
-  const hook = exeContext.hooks?.beforeFieldResolve;
+  const hook = exeContext.fieldExecutionHooks?.beforeFieldResolve;
   if (!hook) {
     return;
   }
@@ -979,7 +979,7 @@ function invokeAfterFieldResolveHook(
   result?: unknown,
   error?: Error,
 ): void {
-  const hook = exeContext.hooks?.afterFieldResolve;
+  const hook = exeContext.fieldExecutionHooks?.afterFieldResolve;
   if (!hook) {
     return;
   }
@@ -1005,7 +1005,7 @@ function invokeAfterFieldCompleteHook(
   result?: unknown,
   error?: Error,
 ): void {
-  const hook = exeContext.hooks?.afterFieldComplete;
+  const hook = exeContext.fieldExecutionHooks?.afterFieldComplete;
   if (!hook) {
     return;
   }

--- a/packages/supermassive/src/hooks/types.ts
+++ b/packages/supermassive/src/hooks/types.ts
@@ -1,23 +1,23 @@
-import { Path } from "../jsutils/Path";
+import { ResolveInfo } from "../types";
 
 interface BaseExecuteHookArgs {
   context: unknown;
 }
 
 interface BaseExecuteFieldHookArgs extends BaseExecuteHookArgs {
-  path: Path;
+  resolveInfo: ResolveInfo;
 }
 
 export interface BeforeFieldResolveHookArgs extends BaseExecuteFieldHookArgs {}
 
 export interface AfterFieldResolveHookArgs extends BaseExecuteFieldHookArgs {
   result?: unknown;
-  error?: Error;
+  error?: any;
 }
 
 export interface AfterFieldCompleteHookArgs extends BaseExecuteFieldHookArgs {
   result?: unknown;
-  error?: Error;
+  error?: any;
 }
 
 export interface BeforeFieldResolveHook {

--- a/packages/supermassive/src/hooks/types.ts
+++ b/packages/supermassive/src/hooks/types.ts
@@ -1,0 +1,39 @@
+import { Path } from "../jsutils/Path";
+
+interface BaseExecuteHookArgs {
+  context: unknown;
+}
+
+interface BaseExecuteFieldHookArgs extends BaseExecuteHookArgs {
+  path: Path;
+}
+
+export interface BeforeFieldResolveHookArgs extends BaseExecuteFieldHookArgs {}
+
+export interface AfterFieldResolveHookArgs extends BaseExecuteFieldHookArgs {
+  result?: unknown;
+  error?: Error;
+}
+
+export interface AfterFieldCompleteHookArgs extends BaseExecuteFieldHookArgs {
+  result?: unknown;
+  error?: Error;
+}
+
+export interface BeforeFieldResolveHook {
+  (args: BeforeFieldResolveHookArgs): void;
+}
+
+export interface AfterFieldResolveHook {
+  (args: AfterFieldResolveHookArgs): void;
+}
+
+export interface AfterFieldCompleteHook {
+  (args: AfterFieldCompleteHookArgs): void;
+}
+
+export interface ExecutionHooks {
+  beforeFieldResolve?: BeforeFieldResolveHook;
+  afterFieldResolve?: AfterFieldResolveHook;
+  afterFieldComplete?: AfterFieldCompleteHook;
+}

--- a/packages/supermassive/src/index.ts
+++ b/packages/supermassive/src/index.ts
@@ -71,3 +71,13 @@ export type {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
 } from "./ast/TypedAST";
+
+export {
+  BeforeFieldResolveHookArgs,
+  AfterFieldResolveHookArgs,
+  AfterFieldCompleteHookArgs,
+  BeforeFieldResolveHook,
+  AfterFieldResolveHook,
+  AfterFieldCompleteHook,
+  ExecutionHooks,
+} from "./hooks/types";

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -163,7 +163,7 @@ export interface CommonExecutionArgs {
   fieldResolver?: Maybe<FunctionFieldResolver<any, any>>;
   typeResolver?: Maybe<TypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<FunctionFieldResolver<any, any>>;
-  hooks?: ExecutionHooks;
+  fieldExecutionHooks?: ExecutionHooks;
 }
 export type ExecutionWithoutSchemaArgs = CommonExecutionArgs & {
   document: DocumentNode;

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -18,6 +18,7 @@ import {
 } from "./ast/TypedAST";
 import { ObjMap } from "./jsutils/ObjMap";
 import { Path } from "./jsutils/Path";
+import { ExecutionHooks } from "./hooks/types";
 
 export type ScalarTypeResolver = GraphQLScalarType;
 export type EnumTypeResolver = GraphQLEnumType; // TODO Record<string, any>;
@@ -162,6 +163,7 @@ export interface CommonExecutionArgs {
   fieldResolver?: Maybe<FunctionFieldResolver<any, any>>;
   typeResolver?: Maybe<TypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<FunctionFieldResolver<any, any>>;
+  hooks?: ExecutionHooks;
 }
 export type ExecutionWithoutSchemaArgs = CommonExecutionArgs & {
   document: DocumentNode;

--- a/packages/supermassive/src/utilities/array.ts
+++ b/packages/supermassive/src/utilities/array.ts
@@ -1,0 +1,14 @@
+export function arraysAreEqual(
+  array1: readonly any[],
+  array2: readonly any[],
+): boolean {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+  for (let i = 0; i < array1.length - 1; i++) {
+    if (array1[i] !== array2[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Initial implementation of the execution hooks:
 - beforeFieldResolve
 - afterFieldResolve
 - afterFieldComplete

Details:
 - Each hook accepts in arguments:
   - `ResolveInfo` of the field
   - Custom context passed into execution (same as passed into resolvers)
   - afterResolve/afterComplete also accept resolved value or error
 - Hooks aren't invoked for the default field resolvers
 - When error is thrown in the hook, it's returned in the response `errors` array