### PR TITLE
Support context in duct tape hooks

### DIFF
--- a/change/@graphitation-apollo-mock-client-8211d886-995f-4c45-af50-b3a60a3e73b6.json
+++ b/change/@graphitation-apollo-mock-client-8211d886-995f-4c45-af50-b3a60a3e73b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add support for context in request",
+  "packageName": "@graphitation/apollo-mock-client",
+  "email": "52814187+ira-kaundal@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-react-relay-duct-tape-89169e12-2445-46a9-b434-24541ccf6357.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-89169e12-2445-46a9-b434-24541ccf6357.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "support context in duct tape hooks",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "52814187+ira-kaundal@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-mock-client/src/index.ts
+++ b/packages/apollo-mock-client/src/index.ts
@@ -17,6 +17,7 @@ import invariant from "invariant";
 export interface RequestDescriptor<Node = DocumentNode> {
   readonly node: Node;
   readonly variables: Record<string, any>;
+  readonly context?: Record<string, any>;
 }
 
 export interface OperationDescriptor<
@@ -164,6 +165,7 @@ class MockLink extends ApolloLink {
           request: {
             node: operation.query,
             variables: operation.variables || {},
+            context: operation.getContext(),
           },
         },
         observer,

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/hooks.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/hooks.test.tsx
@@ -67,9 +67,13 @@ const query = graphql`
 `;
 
 const QueryComponent: React.FC = () => {
-  const { data, error } = useLazyLoadQuery<hooksTestQuery>(query, {
-    id: "some-user-id",
-  });
+  const { data, error } = useLazyLoadQuery<hooksTestQuery>(
+    query,
+    {
+      id: "some-user-id",
+    },
+    { context: { callerInfo: "query-component" } },
+  );
   if (error) {
     return <div id="error">{error.message}</div>;
   } else if (data) {
@@ -120,6 +124,7 @@ const SubscriptionComponent: React.FC<SubjectProps> = ({
   useSubscription<hooksTestSubscription>({
     subscription,
     variables: { id: "some-user-id" },
+    context: { callerInfo: "subscription-component" },
     onNext,
     onError: onError || undefined,
   });
@@ -129,13 +134,14 @@ const SubscriptionComponent: React.FC<SubjectProps> = ({
 const MutationComponent: React.FC<{
   variables: any;
   optimisticResponse: any;
+  context?: any;
 }> = (props) => {
-  const { variables, optimisticResponse } = props;
+  const { variables, optimisticResponse, context } = props;
   const [commit, isInFlight] = useMutation<hooksTestMutation$key>(mutation);
   const [result, setResult] = React.useState<any>(null);
   React.useEffect(() => {
     (async function () {
-      const result = await commit({ variables, optimisticResponse });
+      const result = await commit({ variables, optimisticResponse, context });
       setResult(result);
     })();
   }, [variables, optimisticResponse]);
@@ -172,6 +178,11 @@ describe(useLazyLoadQuery, () => {
     const operation = client.mock.getMostRecentOperation();
     expect(getOperationName(operation.request.node)).toBe("hooksTestQuery");
     expect(operation.request.variables).toEqual({ id: "some-user-id" });
+    console.log(operation.request);
+    expect(operation.request.context).toHaveProperty(
+      "callerInfo",
+      "query-component",
+    );
 
     await act(() =>
       client.mock.resolve(operation, MockPayloadGenerator.generate(operation)),
@@ -220,6 +231,10 @@ describe(useSubscription, () => {
     expect(subscriptionOperation.request.variables).toEqual({
       id: "some-user-id",
     });
+    expect(subscriptionOperation.request.context).toHaveProperty(
+      "callerInfo",
+      "subscription-component",
+    );
 
     // First resolve query...
     await act(() =>
@@ -337,6 +352,7 @@ describe("useMutation", () => {
         <MutationComponent
           variables={{ name: "foo", id: "1" }}
           optimisticResponse={null}
+          context={{ callerInfo: "mutation-component" }}
         />
       </ApolloProvider>,
     );
@@ -358,6 +374,7 @@ describe("useMutation", () => {
                 name: '&lt;mock-value-for-field-"name"&gt;',
               },
             }}
+            context={{ callerInfo: "mutation-component" }}
           />
         </ApolloProvider>,
       );
@@ -387,5 +404,9 @@ describe("useMutation", () => {
       name: "foo",
       id: "1",
     });
+    expect(mutationOperation.request.context).toHaveProperty(
+      "callerInfo",
+      "mutation-component",
+    );
   });
 });

--- a/packages/apollo-react-relay-duct-tape/src/hooks.ts
+++ b/packages/apollo-react-relay-duct-tape/src/hooks.ts
@@ -10,7 +10,7 @@ import {
 } from "@apollo/client";
 
 // import { GraphQLTaggedNode } from "./taggedNode";
-import { KeyType, KeyTypeData, OperationType, Variables } from "./types";
+import { KeyType, KeyTypeData, OperationType } from "./types";
 
 export type GraphQLTaggedNode = DocumentNode;
 
@@ -62,7 +62,7 @@ export type GraphQLTaggedNode = DocumentNode;
 export function useLazyLoadQuery<TQuery extends OperationType>(
   query: GraphQLTaggedNode,
   variables: TQuery["variables"],
-  options?: { fetchPolicy: "cache-first" },
+  options?: { fetchPolicy?: "cache-first"; context?: TQuery["context"] },
 ): { error?: Error; data?: TQuery["response"] } {
   return useApolloQuery(query as any, { variables, ...options });
 }
@@ -144,6 +144,7 @@ interface GraphQLSubscriptionConfig<
 > {
   subscription: GraphQLTaggedNode;
   variables: TSubscriptionPayload["variables"];
+  context?: TSubscriptionPayload["context"];
   /**
    * Should response be nullable?
    */
@@ -156,6 +157,7 @@ export function useSubscription<TSubscriptionPayload extends OperationType>(
 ): void {
   const { error } = useApolloSubscription(config.subscription, {
     variables: config.variables,
+    context: config.context,
     onSubscriptionData: ({ subscriptionData }) => {
       // Supposedly this never gets triggered for an error by design:
       // https://github.com/apollographql/react-apollo/issues/3177#issuecomment-506758144
@@ -184,6 +186,7 @@ export function useSubscription<TSubscriptionPayload extends OperationType>(
 
 interface IMutationCommitterOptions<TMutationPayload extends OperationType> {
   variables: TMutationPayload["variables"];
+  context?: TMutationPayload["context"];
   optimisticResponse?: Partial<TMutationPayload["response"]> | null;
 }
 
@@ -248,6 +251,7 @@ export function useMutation<TMutationPayload extends OperationType>(
     async (options: IMutationCommitterOptions<TMutationPayload>) => {
       const apolloResult = await apolloUpdater({
         variables: options.variables || {},
+        context: options.context,
         optimisticResponse: options.optimisticResponse,
       });
       if (apolloResult.errors) {

--- a/packages/apollo-react-relay-duct-tape/src/types.ts
+++ b/packages/apollo-react-relay-duct-tape/src/types.ts
@@ -2,8 +2,13 @@ export interface Variables {
   [name: string]: any;
 }
 
+export interface Context {
+  [name: string]: any;
+}
+
 export interface OperationType {
   readonly variables: Variables;
+  readonly context?: Context;
   readonly response: unknown;
   readonly rawResponse?: unknown;
 }


### PR DESCRIPTION
Currently, the wrapper hooks exposed from `apollo-react-relay-duct-tape` do not support the passing of context option.

We are discovering use cases for allowing context for supporting scenarios like instrumentation.

For e.g. passing caller information as part of context.

This PR contains the following changes:
- [ ] Add support for context in duct tape hooks
- [ ] Update tests
- [ ] Adjust apollo-mock-client to support context option.

