### PR TITLE
Fix unintentional breaking change in supermassive v3

### DIFF
--- a/change/@graphitation-supermassive-ec5b2b2f-1d23-403c-ada1-291a096723ce.json
+++ b/change/@graphitation-supermassive-ec5b2b2f-1d23-403c-ada1-291a096723ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix unintentional breaking change in supermassive v3",
+  "packageName": "@graphitation/supermassive",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -419,7 +419,7 @@ describe("executeWithoutSchema - minimal viable schema annotation", () => {
 });
 
 describe("executeWithoutSchema - regression tests", () => {
-  test("Supports fieldNodes (gql 16+) in addition to fieldGroup (gql 17+) in ResolveInfo for backwards compatibility", async () => {
+  test("Supports fieldNodes in ResolveInfo for backwards compatibility", async () => {
     let infoAtCallTime: ResolveInfo | undefined;
 
     const resolvers = {
@@ -440,6 +440,5 @@ describe("executeWithoutSchema - regression tests", () => {
     expect(infoAtCallTime?.fieldNodes?.length).toEqual(2);
     expect(infoAtCallTime?.fieldNodes[0].name.value).toEqual("foo");
     expect(infoAtCallTime?.fieldNodes[1].name.value).toEqual("foo");
-    expect(infoAtCallTime?.fieldNodes).toBe(infoAtCallTime?.fieldGroup);
   });
 });

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -7,6 +7,9 @@ import {
 import { makeSchema } from "../benchmarks/swapi-schema";
 import models from "../benchmarks/swapi-schema/models";
 import { createExecutionUtils } from "../__testUtils__/execute";
+import { executeWithoutSchema } from "../executeWithoutSchema";
+import { encodeASTSchema } from "../utilities/encodeASTSchema";
+import { ResolveInfo } from "../types";
 
 const {
   compareResultsForExecuteWithSchema,
@@ -412,5 +415,31 @@ describe("executeWithoutSchema - minimal viable schema annotation", () => {
       document,
       variables,
     );
+  });
+});
+
+describe("executeWithoutSchema - regression tests", () => {
+  test("Supports fieldNodes (gql 16+) in addition to fieldGroup (gql 17+) in ResolveInfo for backwards compatibility", async () => {
+    let infoAtCallTime: ResolveInfo | undefined;
+
+    const resolvers = {
+      Query: {
+        foo(_: unknown, __: unknown, ___: unknown, info: ResolveInfo) {
+          infoAtCallTime = info;
+        },
+      },
+    };
+    const definitions = encodeASTSchema(parse("type Query { foo: String }"))[0];
+    const document = parse(`{ foo, ... { foo } }`);
+
+    await executeWithoutSchema({
+      document,
+      schemaFragment: { schemaId: "test", definitions, resolvers },
+    });
+
+    expect(infoAtCallTime?.fieldNodes?.length).toEqual(2);
+    expect(infoAtCallTime?.fieldNodes[0].name.value).toEqual("foo");
+    expect(infoAtCallTime?.fieldNodes[1].name.value).toEqual("foo");
+    expect(infoAtCallTime?.fieldNodes).toBe(infoAtCallTime?.fieldGroup);
   });
 });

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -764,8 +764,6 @@ export function buildResolveInfo(
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
-
-    // Backwards-compat with graphql 16+ (17+ should use fieldGroup):
     fieldNodes: fieldGroup,
   };
 }

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -756,7 +756,7 @@ export function buildResolveInfo(
   // information about the current execution state.
   return {
     fieldName: fieldName,
-    fieldGroup,
+    fieldNodes: fieldGroup,
     returnTypeName,
     parentTypeName,
     path,
@@ -764,7 +764,6 @@ export function buildResolveInfo(
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
-    fieldNodes: fieldGroup,
   };
 }
 

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -764,6 +764,9 @@ export function buildResolveInfo(
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
+
+    // Backwards-compat with graphql 16+ (17+ should use fieldGroup):
+    fieldNodes: fieldGroup,
   };
 }
 

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -92,7 +92,7 @@ export type UserResolvers<TSource = unknown, TContext = unknown> = Record<
 
 export interface ResolveInfo {
   fieldName: string;
-  fieldGroup: FieldGroup;
+  fieldNodes: FieldGroup;
   returnTypeName: string;
   parentTypeName: string;
   // readonly returnType: GraphQLOutputType;
@@ -103,7 +103,6 @@ export interface ResolveInfo {
   rootValue: unknown;
   operation: OperationDefinitionNode;
   variableValues: { [variable: string]: unknown };
-  fieldNodes: FieldGroup;
 }
 
 export type ExecutionResult<

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -103,8 +103,6 @@ export interface ResolveInfo {
   rootValue: unknown;
   operation: OperationDefinitionNode;
   variableValues: { [variable: string]: unknown };
-
-  // Backwards-compat with graphql 16+ (17+ should use fieldGroup):
   fieldNodes: FieldGroup;
 }
 

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -103,6 +103,9 @@ export interface ResolveInfo {
   rootValue: unknown;
   operation: OperationDefinitionNode;
   variableValues: { [variable: string]: unknown };
+
+  // Backwards-compat with graphql 16+ (17+ should use fieldGroup):
+  fieldNodes: FieldGroup;
 }
 
 export type ExecutionResult<


### PR DESCRIPTION
Supermassive V3 has introduced an unintentional breaking change by renaming `fieldNodes` property of `ResolveInfo` type to `fieldGroup`. 

This PR restores backwards compatibility with Supermassive V2 and graphql 16+