### PR TITLE
Use 'isObjectLike' in mergeResolvers

### DIFF
--- a/change/@graphitation-supermassive-2a63c997-1d3f-48b3-97a6-19ebaadb6692.json
+++ b/change/@graphitation-supermassive-2a63c997-1d3f-48b3-97a6-19ebaadb6692.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use 'isObjectLike' in mergeResolvers due to failure when resolvers entry is esModule",
+  "packageName": "@graphitation/supermassive",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/utilities/mergeResolvers.ts
+++ b/packages/supermassive/src/utilities/mergeResolvers.ts
@@ -1,4 +1,5 @@
 import { UserResolvers, Resolvers, Resolver } from "../types";
+import { isObjectLike } from "../jsutils/isObjectLike";
 
 export function mergeResolvers(
   resolvers: UserResolvers<unknown, unknown>,
@@ -9,11 +10,7 @@ export function mergeResolvers(
   } as Resolvers;
 
   Object.keys(resolvers).forEach((resolverKey: string) => {
-    if (
-      fullResolvers[resolverKey] &&
-      typeof resolvers[resolverKey] === "object" &&
-      resolvers[resolverKey].constructor === Object
-    ) {
+    if (isObjectLike(fullResolvers[resolverKey])) {
       fullResolvers[resolverKey] = {
         ...fullResolvers[resolverKey],
         ...resolvers[resolverKey],


### PR DESCRIPTION
**Bug**:
Currently implemented check for resolvers entry to be plain object fails when resolvers are exported as `export * as Foo from './foo'`

**Fix**:
Use existing `isObjectLike` function from `./jsutils` instead