### PR TITLE
Add invariant as a dependency

### DIFF
--- a/change/@graphitation-supermassive-9c63a234-a911-4e96-b195-e164bee73a94.json
+++ b/change/@graphitation-supermassive-9c63a234-a911-4e96-b195-e164bee73a94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add invariant as a dependency",
+  "packageName": "@graphitation/supermassive",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/package.json
+++ b/packages/supermassive/package.json
@@ -23,6 +23,7 @@
     "@ts-morph/bootstrap": "^0.11.0",
     "@types/benchmark": "^2.1.0",
     "@types/jest": "^26.0.22",
+    "@types/invariant": "^2.2.34",
     "@types/node-json-db": "^0.9.3",
     "benchmark": "^2.1.4",
     "graphql-jit": "^0.8.4",
@@ -46,7 +47,9 @@
       }
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "invariant": "^2.2.4"
+  },
   "peerDependencies": {
     "graphql": "^15.0.0 || ^16.0.0 || ^17.0.0"
   }


### PR DESCRIPTION
Invariant is used in a lot of files but isn't declared as a dependency, this causes issues in stricter package managers.