### PR TITLE
Fix lack of support for default variables and values in supermassive

### DIFF
--- a/change/@graphitation-supermassive-db783379-b33a-4525-99e2-d733bb7d531c.json
+++ b/change/@graphitation-supermassive-db783379-b33a-4525-99e2-d733bb7d531c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix supermassive not supporting unpassed default arguments",
+  "packageName": "@graphitation/supermassive",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -250,6 +250,38 @@ query Person($id: Int!) {
     }
     `,
   },
+  {
+    name: "Default value in variables",
+    document: `
+    query ($title: String! = "The Empire Strikes Back") {
+      searchFilmsByTitle(title: $title) {
+        title
+      }
+    }`,
+  },
+  {
+    name: "Default value",
+    document: `
+    {
+      searchFilmsByTitle {
+        title
+      }
+    }`,
+  },
+  {
+    name: "Advanced Default value in variables",
+    document: `
+    query ($input: AdvancedInput! = { enumField: Film, otherField: "The Empire Strikes Back" }) {
+      advancedDefaultInput(input: $input)
+    }`,
+  },
+  {
+    name: "Advanced Default value",
+    document: `
+    {
+      advancedDefaultInput
+    }`,
+  },
 ];
 
 describe("executeWithSchema", () => {

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -254,7 +254,7 @@ query Person($id: Int!) {
     name: "Default value in variables",
     document: `
     query ($title: String! = "The Empire Strikes Back") {
-      searchFilmsByTitle(title: $title) {
+      searchFilmsByTitle(search: $title) {
         title
       }
     }`,
@@ -281,6 +281,22 @@ query Person($id: Int!) {
     {
       advancedDefaultInput
     }`,
+  },
+  {
+    name: "Not passing arg value vs passing arg value",
+    document: `
+    {
+      multiArger
+    }
+    `,
+  },
+  {
+    name: "Not passing arg value vs passing arg value",
+    document: `
+    {
+      multiArger(a:null)
+    }
+    `,
   },
 ];
 
@@ -351,5 +367,10 @@ async function compareResultsForExecuteWithoutSchema(
     schema,
     variableValues: variables,
   });
+  if (result.errors) {
+    for (const error of result.errors) {
+      console.error(error);
+    }
+  }
   expect(result).toEqual(validResult);
 }

--- a/packages/supermassive/src/ast/TypedAST.ts
+++ b/packages/supermassive/src/ast/TypedAST.ts
@@ -185,7 +185,7 @@ export interface FieldNode {
 
 export interface ArgumentNode {
   readonly __type: TypeNode; // [SUPERMASSIVE] Add the value type
-  readonly __defaultValue: Maybe<ValueNode>; // [SUPERMASSIVE] Add default value
+  readonly __defaultValue?: Maybe<ValueNode>; // [SUPERMASSIVE] Add default value
   readonly kind: "Argument";
   readonly loc?: Location;
   readonly name: NameNode;

--- a/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
+++ b/packages/supermassive/src/ast/__tests__/addTypesToRequestDocument.test.ts
@@ -15,16 +15,25 @@ const schema = buildASTSchema(graphql`
   }
 
   type Mutation {
-    createFilm(input: CreateFilmInput!): Film
+    createFilm(
+      input: CreateFilmInput! = { filmType: GOOD, title: "Default" }
+      enumInput: FilmType!
+    ): Film
   }
 
   type Film {
-    title: String!
+    title(foo: String = "Bar"): String!
     actors: [String!]
+  }
+
+  enum FilmType {
+    GOOD
+    BAD
   }
 
   input CreateFilmInput {
     title: String!
+    filmType: FilmType!
   }
 `);
 
@@ -183,8 +192,11 @@ describe(addTypesToRequestDocument, () => {
       const document = addTypesToRequestDocument(
         schema,
         graphql`
-          mutation {
-            createFilm(input: { title: "The Phantom Menace" }) {
+          mutation Test($filmType: FilmType) {
+            createFilm(
+              input: { title: "The Phantom Menace", filmType: $filmType }
+              enumInput: $filmType
+            ) {
               title
             }
           }
@@ -207,6 +219,53 @@ describe(addTypesToRequestDocument, () => {
           },
         }
       `);
+
+      expect(argumentNode.__defaultValue).toMatchInlineSnapshot(`
+        {
+          "fields": [
+            {
+              "kind": "ObjectField",
+              "name": {
+                "kind": "Name",
+                "value": "title",
+              },
+              "value": {
+                "kind": "StringValue",
+                "value": "Default",
+              },
+            },
+            {
+              "kind": "ObjectField",
+              "name": {
+                "kind": "Name",
+                "value": "filmType",
+              },
+              "value": {
+                "kind": "EnumValue",
+                "value": "GOOD",
+              },
+            },
+          ],
+          "kind": "ObjectValue",
+        }
+      `);
+
+      const secondArgument = fieldNode.arguments![1];
+
+      expect(secondArgument.__type).toMatchInlineSnapshot(`
+        {
+          "kind": "NonNullType",
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "FilmType",
+            },
+          },
+        }
+      `);
+
+      expect(secondArgument.__defaultValue).toMatchInlineSnapshot(`undefined`);
     });
 
     it("errors nicely for unknown fields", () => {

--- a/packages/supermassive/src/ast/addTypesToRequestDocument.ts
+++ b/packages/supermassive/src/ast/addTypesToRequestDocument.ts
@@ -11,6 +11,7 @@ import {
   visitWithTypeInfo,
   Kind,
   astFromValue,
+  GraphQLArgument,
 } from "graphql";
 
 import * as TypelessAST from "graphql/language/ast";
@@ -26,68 +27,90 @@ export function addTypesToRequestDocument(
     document as any,
     visitWithTypeInfo(typeInfo, {
       Argument: {
-        leave(node) {
+        leave(node, _key, _parent, _path, ancestors) {
           const argument = typeInfo.getArgument()!;
           if (argument) {
             const typeNode = generateTypeNode(argument.type);
             const newNode: TypedAST.ArgumentNode = {
               ...node,
               __type: typeNode,
-              __defaultValue: argument.defaultValue
-                ? astFromValue(argument.defaultValue, argument.type)
-                : undefined,
             };
-            if (newNode.__defaultValue) {
-              console.log(newNode);
+            // We only need default value for arguments with variable values
+            if (argument.defaultValue && node.value.kind === Kind.VARIABLE) {
+              (newNode.__defaultValue as
+                | TypedAST.ValueNode
+                | null
+                | undefined) = astFromValue(
+                argument.defaultValue,
+                argument.type,
+              );
             }
             return newNode;
           }
+          const errorPath = makeReadableErrorPath(ancestors);
+          throw new Error(
+            `Cannot find type for argument: ${errorPath.join(".")}.${
+              node.name.value
+            }`,
+          );
         },
       },
       Field: {
         leave(
-          node: Omit<
-            TypelessAST.FieldNode,
-            "selectionSet" | "arguments" | "directives"
-          >,
+          node: Omit<TypelessAST.FieldNode, "selectionSet" | "directives">,
           _key,
           _parent,
           _path,
           ancestors,
         ) {
-          const type = typeInfo.getType();
-          if (type) {
-            const typeNode = generateTypeNode(type);
-            const newNode: TypedAST.FieldNode = {
-              ...node,
-              __type: typeNode,
-            };
-            return newNode;
-          }
-          const path: string[] = [];
-          ancestors.forEach((ancestorOrArray) => {
-            let ancestor: TypelessAST.ASTNode;
-            if (!Array.isArray(ancestorOrArray)) {
-              ancestor = ancestorOrArray as TypelessAST.ASTNode;
-              if (ancestor && ancestor.kind === Kind.FIELD) {
-                path.push(ancestor.name.value);
-              } else if (
-                ancestor &&
-                ancestor.kind === Kind.OPERATION_DEFINITION
-              ) {
-                let name;
-                if (ancestor.name) {
-                  name = `${ancestor.operation} ${ancestor.name.value}`;
-                } else {
-                  name = ancestor.operation;
-                }
-                path.push(name);
+          const fieldDef = typeInfo.getFieldDef();
+          if (fieldDef) {
+            const type = fieldDef.type;
+            if (type) {
+              const typeNode = generateTypeNode(type);
+              const missingArgs: Array<GraphQLArgument> = fieldDef.args.filter(
+                (argDef) =>
+                  argDef.defaultValue != null &&
+                  node.arguments?.findIndex(
+                    (arg) => arg.name.value === argDef.name,
+                  ) === -1,
+              );
+              const newNode: TypedAST.FieldNode = {
+                ...(node as Omit<
+                  TypelessAST.FieldNode,
+                  "selectionSet" | "arguments" | "directives"
+                >),
+                __type: typeNode,
+              };
+              if (missingArgs) {
+                (newNode.arguments as TypedAST.ArgumentNode[]) = (
+                  newNode.arguments || []
+                ).concat(
+                  missingArgs.map((arg) => ({
+                    __type: generateTypeNode(arg.type),
+                    kind: Kind.ARGUMENT,
+                    name: {
+                      kind: Kind.NAME,
+                      value: arg.name,
+                    },
+                    value: astFromValue(
+                      arg.defaultValue,
+                      arg.type,
+                    ) as TypedAST.ValueNode,
+                  })),
+                );
               }
+              return newNode;
             }
-          });
+          }
+
+          const errorPath = makeReadableErrorPath(ancestors);
+
           // This happens whenever a new field is requested that hasn't been defined in schema
           throw new Error(
-            `Cannot find type for field: ${path.join(".")}.${node.name.value}`,
+            `Cannot find type for field: ${errorPath.join(".")}.${
+              node.name.value
+            }`,
           );
         },
       },
@@ -122,4 +145,30 @@ function generateTypeNode(type: GraphQLType): TypedAST.TypeNode {
     };
   }
   throw new Error(`Can't generate TypeNode for type: ${type}`);
+}
+
+function makeReadableErrorPath(
+  ancestors: ReadonlyArray<
+    readonly TypelessAST.ASTNode[] | TypelessAST.ASTNode
+  >,
+): string[] {
+  const path: string[] = [];
+  ancestors.forEach((ancestorOrArray) => {
+    let ancestor: TypelessAST.ASTNode;
+    if (!Array.isArray(ancestorOrArray)) {
+      ancestor = ancestorOrArray as TypelessAST.ASTNode;
+      if (ancestor && ancestor.kind === Kind.FIELD) {
+        path.push(ancestor.name.value);
+      } else if (ancestor && ancestor.kind === Kind.OPERATION_DEFINITION) {
+        let name;
+        if (ancestor.name) {
+          name = `${ancestor.operation} ${ancestor.name.value}`;
+        } else {
+          name = ancestor.operation;
+        }
+        path.push(name);
+      }
+    }
+  });
+  return path;
 }

--- a/packages/supermassive/src/ast/addTypesToRequestDocument.ts
+++ b/packages/supermassive/src/ast/addTypesToRequestDocument.ts
@@ -10,6 +10,7 @@ import {
   print,
   visitWithTypeInfo,
   Kind,
+  astFromValue,
 } from "graphql";
 
 import * as TypelessAST from "graphql/language/ast";
@@ -33,9 +34,12 @@ export function addTypesToRequestDocument(
               ...node,
               __type: typeNode,
               __defaultValue: argument.defaultValue
-                ? parseValue(JSON.stringify(argument.defaultValue))
+                ? astFromValue(argument.defaultValue, argument.type)
                 : undefined,
             };
+            if (newNode.__defaultValue) {
+              console.log(newNode);
+            }
             return newNode;
           }
         },

--- a/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
+++ b/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
@@ -334,6 +334,9 @@ const resolvers: IExecutableSchemaDefinition["resolvers"] = {
     advancedDefaultInput(parent, args) {
       return JSON.stringify(args);
     },
+    multiArger(parent, args) {
+      return JSON.stringify(args);
+    },
   },
   Film: {
     starships,

--- a/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
+++ b/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
@@ -331,6 +331,9 @@ const resolvers: IExecutableSchemaDefinition["resolvers"] = {
     allTransports(parent, args, { models }) {
       return models.getData("/transport");
     },
+    advancedDefaultInput(parent, args) {
+      return JSON.stringify(args);
+    },
   },
   Film: {
     starships,

--- a/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
+++ b/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
@@ -38,7 +38,11 @@ type Query {
   searchSpeciesByName(search: String!): [Species]
   searchVehiclesByName(search: String!): [Vehicle]
   searchPlanetsByName(search: String!): [Planet]
-  searchFilmsByTitle(search: String!): [Film]
+  searchFilmsByTitle(search: String! = "The Empire Strikes Back"): [Film]
+
+  advancedDefaultInput(
+    input: AdvancedInput! = { enumField: Transport, otherField: "Foo" }
+  ): String
 
   allFilms: [Film]
   allStarships: [Starship]
@@ -182,4 +186,9 @@ type Transport implements Node {
   manufacturer: String
   image: String
   id: Int
+}
+
+input AdvancedInput {
+  enumField: NodeType!
+  otherField: String!
 }

--- a/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
+++ b/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
@@ -40,16 +40,17 @@ type Query {
   searchPlanetsByName(search: String!): [Planet]
   searchFilmsByTitle(search: String! = "The Empire Strikes Back"): [Film]
 
-  advancedDefaultInput(
-    input: AdvancedInput! = { enumField: Transport, otherField: "Foo" }
-  ): String
-
   allFilms: [Film]
   allStarships: [Starship]
   allPeople: [Person]
   allPlanets: [Planet]
   allSpecies: [Species]
   allTransports: [Transport]
+
+  advancedDefaultInput(
+    input: AdvancedInput! = { enumField: Transport, otherField: "Foo" }
+  ): String
+  multiArger(a: Int, b: String, c: AdvancedInput): String
 }
 
 interface Node {

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -221,7 +221,7 @@ export function getArgumentValues(
       }
     }
 
-    let coercedValue = valueFromAST(
+    const coercedValue = valueFromAST(
       valueNode as GraphQLValueNode,
       argType,
       variableValues,

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -227,7 +227,7 @@ export function getArgumentValues(
       isNull = !variableValues || variableValues[variableName] == null;
     }
 
-    const coercedValue = valueFromAST(
+    let coercedValue = valueFromAST(
       valueNode as GraphQLValueNode,
       argType,
       variableValues,

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -34,6 +34,7 @@ import type { ObjMap } from "./jsutils/ObjMap";
 import { printPathArray } from "./jsutils/printPathArray";
 import { Resolvers } from "./types";
 import { GraphQLDirective } from "./directives";
+import { filterAndExtractExtensionDefinitions } from "@graphql-tools/schema";
 
 type CoercedVariableValues =
   | { errors: Array<GraphQLError>; coerced?: never }
@@ -183,10 +184,6 @@ export function getArgumentValues(
 
   // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
   const argumentNodes = node.arguments ?? [];
-  const argNodeMap = keyMap(
-    argumentNodes,
-    (arg: ArgumentNode) => arg.name.value,
-  );
 
   for (const argumentNode of argumentNodes) {
     const name = argumentNode.name.value;
@@ -194,7 +191,6 @@ export function getArgumentValues(
     const argType = graphqlTypeFromTypeAst(resolvers, argTypeNode);
 
     if (!isInputType(argType)) {
-      console.log(argType, isInputType(argType));
       throw new GraphQLError(
         `Argument "$${name}" expected value of type "${inspect(
           argType,
@@ -204,7 +200,6 @@ export function getArgumentValues(
     }
 
     let valueNode = argumentNode.value;
-    let isNull = valueNode.kind === Kind.NULL;
 
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
@@ -212,7 +207,7 @@ export function getArgumentValues(
         variableValues == null ||
         !hasOwnProperty(variableValues, variableName)
       ) {
-        if (argumentNode.__defaultValue != undefined) {
+        if (argumentNode.__defaultValue) {
           valueNode = argumentNode.__defaultValue;
         } else if (isNonNullType(argType)) {
           throw new GraphQLError(
@@ -224,7 +219,6 @@ export function getArgumentValues(
 
         continue;
       }
-      isNull = !variableValues || variableValues[variableName] == null;
     }
 
     let coercedValue = valueFromAST(


### PR DESCRIPTION
Missing arguments without defaults were being ignored, now it's not the case.
- [x] Type annotator to add default values to all fields (so not just arguments, but missing ones too)
- [x] Check serialization and deserialization to see how it should actually be included in AST