### PR TITLE
Embedded doc loader: speed this up to only apply work on relevant files

### DIFF
--- a/change/@graphitation-embedded-document-artefact-loader-b34b447f-c0ae-4ad7-840c-4213efd94c2c.json
+++ b/change/@graphitation-embedded-document-artefact-loader-b34b447f-c0ae-4ad7-840c-4213efd94c2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "No behavior change, just makes the loader only do work when there are graphql tags",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
+++ b/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
@@ -1,4 +1,5 @@
 import { transform } from "../transform";
+import { SourceMapGenerator } from "source-map-js";
 
 describe("transform", () => {
   it("should do no work if there are no embedded documents", () => {
@@ -6,6 +7,11 @@ describe("transform", () => {
       import { graphql } from "@nova/react";
       console.log()
     `;
-    expect(transform(source, "somepath", undefined)).toBeUndefined();
+    const sourceMapGenerator = new SourceMapGenerator();
+
+    expect(transform(source, "somepath", sourceMapGenerator)).toBeUndefined();
+    expect(sourceMapGenerator.toString()).toMatchInlineSnapshot(
+      `"{"version":3,"sources":["somepath"],"names":[],"mappings":"AAAA"}"`,
+    );
   });
 });

--- a/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
+++ b/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
@@ -1,0 +1,11 @@
+import { transform } from "../transform";
+
+describe("transform", () => {
+  it("should do no work if there are no embedded documents", () => {
+    const source = `
+      import { graphql } from "@nova/react";
+      console.log()
+    `;
+    expect(transform(source, "somepath", undefined)).toBeUndefined();
+  });
+});

--- a/packages/embedded-document-artefact-loader/src/transform.ts
+++ b/packages/embedded-document-artefact-loader/src/transform.ts
@@ -121,6 +121,11 @@ export function transform(
     },
   );
 
+  // Quick bail out if we didn't make any changes. This avoids any unnecessary work towards SourceMaps generation.
+  if (!anyChanges) {
+    return undefined;
+  }
+
   if (sourceMap) {
     addNewLineMappings(
       lastChunkOffset,
@@ -132,7 +137,7 @@ export function transform(
     );
   }
 
-  return anyChanges ? result : undefined;
+  return result;
 }
 
 function offsetToLineColumn(


### PR DESCRIPTION
We bail a little early when "anyChanges" is not set as true. This means we skip the offset scanning work done - this speeds up the loader significantly (1 minute vs <1s over 20k files, for example, inside a sizeable repo).