### PR TITLE
[SUPERMASSIVE] fix invalid behavior in execution hooks error handling

### DIFF
--- a/change/@graphitation-supermassive-54517af7-4703-4b73-bac9-a77243ba55d9.json
+++ b/change/@graphitation-supermassive-54517af7-4703-4b73-bac9-a77243ba55d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[SUPERMASSIVE] fix invalid behavior in execution hooks error handling",
+  "packageName": "@graphitation/supermassive",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -989,12 +989,14 @@ function invokeBeforeFieldResolveHook(
         context: exeContext.contextValue,
       }),
     (_, rawError) => {
-      const error = toGraphQLError(
-        rawError,
-        resolveInfo.path,
-        "Unexpected error in beforeFieldResolve hook",
-      );
-      exeContext.errors.push(error);
+      if (rawError) {
+        const error = toGraphQLError(
+          rawError,
+          resolveInfo.path,
+          "Unexpected error in beforeFieldResolve hook",
+        );
+        exeContext.errors.push(error);
+      }
     },
   );
 }
@@ -1018,12 +1020,14 @@ function invokeAfterFieldResolveHook(
         error,
       }),
     (_, rawError) => {
-      const error = toGraphQLError(
-        rawError,
-        resolveInfo.path,
-        "Unexpected error in afterFieldResolve hook",
-      );
-      exeContext.errors.push(error);
+      if (rawError) {
+        const error = toGraphQLError(
+          rawError,
+          resolveInfo.path,
+          "Unexpected error in afterFieldResolve hook",
+        );
+        exeContext.errors.push(error);
+      }
     },
   );
 }
@@ -1047,12 +1051,14 @@ function invokeAfterFieldCompleteHook(
         error,
       }),
     (_, rawError) => {
-      const error = toGraphQLError(
-        rawError,
-        resolveInfo.path,
-        "Unexpected error in afterFieldComplete hook",
-      );
-      exeContext.errors.push(error);
+      if (rawError) {
+        const error = toGraphQLError(
+          rawError,
+          resolveInfo.path,
+          "Unexpected error in afterFieldComplete hook",
+        );
+        exeContext.errors.push(error);
+      }
     },
   );
 }


### PR DESCRIPTION
Fixes an issue when error is created and added into execution result regardless of the fact that it's happened actually.