### PR TITLE
Fix inconsistency with graphql-js on errors in root-level resolvers

### DIFF
--- a/change/@graphitation-supermassive-8c7afc91-6856-41c9-9dcc-b081f4def405.json
+++ b/change/@graphitation-supermassive-8c7afc91-6856-41c9-9dcc-b081f4def405.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Moved to newer stream/defer implementation",
+  "packageName": "@graphitation/supermassive",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/IncrementalPublisher.ts
+++ b/packages/supermassive/src/IncrementalPublisher.ts
@@ -8,7 +8,6 @@ import { promiseWithResolvers } from "./jsutils/promiseWithResolvers";
 import type { GroupedFieldSet } from "./buildFieldPlan";
 import {
   CompletedResult,
-  ExecutionResult,
   IncrementalDeferResult,
   IncrementalResult,
   IncrementalStreamResult,

--- a/packages/supermassive/src/IncrementalPublisher.ts
+++ b/packages/supermassive/src/IncrementalPublisher.ts
@@ -1,0 +1,709 @@
+import type { GraphQLError } from "graphql";
+
+import type { ObjMap } from "./jsutils/ObjMap";
+import type { Path } from "./jsutils/Path";
+import { pathToArray } from "./jsutils/Path";
+import { promiseWithResolvers } from "./jsutils/promiseWithResolvers";
+
+import type { GroupedFieldSet } from "./buildFieldPlan";
+import {
+  CompletedResult,
+  ExecutionResult,
+  IncrementalDeferResult,
+  IncrementalResult,
+  IncrementalStreamResult,
+  IncrementalUpdate,
+  PendingResult,
+  SubsequentIncrementalExecutionResult,
+  TotalExecutionResult,
+  IncrementalExecutionResults,
+} from "./types";
+
+/**
+ * This class is used to publish incremental results to the client, enabling semi-concurrent
+ * execution while preserving result order.
+ *
+ * The internal publishing state is managed as follows:
+ *
+ * '_released': the set of Subsequent Result records that are ready to be sent to the client,
+ * i.e. their parents have completed and they have also completed.
+ *
+ * `_pending`: the set of Subsequent Result records that are definitely pending, i.e. their
+ * parents have completed so that they can no longer be filtered. This includes all Subsequent
+ * Result records in `released`, as well as the records that have not yet completed.
+ *
+ * @internal
+ */
+export class IncrementalPublisher {
+  private _nextId = 0;
+  private _released: Set<SubsequentResultRecord>;
+  private _pending: Set<SubsequentResultRecord>;
+
+  // these are assigned within the Promise executor called synchronously within the constructor
+  private _signalled!: Promise<unknown>;
+  private _resolve!: () => void;
+
+  constructor() {
+    this._released = new Set();
+    this._pending = new Set();
+    this._reset();
+  }
+
+  reportNewDeferFragmentRecord(
+    deferredFragmentRecord: DeferredFragmentRecord,
+    parentIncrementalResultRecord:
+      | InitialResultRecord
+      | DeferredFragmentRecord
+      | StreamItemsRecord,
+  ): void {
+    parentIncrementalResultRecord.children.add(deferredFragmentRecord);
+  }
+
+  reportNewDeferredGroupedFieldSetRecord(
+    deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
+  ): void {
+    for (const deferredFragmentRecord of deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+      deferredFragmentRecord._pending.add(deferredGroupedFieldSetRecord);
+      deferredFragmentRecord.deferredGroupedFieldSetRecords.add(
+        deferredGroupedFieldSetRecord,
+      );
+    }
+  }
+
+  reportNewStreamItemsRecord(
+    streamItemsRecord: StreamItemsRecord,
+    parentIncrementalDataRecord: IncrementalDataRecord,
+  ): void {
+    if (isDeferredGroupedFieldSetRecord(parentIncrementalDataRecord)) {
+      for (const parent of parentIncrementalDataRecord.deferredFragmentRecords) {
+        parent.children.add(streamItemsRecord);
+      }
+    } else {
+      parentIncrementalDataRecord.children.add(streamItemsRecord);
+    }
+  }
+
+  completeDeferredGroupedFieldSet(
+    deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
+    data: ObjMap<unknown>,
+  ): void {
+    deferredGroupedFieldSetRecord.data = data;
+    for (const deferredFragmentRecord of deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+      deferredFragmentRecord._pending.delete(deferredGroupedFieldSetRecord);
+      if (deferredFragmentRecord._pending.size === 0) {
+        this.completeDeferredFragmentRecord(deferredFragmentRecord);
+      }
+    }
+  }
+
+  markErroredDeferredGroupedFieldSet(
+    deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
+    error: GraphQLError,
+  ): void {
+    for (const deferredFragmentRecord of deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+      deferredFragmentRecord.errors.push(error);
+      this.completeDeferredFragmentRecord(deferredFragmentRecord);
+    }
+  }
+
+  completeDeferredFragmentRecord(
+    deferredFragmentRecord: DeferredFragmentRecord,
+  ): void {
+    this._release(deferredFragmentRecord);
+  }
+
+  completeStreamItemsRecord(
+    streamItemsRecord: StreamItemsRecord,
+    items: Array<unknown>,
+  ) {
+    streamItemsRecord.items = items;
+    streamItemsRecord.isCompleted = true;
+    this._release(streamItemsRecord);
+  }
+
+  markErroredStreamItemsRecord(
+    streamItemsRecord: StreamItemsRecord,
+    error: GraphQLError,
+  ) {
+    streamItemsRecord.streamRecord.errors.push(error);
+    this.setIsFinalRecord(streamItemsRecord);
+    streamItemsRecord.isCompleted = true;
+    streamItemsRecord.streamRecord.earlyReturn?.().catch(() => {
+      // ignore error
+    });
+    this._release(streamItemsRecord);
+  }
+
+  setIsFinalRecord(streamItemsRecord: StreamItemsRecord) {
+    streamItemsRecord.isFinalRecord = true;
+  }
+
+  setIsCompletedAsyncIterator(streamItemsRecord: StreamItemsRecord) {
+    streamItemsRecord.isCompletedAsyncIterator = true;
+    this.setIsFinalRecord(streamItemsRecord);
+  }
+
+  addFieldError(
+    incrementalDataRecord: IncrementalDataRecord,
+    error: GraphQLError,
+  ) {
+    incrementalDataRecord.errors.push(error);
+  }
+
+  buildDataResponse(
+    initialResultRecord: InitialResultRecord,
+    data: ObjMap<unknown> | null,
+  ): TotalExecutionResult | IncrementalExecutionResults {
+    for (const child of initialResultRecord.children) {
+      if (child.filtered) {
+        continue;
+      }
+      this._publish(child);
+    }
+
+    const errors = initialResultRecord.errors;
+    const initialResult = errors.length === 0 ? { data } : { errors, data };
+    const pending = this._pending;
+    if (pending.size > 0) {
+      const pendingSources = new Set<DeferredFragmentRecord | StreamRecord>();
+      for (const subsequentResultRecord of pending) {
+        const pendingSource = isStreamItemsRecord(subsequentResultRecord)
+          ? subsequentResultRecord.streamRecord
+          : subsequentResultRecord;
+        pendingSources.add(pendingSource);
+      }
+
+      return {
+        initialResult: {
+          ...initialResult,
+          pending: this._pendingSourcesToResults(pendingSources),
+          hasNext: true,
+        },
+        subsequentResults: this._subscribe(),
+      };
+    }
+    return initialResult;
+  }
+
+  buildErrorResponse(
+    initialResultRecord: InitialResultRecord,
+    error: GraphQLError,
+  ): TotalExecutionResult {
+    const errors = initialResultRecord.errors;
+    errors.push(error);
+    return { data: null, errors };
+  }
+
+  filter(
+    nullPath: Path | undefined,
+    erroringIncrementalDataRecord: IncrementalDataRecord,
+  ): void {
+    const nullPathArray = pathToArray(nullPath);
+
+    const streams = new Set<StreamRecord>();
+
+    const children = this._getChildren(erroringIncrementalDataRecord);
+    const descendants = this._getDescendants(children);
+
+    for (const child of descendants) {
+      if (!this._nullsChildSubsequentResultRecord(child, nullPathArray)) {
+        continue;
+      }
+
+      child.filtered = true;
+
+      if (isStreamItemsRecord(child)) {
+        streams.add(child.streamRecord);
+      }
+    }
+
+    streams.forEach((stream) => {
+      stream.earlyReturn?.().catch(() => {
+        // ignore error
+      });
+    });
+  }
+
+  private _pendingSourcesToResults(
+    pendingSources: ReadonlySet<DeferredFragmentRecord | StreamRecord>,
+  ): Array<PendingResult> {
+    const pendingResults: Array<PendingResult> = [];
+    for (const pendingSource of pendingSources) {
+      pendingSource.pendingSent = true;
+      const id = this._getNextId();
+      pendingSource.id = id;
+      const pendingResult: PendingResult = {
+        id,
+        path: pendingSource.path,
+      };
+      if (pendingSource.label !== undefined) {
+        pendingResult.label = pendingSource.label;
+      }
+      pendingResults.push(pendingResult);
+    }
+    return pendingResults;
+  }
+
+  private _getNextId(): string {
+    return String(this._nextId++);
+  }
+
+  private _subscribe(): AsyncGenerator<
+    SubsequentIncrementalExecutionResult,
+    void,
+    void
+  > {
+    let isDone = false;
+
+    const _next = async (): Promise<
+      IteratorResult<SubsequentIncrementalExecutionResult, void>
+    > => {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (isDone) {
+          return { value: undefined, done: true };
+        }
+
+        for (const item of this._released) {
+          this._pending.delete(item);
+        }
+        const released = this._released;
+        this._released = new Set();
+
+        const result = this._getIncrementalResult(released);
+
+        if (this._pending.size === 0) {
+          isDone = true;
+        }
+
+        if (result !== undefined) {
+          return { value: result, done: false };
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await this._signalled;
+      }
+    };
+
+    const returnStreamIterators = async (): Promise<void> => {
+      const streams = new Set<StreamRecord>();
+      const descendants = this._getDescendants(this._pending);
+      for (const subsequentResultRecord of descendants) {
+        if (isStreamItemsRecord(subsequentResultRecord)) {
+          streams.add(subsequentResultRecord.streamRecord);
+        }
+      }
+      const promises: Array<Promise<unknown>> = [];
+      streams.forEach((streamRecord) => {
+        if (streamRecord.earlyReturn) {
+          promises.push(streamRecord.earlyReturn());
+        }
+      });
+      await Promise.all(promises);
+    };
+
+    const _return = async (): Promise<
+      IteratorResult<SubsequentIncrementalExecutionResult, void>
+    > => {
+      isDone = true;
+      await returnStreamIterators();
+      return { value: undefined, done: true };
+    };
+
+    const _throw = async (
+      error?: unknown,
+    ): Promise<IteratorResult<SubsequentIncrementalExecutionResult, void>> => {
+      isDone = true;
+      await returnStreamIterators();
+      return Promise.reject(error);
+    };
+
+    return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: _next,
+      return: _return,
+      throw: _throw,
+    };
+  }
+
+  private _trigger() {
+    this._resolve();
+    this._reset();
+  }
+
+  private _reset() {
+    // promiseWithResolvers uses void only as a generic type parameter
+    // see: https://typescript-eslint.io/rules/no-invalid-void-type/
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    const { promise: signalled, resolve } = promiseWithResolvers<void>();
+    this._resolve = resolve;
+    this._signalled = signalled;
+  }
+
+  private _introduce(item: SubsequentResultRecord) {
+    this._pending.add(item);
+  }
+
+  private _release(item: SubsequentResultRecord): void {
+    if (this._pending.has(item)) {
+      this._released.add(item);
+      this._trigger();
+    }
+  }
+
+  private _push(item: SubsequentResultRecord): void {
+    this._released.add(item);
+    this._pending.add(item);
+    this._trigger();
+  }
+
+  private _getIncrementalResult(
+    completedRecords: ReadonlySet<SubsequentResultRecord>,
+  ): SubsequentIncrementalExecutionResult | undefined {
+    const { pending, incremental, completed } =
+      this._processPending(completedRecords);
+
+    const hasNext = this._pending.size > 0;
+    if (incremental.length === 0 && completed.length === 0 && hasNext) {
+      return undefined;
+    }
+
+    const result: SubsequentIncrementalExecutionResult = { hasNext };
+    if (pending.length) {
+      result.pending = pending;
+    }
+    if (incremental.length) {
+      result.incremental = incremental;
+    }
+    if (completed.length) {
+      result.completed = completed;
+    }
+
+    return result;
+  }
+
+  private _processPending(
+    completedRecords: ReadonlySet<SubsequentResultRecord>,
+  ): IncrementalUpdate {
+    const newPendingSources = new Set<DeferredFragmentRecord | StreamRecord>();
+    const incrementalResults: Array<IncrementalResult> = [];
+    const completedResults: Array<CompletedResult> = [];
+    for (const subsequentResultRecord of completedRecords) {
+      for (const child of subsequentResultRecord.children) {
+        if (child.filtered) {
+          continue;
+        }
+        const pendingSource = isStreamItemsRecord(child)
+          ? child.streamRecord
+          : child;
+        if (!pendingSource.pendingSent) {
+          newPendingSources.add(pendingSource);
+        }
+        this._publish(child);
+      }
+      if (isStreamItemsRecord(subsequentResultRecord)) {
+        if (subsequentResultRecord.isFinalRecord) {
+          newPendingSources.delete(subsequentResultRecord.streamRecord);
+          completedResults.push(
+            this._completedRecordToResult(subsequentResultRecord.streamRecord),
+          );
+        }
+        if (subsequentResultRecord.isCompletedAsyncIterator) {
+          // async iterable resolver just finished but there may be pending payloads
+          continue;
+        }
+        if (subsequentResultRecord.streamRecord.errors.length > 0) {
+          continue;
+        }
+        const incrementalResult: IncrementalStreamResult = {
+          // safe because `items` is always defined when the record is completed
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          items: subsequentResultRecord.items!,
+          // safe because `id` is defined once the stream has been released as pending
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          id: subsequentResultRecord.streamRecord.id!,
+        };
+        if (subsequentResultRecord.errors.length > 0) {
+          incrementalResult.errors = subsequentResultRecord.errors;
+        }
+        incrementalResults.push(incrementalResult);
+      } else {
+        newPendingSources.delete(subsequentResultRecord);
+        completedResults.push(
+          this._completedRecordToResult(subsequentResultRecord),
+        );
+        if (subsequentResultRecord.errors.length > 0) {
+          continue;
+        }
+        for (const deferredGroupedFieldSetRecord of subsequentResultRecord.deferredGroupedFieldSetRecords) {
+          if (!deferredGroupedFieldSetRecord.sent) {
+            deferredGroupedFieldSetRecord.sent = true;
+            const incrementalResult: IncrementalDeferResult =
+              this._getIncrementalDeferResult(deferredGroupedFieldSetRecord);
+            if (deferredGroupedFieldSetRecord.errors.length > 0) {
+              incrementalResult.errors = deferredGroupedFieldSetRecord.errors;
+            }
+            incrementalResults.push(incrementalResult);
+          }
+        }
+      }
+    }
+
+    return {
+      pending: this._pendingSourcesToResults(newPendingSources),
+      incremental: incrementalResults,
+      completed: completedResults,
+    };
+  }
+
+  private _getIncrementalDeferResult(
+    deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
+  ): IncrementalDeferResult {
+    const { data, deferredFragmentRecords } = deferredGroupedFieldSetRecord;
+    let maxLength: number | undefined;
+    let idWithLongestPath: string | undefined;
+    for (const deferredFragmentRecord of deferredFragmentRecords) {
+      const id = deferredFragmentRecord.id;
+      if (id === undefined) {
+        continue;
+      }
+      const length = deferredFragmentRecord.path.length;
+      if (maxLength === undefined || length > maxLength) {
+        maxLength = length;
+        idWithLongestPath = id;
+      }
+    }
+    const subPath = deferredGroupedFieldSetRecord.path.slice(maxLength);
+    const incrementalDeferResult: IncrementalDeferResult = {
+      // safe because `data``is always defined when the record is completed
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      data: data!,
+      // safe because `id` is always defined once the fragment has been released
+      // as pending and at least one fragment has been completed, so must have been
+      // released as pending
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      id: idWithLongestPath!,
+    };
+
+    if (subPath.length > 0) {
+      incrementalDeferResult.subPath = subPath;
+    }
+
+    return incrementalDeferResult;
+  }
+
+  private _completedRecordToResult(
+    completedRecord: DeferredFragmentRecord | StreamRecord,
+  ): CompletedResult {
+    const result: CompletedResult = {
+      // safe because `id` is defined once the stream has been released as pending
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      id: completedRecord.id!,
+    };
+    if (completedRecord.errors.length > 0) {
+      result.errors = completedRecord.errors;
+    }
+    return result;
+  }
+
+  private _publish(subsequentResultRecord: SubsequentResultRecord): void {
+    if (isStreamItemsRecord(subsequentResultRecord)) {
+      if (subsequentResultRecord.isCompleted) {
+        this._push(subsequentResultRecord);
+        return;
+      }
+
+      this._introduce(subsequentResultRecord);
+      return;
+    }
+
+    if (subsequentResultRecord._pending.size > 0) {
+      this._introduce(subsequentResultRecord);
+    } else if (
+      subsequentResultRecord.deferredGroupedFieldSetRecords.size > 0 ||
+      subsequentResultRecord.children.size > 0
+    ) {
+      this._push(subsequentResultRecord);
+    }
+  }
+
+  private _getChildren(
+    erroringIncrementalDataRecord: IncrementalDataRecord,
+  ): ReadonlySet<SubsequentResultRecord> {
+    const children = new Set<SubsequentResultRecord>();
+    if (isDeferredGroupedFieldSetRecord(erroringIncrementalDataRecord)) {
+      for (const erroringIncrementalResultRecord of erroringIncrementalDataRecord.deferredFragmentRecords) {
+        for (const child of erroringIncrementalResultRecord.children) {
+          children.add(child);
+        }
+      }
+    } else {
+      for (const child of erroringIncrementalDataRecord.children) {
+        children.add(child);
+      }
+    }
+    return children;
+  }
+
+  private _getDescendants(
+    children: ReadonlySet<SubsequentResultRecord>,
+    descendants = new Set<SubsequentResultRecord>(),
+  ): ReadonlySet<SubsequentResultRecord> {
+    for (const child of children) {
+      descendants.add(child);
+      this._getDescendants(child.children, descendants);
+    }
+    return descendants;
+  }
+
+  private _nullsChildSubsequentResultRecord(
+    subsequentResultRecord: SubsequentResultRecord,
+    nullPath: ReadonlyArray<string | number>,
+  ): boolean {
+    const incrementalDataRecords = isStreamItemsRecord(subsequentResultRecord)
+      ? [subsequentResultRecord]
+      : subsequentResultRecord.deferredGroupedFieldSetRecords;
+
+    for (const incrementalDataRecord of incrementalDataRecords) {
+      if (this._matchesPath(incrementalDataRecord.path, nullPath)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _matchesPath(
+    testPath: ReadonlyArray<string | number>,
+    basePath: ReadonlyArray<string | number>,
+  ): boolean {
+    for (let i = 0; i < basePath.length; i++) {
+      if (basePath[i] !== testPath[i]) {
+        // testPath points to a path unaffected at basePath
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+function isDeferredGroupedFieldSetRecord(
+  incrementalDataRecord: unknown,
+): incrementalDataRecord is DeferredGroupedFieldSetRecord {
+  return incrementalDataRecord instanceof DeferredGroupedFieldSetRecord;
+}
+
+function isStreamItemsRecord(
+  subsequentResultRecord: unknown,
+): subsequentResultRecord is StreamItemsRecord {
+  return subsequentResultRecord instanceof StreamItemsRecord;
+}
+
+/** @internal */
+export class InitialResultRecord {
+  errors: Array<GraphQLError>;
+  children: Set<SubsequentResultRecord>;
+  constructor() {
+    this.errors = [];
+    this.children = new Set();
+  }
+}
+
+/** @internal */
+export class DeferredGroupedFieldSetRecord {
+  path: ReadonlyArray<string | number>;
+  deferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord>;
+  groupedFieldSet: GroupedFieldSet;
+  shouldInitiateDefer: boolean;
+  errors: Array<GraphQLError>;
+  data: ObjMap<unknown> | undefined;
+  sent: boolean;
+
+  constructor(opts: {
+    path: Path | undefined;
+    deferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord>;
+    groupedFieldSet: GroupedFieldSet;
+    shouldInitiateDefer: boolean;
+  }) {
+    this.path = pathToArray(opts.path);
+    this.deferredFragmentRecords = opts.deferredFragmentRecords;
+    this.groupedFieldSet = opts.groupedFieldSet;
+    this.shouldInitiateDefer = opts.shouldInitiateDefer;
+    this.errors = [];
+    this.sent = false;
+  }
+}
+
+/** @internal */
+export class DeferredFragmentRecord {
+  path: ReadonlyArray<string | number>;
+  label: string | undefined;
+  id: string | undefined;
+  children: Set<SubsequentResultRecord>;
+  deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
+  errors: Array<GraphQLError>;
+  filtered: boolean;
+  pendingSent?: boolean;
+  _pending: Set<DeferredGroupedFieldSetRecord>;
+
+  constructor(opts: { path: Path | undefined; label: string | undefined }) {
+    this.path = pathToArray(opts.path);
+    this.label = opts.label;
+    this.children = new Set();
+    this.filtered = false;
+    this.deferredGroupedFieldSetRecords = new Set();
+    this.errors = [];
+    this._pending = new Set();
+  }
+}
+
+/** @internal */
+export class StreamRecord {
+  label: string | undefined;
+  path: ReadonlyArray<string | number>;
+  id: string | undefined;
+  errors: Array<GraphQLError>;
+  earlyReturn?: (() => Promise<unknown>) | undefined;
+  pendingSent?: boolean;
+  constructor(opts: {
+    label: string | undefined;
+    path: Path;
+    earlyReturn?: (() => Promise<unknown>) | undefined;
+  }) {
+    this.label = opts.label;
+    this.path = pathToArray(opts.path);
+    this.errors = [];
+    this.earlyReturn = opts.earlyReturn;
+  }
+}
+
+/** @internal */
+export class StreamItemsRecord {
+  errors: Array<GraphQLError>;
+  streamRecord: StreamRecord;
+  path: ReadonlyArray<string | number>;
+  items: Array<unknown> | undefined;
+  children: Set<SubsequentResultRecord>;
+  isFinalRecord?: boolean;
+  isCompletedAsyncIterator?: boolean;
+  isCompleted: boolean;
+  filtered: boolean;
+
+  constructor(opts: { streamRecord: StreamRecord; path: Path | undefined }) {
+    this.streamRecord = opts.streamRecord;
+    this.path = pathToArray(opts.path);
+    this.children = new Set();
+    this.errors = [];
+    this.isCompleted = false;
+    this.filtered = false;
+  }
+}
+
+export type IncrementalDataRecord =
+  | InitialResultRecord
+  | DeferredGroupedFieldSetRecord
+  | StreamItemsRecord;
+
+type SubsequentResultRecord = DeferredFragmentRecord | StreamItemsRecord;

--- a/packages/supermassive/src/__tests__/__snapshots__/execute.test.ts.snap
+++ b/packages/supermassive/src/__tests__/__snapshots__/execute.test.ts.snap
@@ -245,6 +245,54 @@ exports[`graphql-js snapshot check to ensure test stability interface in union f
 }
 `;
 
+exports[`graphql-js snapshot check to ensure test stability non-null query return null 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Cannot return null for non-nullable field Query.nonNullWithNull.],
+  ],
+}
+`;
+
+exports[`graphql-js snapshot check to ensure test stability non-null query throw an error 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query error],
+  ],
+}
+`;
+
+exports[`graphql-js snapshot check to ensure test stability non-null subscription return null 1`] = `
+[
+  {
+    "data": null,
+    "errors": [
+      [GraphQLError: Cannot return null for non-nullable field Subscription.nonNullWithNull.],
+    ],
+  },
+]
+`;
+
+exports[`graphql-js snapshot check to ensure test stability non-null subscription throw in resolve 1`] = `
+[
+  {
+    "data": null,
+    "errors": [
+      [GraphQLError: Subscription event error],
+    ],
+  },
+]
+`;
+
+exports[`graphql-js snapshot check to ensure test stability non-null subscription throw in subscribe 1`] = `
+{
+  "errors": [
+    [GraphQLError: Subscribe error],
+  ],
+}
+`;
+
 exports[`graphql-js snapshot check to ensure test stability query with interfaces 1`] = `
 {
   "data": {

--- a/packages/supermassive/src/__tests__/__snapshots__/execute.test.ts.snap
+++ b/packages/supermassive/src/__tests__/__snapshots__/execute.test.ts.snap
@@ -364,14 +364,6 @@ exports[`graphql-js snapshot check to ensure test stability skip directive TRUE 
 }
 `;
 
-exports[`graphql-js snapshot check to ensure test stability subscription throw an error 1`] = `
-{
-  "errors": [
-    [GraphQLError: error],
-  ],
-}
-`;
-
 exports[`graphql-js snapshot check to ensure test stability union in interface fragment spread 1`] = `
 {
   "data": {

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -350,21 +350,22 @@ query Person($id: Int!) {
       limit: 5,
     },
   },
-  {
-    name: "subscription throw an error",
-    document: `
-  subscription emitPersons($limit: Int!, $throwError: Boolean) {
-    emitPersons(limit: $limit, throwError: $throwError) {
-      name
-      gender
-    }
-  }
- `,
-    variables: {
-      limit: 5,
-      throwError: true,
-    },
-  },
+  // TODO: results in data: null in current implementation, alongside error
+  //   {
+  //     name: "subscription throw an error",
+  //     document: `
+  //   subscription emitPersons($limit: Int!, $throwError: Boolean) {
+  //     emitPersons(limit: $limit, throwError: $throwError) {
+  //       name
+  //       gender
+  //     }
+  //   }
+  //  `,
+  //     variables: {
+  //       limit: 5,
+  //       throwError: true,
+  //     },
+  //   },
   {
     name: "non-null query return null",
     document: `query { nonNullWithNull }`,

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -365,6 +365,26 @@ query Person($id: Int!) {
       throwError: true,
     },
   },
+  {
+    name: "non-null query return null",
+    document: `query { nonNullWithNull }`,
+  },
+  {
+    name: "non-null subscription return null",
+    document: `subscription { nonNullWithNull }`,
+  },
+  {
+    name: "non-null query throw an error",
+    document: `query { nonNullWithError }`,
+  },
+  {
+    name: "non-null subscription throw in subscribe",
+    document: `subscription { nonNullWithError }`,
+  },
+  {
+    name: "non-null subscription throw in resolve",
+    document: `subscription { nonNullWithErrorEvent }`,
+  },
 ];
 
 describe("graphql-js snapshot check to ensure test stability", () => {

--- a/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
+++ b/packages/supermassive/src/benchmarks/swapi-schema/resolvers.ts
@@ -251,6 +251,25 @@ const resolvers: IExecutableSchemaDefinition["resolvers"] = {
     emitPersons: {
       subscribe: emitPersons,
     },
+    nonNullWithError: {
+      subscribe() {
+        throw new Error("Subscribe error");
+      },
+    },
+    nonNullWithErrorEvent: {
+      subscribe() {
+        return createAsyncIterator(["foo"]);
+      },
+      resolve() {
+        throw new Error("Subscription event error");
+      },
+    },
+    nonNullWithNull: {
+      subscribe() {
+        return createAsyncIterator(["foo"]);
+      },
+      resolve() {},
+    },
   },
   Query: {
     search(parent, { search }, { models }, info) {
@@ -359,6 +378,10 @@ const resolvers: IExecutableSchemaDefinition["resolvers"] = {
     multiArger(_parent, args) {
       return JSON.stringify(args);
     },
+    nonNullWithError() {
+      throw new Error("Query error");
+    },
+    nonNullWithNull() {},
   },
   Film: {
     starships,

--- a/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
+++ b/packages/supermassive/src/benchmarks/swapi-schema/schema.graphql
@@ -30,6 +30,9 @@ enum NodeType {
 
 type Subscription {
   emitPersons(limit: Int!, throwError: Boolean): Person
+  nonNullWithError: String!
+  nonNullWithErrorEvent: String!
+  nonNullWithNull: String!
 }
 
 type Query {
@@ -62,6 +65,8 @@ type Query {
     input: AdvancedInput! = { enumField: Transport, otherField: "Foo" }
   ): String
   multiArger(a: Int, b: String, c: AdvancedInput): String
+  nonNullWithError: String!
+  nonNullWithNull: String!
 }
 
 interface Node {

--- a/packages/supermassive/src/buildFieldPlan.ts
+++ b/packages/supermassive/src/buildFieldPlan.ts
@@ -1,0 +1,165 @@
+import { getBySet } from "./jsutils/getBySet";
+import { isSameSet } from "./jsutils/isSameSet";
+
+import type { DeferUsage, FieldDetails } from "./collectFields.js";
+
+export type DeferUsageSet = ReadonlySet<DeferUsage>;
+
+export interface FieldGroup {
+  fields: ReadonlyArray<FieldDetails>;
+  deferUsages?: DeferUsageSet | undefined;
+  knownDeferUsages?: DeferUsageSet | undefined;
+}
+
+export type GroupedFieldSet = Map<string, FieldGroup>;
+
+export interface NewGroupedFieldSetDetails {
+  groupedFieldSet: GroupedFieldSet;
+  shouldInitiateDefer: boolean;
+}
+
+export function buildFieldPlan(
+  fields: Map<string, ReadonlyArray<FieldDetails>>,
+  parentDeferUsages: DeferUsageSet = new Set<DeferUsage>(),
+  knownDeferUsages: DeferUsageSet = new Set<DeferUsage>(),
+): {
+  groupedFieldSet: GroupedFieldSet;
+  newGroupedFieldSetDetailsMap: Map<DeferUsageSet, NewGroupedFieldSetDetails>;
+  newDeferUsages: ReadonlyArray<DeferUsage>;
+} {
+  const newDeferUsages: Set<DeferUsage> = new Set<DeferUsage>();
+  const newKnownDeferUsages = new Set<DeferUsage>(knownDeferUsages);
+
+  const groupedFieldSet = new Map<
+    string,
+    {
+      fields: Array<FieldDetails>;
+      deferUsages: DeferUsageSet;
+      knownDeferUsages: DeferUsageSet;
+    }
+  >();
+
+  const newGroupedFieldSetDetailsMap = new Map<
+    DeferUsageSet,
+    {
+      groupedFieldSet: Map<
+        string,
+        {
+          fields: Array<FieldDetails>;
+          deferUsages: DeferUsageSet;
+          knownDeferUsages: DeferUsageSet;
+        }
+      >;
+      shouldInitiateDefer: boolean;
+    }
+  >();
+
+  const map = new Map<
+    string,
+    {
+      deferUsageSet: DeferUsageSet;
+      fieldDetailsList: ReadonlyArray<FieldDetails>;
+    }
+  >();
+
+  for (const [responseKey, fieldDetailsList] of fields) {
+    const deferUsageSet = new Set<DeferUsage>();
+    let inOriginalResult = false;
+    for (const fieldDetails of fieldDetailsList) {
+      const deferUsage = fieldDetails.deferUsage;
+      if (deferUsage === undefined) {
+        inOriginalResult = true;
+        continue;
+      }
+      deferUsageSet.add(deferUsage);
+      if (!knownDeferUsages.has(deferUsage)) {
+        newDeferUsages.add(deferUsage);
+        newKnownDeferUsages.add(deferUsage);
+      }
+    }
+    if (inOriginalResult) {
+      deferUsageSet.clear();
+    } else {
+      deferUsageSet.forEach((deferUsage) => {
+        const ancestors = getAncestors(deferUsage);
+        for (const ancestor of ancestors) {
+          if (deferUsageSet.has(ancestor)) {
+            deferUsageSet.delete(deferUsage);
+          }
+        }
+      });
+    }
+    map.set(responseKey, { deferUsageSet, fieldDetailsList });
+  }
+
+  for (const [responseKey, { deferUsageSet, fieldDetailsList }] of map) {
+    if (isSameSet(deferUsageSet, parentDeferUsages)) {
+      let fieldGroup = groupedFieldSet.get(responseKey);
+      if (fieldGroup === undefined) {
+        fieldGroup = {
+          fields: [],
+          deferUsages: deferUsageSet,
+          knownDeferUsages: newKnownDeferUsages,
+        };
+        groupedFieldSet.set(responseKey, fieldGroup);
+      }
+      fieldGroup.fields.push(...fieldDetailsList);
+      continue;
+    }
+
+    let newGroupedFieldSetDetails = getBySet(
+      newGroupedFieldSetDetailsMap,
+      deferUsageSet,
+    );
+    let newGroupedFieldSet;
+    if (newGroupedFieldSetDetails === undefined) {
+      newGroupedFieldSet = new Map<
+        string,
+        {
+          fields: Array<FieldDetails>;
+          deferUsages: DeferUsageSet;
+          knownDeferUsages: DeferUsageSet;
+        }
+      >();
+
+      newGroupedFieldSetDetails = {
+        groupedFieldSet: newGroupedFieldSet,
+        shouldInitiateDefer: Array.from(deferUsageSet).some(
+          (deferUsage) => !parentDeferUsages.has(deferUsage),
+        ),
+      };
+      newGroupedFieldSetDetailsMap.set(
+        deferUsageSet,
+        newGroupedFieldSetDetails,
+      );
+    } else {
+      newGroupedFieldSet = newGroupedFieldSetDetails.groupedFieldSet;
+    }
+    let fieldGroup = newGroupedFieldSet.get(responseKey);
+    if (fieldGroup === undefined) {
+      fieldGroup = {
+        fields: [],
+        deferUsages: deferUsageSet,
+        knownDeferUsages: newKnownDeferUsages,
+      };
+      newGroupedFieldSet.set(responseKey, fieldGroup);
+    }
+    fieldGroup.fields.push(...fieldDetailsList);
+  }
+
+  return {
+    groupedFieldSet,
+    newGroupedFieldSetDetailsMap,
+    newDeferUsages: Array.from(newDeferUsages),
+  };
+}
+
+function getAncestors(deferUsage: DeferUsage): ReadonlyArray<DeferUsage> {
+  const ancestors: Array<DeferUsage> = [];
+  let parentDeferUsage: DeferUsage | undefined = deferUsage.parentDeferUsage;
+  while (parentDeferUsage !== undefined) {
+    ancestors.unshift(parentDeferUsage);
+    parentDeferUsage = parentDeferUsage.parentDeferUsage;
+  }
+  return ancestors;
+}

--- a/packages/supermassive/src/index.ts
+++ b/packages/supermassive/src/index.ts
@@ -69,7 +69,7 @@ export type {
   EnumTypeResolver,
   ExecutionResult,
   FunctionFieldResolver,
-  IncrementalExecutionResult,
+  IncrementalExecutionResults,
   ObjectTypeResolver,
   ResolveInfo,
   Resolvers,

--- a/packages/supermassive/src/jsutils/getBySet.ts
+++ b/packages/supermassive/src/jsutils/getBySet.ts
@@ -1,0 +1,13 @@
+import { isSameSet } from "./isSameSet";
+
+export function getBySet<T, U>(
+  map: ReadonlyMap<ReadonlySet<T>, U>,
+  setToMatch: ReadonlySet<T>,
+): U | undefined {
+  for (const set of map.keys()) {
+    if (isSameSet(set, setToMatch)) {
+      return map.get(set);
+    }
+  }
+  return undefined;
+}

--- a/packages/supermassive/src/jsutils/isSameSet.ts
+++ b/packages/supermassive/src/jsutils/isSameSet.ts
@@ -1,0 +1,14 @@
+export function isSameSet<T>(
+  setA: ReadonlySet<T>,
+  setB: ReadonlySet<T>,
+): boolean {
+  if (setA.size !== setB.size) {
+    return false;
+  }
+  for (const item of setA) {
+    if (!setB.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/supermassive/src/jsutils/promiseWithResolvers.ts
+++ b/packages/supermassive/src/jsutils/promiseWithResolvers.ts
@@ -1,0 +1,20 @@
+import type { PromiseOrValue } from "./PromiseOrValue";
+
+/**
+ * Based on Promise.withResolvers proposal
+ * https://github.com/tc39/proposal-promise-with-resolvers
+ */
+export function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseOrValue<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  // these are assigned synchronously within the Promise constructor
+  let resolve!: (value: T | PromiseOrValue<T>) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/supermassive/src/jsutils/promiseWithResolvers.ts
+++ b/packages/supermassive/src/jsutils/promiseWithResolvers.ts
@@ -7,11 +7,11 @@ import type { PromiseOrValue } from "./PromiseOrValue";
 export function promiseWithResolvers<T>(): {
   promise: Promise<T>;
   resolve: (value: T | PromiseOrValue<T>) => void;
-  reject: (reason?: any) => void;
+  reject: (reason?: unknown) => void;
 } {
   // these are assigned synchronously within the Promise constructor
   let resolve!: (value: T | PromiseOrValue<T>) => void;
-  let reject!: (reason?: any) => void;
+  let reject!: (reason?: unknown) => void;
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -5,13 +5,13 @@ import {
   DocumentNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
+  FieldNode,
 } from "graphql";
 import { Maybe } from "./jsutils/Maybe";
 import { PromiseOrValue } from "./jsutils/PromiseOrValue";
 import { ObjMap } from "./jsutils/ObjMap";
 import { Path } from "./jsutils/Path";
 import { ExecutionHooks } from "./hooks/types";
-import { FieldGroup } from "./collectFields";
 import { OperationTypes, SchemaDefinitions } from "./schema/definition";
 import { TypeName } from "./schema/reference";
 
@@ -92,7 +92,7 @@ export type UserResolvers<TSource = unknown, TContext = unknown> = Record<
 
 export interface ResolveInfo {
   fieldName: string;
-  fieldNodes: FieldGroup;
+  fieldNodes: ReadonlyArray<FieldNode>;
   returnTypeName: string;
   parentTypeName: string;
   // readonly returnType: GraphQLOutputType;
@@ -105,13 +105,29 @@ export interface ResolveInfo {
   variableValues: { [variable: string]: unknown };
 }
 
-export type ExecutionResult<
-  TData = ObjMap<unknown>,
+export interface IncrementalUpdate<
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
-> =
+> {
+  pending: ReadonlyArray<PendingResult>;
+  incremental: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  completed: ReadonlyArray<CompletedResult>;
+}
+
+export type ExecutionResult<TData = unknown, TExtensions = ObjMap<unknown>> =
   | TotalExecutionResult<TData, TExtensions>
   | SubscriptionExecutionResult<TData, TExtensions>
-  | IncrementalExecutionResult<TData, TExtensions>;
+  | IncrementalExecutionResults<TData, TExtensions>;
+
+/**
+ * The result of GraphQL execution.
+ *
+ *   - `errors` is included when any errors occurred as a non-empty array.
+ *   - `data` is the result of a successful execution of the query.
+ *   - `hasNext` is true if a future payload is expected.
+ *   - `extensions` is reserved for adding non-standard properties.
+ *   - `incremental` is a list of the results from defer/stream directives.
+ */
 
 /**
  * The result of GraphQL execution.
@@ -136,7 +152,7 @@ export type SubscriptionExecutionResult<
   TExtensions = ObjMap<unknown>,
 > = AsyncGenerator<TotalExecutionResult<TData, TExtensions>>;
 
-export interface FormattedTotalExecutionResult<
+export interface FormattedExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
@@ -145,8 +161,8 @@ export interface FormattedTotalExecutionResult<
   extensions?: TExtensions;
 }
 
-export interface IncrementalExecutionResult<
-  TData = ObjMap<unknown>,
+export interface IncrementalExecutionResults<
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   initialResult: InitialIncrementalExecutionResult<TData, TExtensions>;
@@ -161,52 +177,61 @@ export interface InitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
 > extends TotalExecutionResult<TData, TExtensions> {
-  hasNext: boolean;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  data: TData;
+  pending: ReadonlyArray<PendingResult>;
+  hasNext: true;
   extensions?: TExtensions;
 }
 
 export interface FormattedInitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends FormattedTotalExecutionResult<TData, TExtensions> {
+> extends FormattedExecutionResult<TData, TExtensions> {
+  data: TData;
+  pending: ReadonlyArray<PendingResult>;
   hasNext: boolean;
-  incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
   extensions?: TExtensions;
 }
 
 export interface SubsequentIncrementalExecutionResult<
-  TData = ObjMap<unknown>,
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
-> {
+> extends Partial<IncrementalUpdate<TData, TExtensions>> {
   hasNext: boolean;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
   extensions?: TExtensions;
 }
 
 export interface FormattedSubsequentIncrementalExecutionResult<
-  TData = ObjMap<unknown>,
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
+  pending?: ReadonlyArray<PendingResult>;
   incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
+  completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
 }
 
 export interface IncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends TotalExecutionResult<TData, TExtensions> {
-  path?: ReadonlyArray<string | number>;
-  label?: string;
+> {
+  errors?: ReadonlyArray<GraphQLError>;
+  data: TData;
+  id: string;
+  subPath?: ReadonlyArray<string | number>;
+  extensions?: TExtensions;
 }
 
 export interface FormattedIncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends FormattedTotalExecutionResult<TData, TExtensions> {
-  path?: ReadonlyArray<string | number>;
-  label?: string;
+> {
+  errors?: ReadonlyArray<GraphQLFormattedError>;
+  data: TData;
+  id: string;
+  subPath?: ReadonlyArray<string | number>;
+  extensions?: TExtensions;
 }
 
 export interface IncrementalStreamResult<
@@ -214,9 +239,9 @@ export interface IncrementalStreamResult<
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLError>;
-  items?: TData | null;
-  path?: ReadonlyArray<string | number>;
-  label?: string;
+  items: TData;
+  id: string;
+  subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
@@ -225,25 +250,39 @@ export interface FormattedIncrementalStreamResult<
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items?: TData | null;
-  path?: ReadonlyArray<string | number>;
-  label?: string;
+  items: TData;
+  id: string;
+  subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
-export type IncrementalResult<
-  TData = ObjMap<unknown>,
-  TExtensions = ObjMap<unknown>,
-> =
+export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
   | IncrementalDeferResult<TData, TExtensions>
   | IncrementalStreamResult<TData, TExtensions>;
 
 export type FormattedIncrementalResult<
-  TData = ObjMap<unknown>,
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
 > =
   | FormattedIncrementalDeferResult<TData, TExtensions>
   | FormattedIncrementalStreamResult<TData, TExtensions>;
+
+export interface PendingResult {
+  id: string;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+export interface CompletedResult {
+  id: string;
+  errors?: ReadonlyArray<GraphQLError>;
+}
+
+export interface FormattedCompletedResult {
+  path: ReadonlyArray<string | number>;
+  label?: string;
+  errors?: ReadonlyArray<GraphQLError>;
+}
 
 export interface CommonExecutionArgs {
   document: DocumentNode;

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -29,6 +29,8 @@ import {
   typeReferenceFromNode,
 } from "./schema/reference";
 import type { SchemaFragment } from "./types";
+import { Maybe } from "./jsutils/Maybe";
+import { ObjMap } from "./jsutils/ObjMap";
 
 type CoercedVariableValues =
   | { errors: Array<GraphQLError>; coerced?: never }
@@ -163,11 +165,12 @@ function coerceVariableValues(
  * @internal
  */
 export function getArgumentValues(
-  exeContext: ExecutionContext,
+  schemaFragment: SchemaFragment,
   def: FieldDefinition | DirectiveDefinitionTuple,
   node: FieldNode | DirectiveNode,
+  variableValues?: Maybe<ObjMap<unknown>>,
 ): { [argument: string]: unknown } {
-  const definitions = exeContext.schemaFragment.definitions;
+  const definitions = schemaFragment.definitions;
   const coercedValues: { [argument: string]: unknown } = {};
   const argumentDefs =
     node.kind === Kind.FIELD
@@ -219,8 +222,8 @@ export function getArgumentValues(
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
       if (
-        exeContext.variableValues == null ||
-        !hasOwnProperty(exeContext.variableValues, variableName)
+        variableValues == null ||
+        !hasOwnProperty(variableValues, variableName)
       ) {
         if (defaultValue !== undefined) {
           coercedValues[name] = defaultValue;
@@ -234,7 +237,7 @@ export function getArgumentValues(
         }
         continue;
       }
-      isNull = exeContext.variableValues[variableName] == null;
+      isNull = variableValues[variableName] == null;
     }
 
     if (isNull && isNonNullType(argumentTypeRef)) {
@@ -248,8 +251,8 @@ export function getArgumentValues(
     const coercedValue = valueFromAST(
       valueNode,
       argumentTypeRef,
-      exeContext.schemaFragment,
-      exeContext.variableValues,
+      schemaFragment,
+      variableValues,
     );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before
@@ -278,9 +281,10 @@ export function getArgumentValues(
  * Object prototype.
  */
 export function getDirectiveValues(
-  exeContext: ExecutionContext,
+  schemaFragment: SchemaFragment,
   directiveDef: DirectiveDefinitionTuple,
   node: { directives?: ReadonlyArray<DirectiveNode> },
+  variableValues?: Maybe<ObjMap<unknown>>,
 ): undefined | { [argument: string]: unknown } {
   const name = getDirectiveName(directiveDef);
 
@@ -290,7 +294,12 @@ export function getDirectiveValues(
   );
 
   if (directiveNode) {
-    return getArgumentValues(exeContext, directiveDef, directiveNode);
+    return getArgumentValues(
+      schemaFragment,
+      directiveDef,
+      directiveNode,
+      variableValues,
+    );
   }
 }
 

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -9,7 +9,6 @@ import {
 } from "graphql";
 import { inspect } from "./jsutils/inspect";
 import { printPathArray } from "./jsutils/printPathArray";
-import { ExecutionContext } from "./executeWithoutSchema";
 import {
   DirectiveDefinitionTuple,
   FieldDefinition,


### PR DESCRIPTION
Tests in this PR demonstrate a problem found in supermassive v3 with error handling in the root fields. The fix required porting the latest implementation of the defer/stream from upstream graphql-js repo (the old implementation was originally the culprit for this issue).