### PR TITLE
Several changes to supermassive and related plugins

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 /.yarn/** linguist-vendored
+
+* text=auto eol=lf
+yarn.lock text eol=lf

--- a/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-5fa28e8f-45d5-480a-9433-a936bf0a7f61.json
+++ b/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-5fa28e8f-45d5-480a-9433-a936bf0a7f61.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support conditional annotations in `graphql-codegen-supermassive-typed-document-node-plugin`",
+  "packageName": "@graphitation/graphql-codegen-supermassive-typed-document-node-plugin",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-supermassive-88183e2c-4534-4e2b-aea4-9e3d46838e94.json
+++ b/change/@graphitation-supermassive-88183e2c-4534-4e2b-aea4-9e3d46838e94.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make execution argument `schemaResolvers` optional",
+  "packageName": "@graphitation/supermassive",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-supermassive-extractors-b9de4061-1151-4cd0-83af-1848c876f813.json
+++ b/change/@graphitation-supermassive-extractors-b9de4061-1151-4cd0-83af-1848c876f813.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose printed TS version of extracted implicit types",
+  "packageName": "@graphitation/supermassive-extractors",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive-extractors/src/__tests__/extractImplicitTypesToTypescript.test.ts
+++ b/packages/supermassive-extractors/src/__tests__/extractImplicitTypesToTypescript.test.ts
@@ -2,11 +2,14 @@ import * as fs from "fs";
 import * as path from "path";
 import ts from "typescript";
 import { parse } from "graphql";
-import { extractImplicitTypesToTypescript } from "../extractImplicitTypesToTypescript";
+import {
+  extractAndPrintImplicitTypesToTypescript,
+  extractImplicitTypesToTypescript,
+} from "../extractImplicitTypesToTypescript";
 
 describe(extractImplicitTypesToTypescript, () => {
   it("benchmark schema extract", () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const typeDefs = fs.readFileSync(
       path.join(
         __dirname,
@@ -16,13 +19,16 @@ describe(extractImplicitTypesToTypescript, () => {
         encoding: "utf-8",
       },
     );
-    const sourceFile = extractImplicitTypesToTypescript(parse(typeDefs));
+    const document = parse(typeDefs);
+    const sourceFile = extractImplicitTypesToTypescript(document);
     const printer = ts.createPrinter();
     const printedSource = printer.printNode(
       ts.EmitHint.SourceFile,
       sourceFile,
       sourceFile,
     );
+    const printed = extractAndPrintImplicitTypesToTypescript(document);
     expect(printedSource).toMatchSnapshot();
+    expect(printed).toEqual(printedSource);
   });
 });

--- a/packages/supermassive-extractors/src/extractImplicitTypesToTypescript.ts
+++ b/packages/supermassive-extractors/src/extractImplicitTypesToTypescript.ts
@@ -197,6 +197,13 @@ export function extractImplicitTypesToTypescript(
   );
 }
 
+export function extractAndPrintImplicitTypesToTypescript(
+  document: DocumentNode,
+): string {
+  const file = extractImplicitTypesToTypescript(document);
+  return ts.createPrinter().printFile(file);
+}
+
 function createDeclaration(
   name: string,
   decl: ts.Expression,

--- a/packages/supermassive-extractors/src/index.ts
+++ b/packages/supermassive-extractors/src/index.ts
@@ -1,1 +1,4 @@
-export { extractImplicitTypesToTypescript } from "./extractImplicitTypesToTypescript";
+export {
+  extractImplicitTypesToTypescript,
+  extractAndPrintImplicitTypesToTypescript,
+} from "./extractImplicitTypesToTypescript";

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -123,7 +123,9 @@ export function executeWithoutSchema(
     fieldExecutionHooks,
   } = args;
 
-  const combinedResolvers = mergeResolvers(resolvers, schemaResolvers);
+  const combinedResolvers = schemaResolvers
+    ? mergeResolvers(resolvers, schemaResolvers)
+    : resolvers;
   // If arguments are missing or incorrect, throw an error.
   assertValidExecutionArguments(document, variableValues);
 

--- a/packages/supermassive/src/subscribeWithoutSchema.ts
+++ b/packages/supermassive/src/subscribeWithoutSchema.ts
@@ -71,7 +71,9 @@ export async function subscribeWithoutSchema(
     subscribeFieldResolver,
   } = args;
 
-  const combinedResolvers = mergeResolvers(resolvers, schemaResolvers);
+  const combinedResolvers = schemaResolvers
+    ? mergeResolvers(resolvers, schemaResolvers)
+    : resolvers;
 
   const resultOrStream = await createSourceEventStream(
     combinedResolvers,

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -167,7 +167,7 @@ export interface CommonExecutionArgs {
 }
 export type ExecutionWithoutSchemaArgs = CommonExecutionArgs & {
   document: DocumentNode;
-  schemaResolvers: Resolvers;
+  schemaResolvers?: Resolvers;
 };
 
 export type ExecutionWithSchemaArgs = CommonExecutionArgs & {


### PR DESCRIPTION
### `@graphitation/supermassive`

Make execution argument `schemaResolvers` optional.

Currently `schemaResolvers` is a required argument. But when we merge resolvers outside of supermassive - implicit resolvers (aka schemaResolvers) become a part of `resolvers` argument and don't require a separate merging pass inside supermassive.

### `@graphitation/graphql-codegen-supermassive-typed-document-node-plugin`

New feature, allowing to set a custom option `supermassiveDocumentNodeConditional` to the codegen. When set, it will conditionally render standard GraphQL AST or Supermassive AST, e.g with `supermassiveDocumentNodeConditional: "process.env.ENABLE_SUPERMASSIVE"`, the plugin produces:

```ts
export const MyQueryDocument = (process.env.ENABLE_SUPERMASSIVE
  ? { "kind": "Document", /* supermassive AST */ }
  : { "kind": "Document", /* standard AST */ }
) as unknown as DocumentNode<MyQuery, MyQueryVariables>;
```

### `@graphitation/supermassive-extractors`

Currently, plugin exposes typescript AST node for extracted implicit types (not printed TS code). The problem here is that the plugin could be used in a project containing a different version of Typescript. So project-level TS printer may be incompatible with TS AST produced by this plugin. In this case there is no easy way to print the AST node.

By exposing printed version, we ensure that both factory and printer are using the same version of TS under the hood.