### PR TITLE
Add a scroller to Apollo clients window selection

### DIFF
--- a/change/@graphitation-rempl-apollo-devtools-a88bc040-37bc-4b0a-8e0f-89d3597b0de3.json
+++ b/change/@graphitation-rempl-apollo-devtools-a88bc040-37bc-4b0a-8e0f-89d3597b0de3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update",
+  "packageName": "@graphitation/rempl-apollo-devtools",
+  "email": "jpsahoo14@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/rempl-apollo-devtools/package.json
+++ b/packages/rempl-apollo-devtools/package.json
@@ -31,7 +31,7 @@
     "@types/react-router": "^5.1.18",
     "@types/react": "^17.0.2",
     "@types/uuid": "^8.3.4",
-    "apollo-inspector-ui": "^0.0.5",
+    "apollo-inspector-ui": "^0.0.6",
     "apollo-inspector": "^1.17.3",
     "graphiql": "^2.0.9",
     "graphql": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4227,10 +4227,10 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-inspector-ui@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/apollo-inspector-ui/-/apollo-inspector-ui-0.0.5.tgz#e8d694d1e23e184d4309ce5ad717a11840ab390d"
-  integrity sha512-OQHFzLqpqVYMW9AiS+tdTa+hJMMGkn7+3qkCtJXTNCTDadP4xLVx4i50AJtIg+3+qpyy6a9LMbnL6+6HXd5nUg==
+apollo-inspector-ui@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/apollo-inspector-ui/-/apollo-inspector-ui-0.0.6.tgz#0cf977e0f6b49d8d604ac1c982026feaa8066908"
+  integrity sha512-ARrnnefcsdkgZ8t7yvxvByxGzGtIfBvrrEZZz0SXcRR+JLCd4geu7Ux4pu3YlaeTpAKKnWCmxFgV2mt0iuNV5Q==
   dependencies:
     apollo-inspector "1.17.3"
     graphql "16.8.1"


### PR DESCRIPTION
Add a scroller to Apollo clients window selection.

Issue: When there are lot of apollo clients available, then in a smaller window, some of the apollo clients move out of the view.
In this fix, added a scroller to view all the apollo Clients.