### PR TITLE
Update graphql-codegen-supermassive-schema-extraction-plugin for usage with supermassive v3

### DIFF
--- a/change/@graphitation-graphql-codegen-supermassive-schema-extraction-plugin-fd47181f-d477-41ec-a1b7-1ef472945482.json
+++ b/change/@graphitation-graphql-codegen-supermassive-schema-extraction-plugin-fd47181f-d477-41ec-a1b7-1ef472945482.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Update graphql-codegen-supermassive-schema-extraction-plugin for usage with supermassive v3",
+  "packageName": "@graphitation/graphql-codegen-supermassive-schema-extraction-plugin",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-codegen-supermassive-schema-extraction-plugin/README.md
+++ b/packages/graphql-codegen-supermassive-schema-extraction-plugin/README.md
@@ -1,5 +1,7 @@
 # Custom GraphQL codegen plugins
 
-## supermassive-typed-document-node
+## graphql-codegen-supermassive-schema-extraction-plugin
 
-Do the same stuff as the original typed-document-node plugin except it extends GraphQL AST data to match Supermassive AST
+Encodes type definitions into compact schema format of Supermassive V3.
+
+Output file contains JSON, which is faster than JS literal: https://v8.dev/blog/cost-of-javascript-2019#json

--- a/packages/graphql-codegen-supermassive-schema-extraction-plugin/package.json
+++ b/packages/graphql-codegen-supermassive-schema-extraction-plugin/package.json
@@ -17,15 +17,13 @@
   "devDependencies": {
     "@graphql-codegen/plugin-helpers": "^1.18.2",
     "@types/jest": "^26.0.22",
-    "monorepo-scripts": "*",
-    "typescript": "^4.9.5"
+    "monorepo-scripts": "*"
   },
   "peerDependencies": {
-    "@graphql-codegen/plugin-helpers": ">= 1.18.0 < 2",
-    "typescript": "^4.3.0"
+    "@graphql-codegen/plugin-helpers": ">= 1.18.0 < 2"
   },
   "dependencies": {
-    "@graphitation/supermassive-extractors": "^2.2.1",
+    "@graphitation/supermassive": "^3.0.0",
     "graphql": "^15.0.0"
   },
   "sideEffects": false,

--- a/packages/graphql-codegen-supermassive-schema-extraction-plugin/src/index.ts
+++ b/packages/graphql-codegen-supermassive-schema-extraction-plugin/src/index.ts
@@ -23,7 +23,8 @@ export const plugin: PluginFunction<PluginConfig> = (schema: GraphQLSchema) => {
     encodeASTSchema(schemaAST),
   );
 
-  return `export default JSON.parse('${JSON.stringify(typeDefs)}')`;
+  return `export const definitions = JSON.parse('${JSON.stringify(typeDefs)}');
+`;
 };
 
 export const validate: PluginValidateFn<PluginConfig> = async (


### PR DESCRIPTION
Update our graphql codegen plugin, and make it encode type definitions into compact schema format of Supermassive V3.