### PR TITLE
Make decodeASTSchema correctly decode encoded Booleans

### DIFF
--- a/change/@graphitation-supermassive-93463287-b917-4722-b3f2-2472eb0c78a2.json
+++ b/change/@graphitation-supermassive-93463287-b917-4722-b3f2-2472eb0c78a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Properly decode boolean in schema",
+  "packageName": "@graphitation/supermassive",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/utilities/__tests__/__snapshots__/decodeASTSchema.test.ts.snap
+++ b/packages/supermassive/src/utilities/__tests__/__snapshots__/decodeASTSchema.test.ts.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`encodeASTSchema correctly encodes kitchen sink AST schema 1`] = `
+exports[`decodeASTSchema correctly encodes a schema with a Boolean parameter 1`] = `
+"type Query {
+  person(id: Int!): Person
+}
+
+type Person {
+  name: String!
+  phones(includeDefault: Boolean = true): [String!]!
+}
+"
+`;
+
+exports[`decodeASTSchema correctly encodes kitchen sink AST schema 1`] = `
 "type Foo implements Bar & Baz & Two {
   one: Type
   two(argument: InputType!): Type
@@ -88,7 +100,7 @@ directive @myRepeatableDir(name: String!) on OBJECT | INTERFACE
 "
 `;
 
-exports[`encodeASTSchema correctly encodes swapi AST schema 1`] = `
+exports[`decodeASTSchema correctly encodes swapi AST schema 1`] = `
 "union SearchResult = Person | Starship | Transport | Species | Vehicle | Planet | Film
 
 enum NodeType {

--- a/packages/supermassive/src/utilities/__tests__/decodeASTSchema.test.ts
+++ b/packages/supermassive/src/utilities/__tests__/decodeASTSchema.test.ts
@@ -4,8 +4,9 @@ import { encodeASTSchema } from "../encodeASTSchema";
 import { kitchenSinkSDL } from "./fixtures/kitchenSinkSDL";
 import { swapiSDL } from "./fixtures/swapiSDL";
 import { mergeSchemaDefinitions } from "../mergeSchemaDefinitions";
+import { schemaWithBooleanParameter } from "./fixtures/schemaWithBooleanParameter";
 
-describe(encodeASTSchema, () => {
+describe(decodeASTSchema, () => {
   test("correctly encodes swapi AST schema", () => {
     const doc = cleanUpDocument(swapiSDL.document);
     const encoded = encodeASTSchema(doc);
@@ -25,6 +26,16 @@ describe(encodeASTSchema, () => {
       ),
     ];
     const decoded = decodeASTSchema(encoded);
+    expect(encodeASTSchema(decoded)).toEqual(encoded);
+    expect(print(decoded)).toMatchSnapshot();
+  });
+
+  test("correctly encodes a schema with a Boolean parameter", () => {
+    const doc = cleanUpDocument(schemaWithBooleanParameter.document);
+    const encoded = encodeASTSchema(doc);
+    const decoded = decodeASTSchema(encoded);
+
+    expect(decoded).toEqual(doc);
     expect(encodeASTSchema(decoded)).toEqual(encoded);
     expect(print(decoded)).toMatchSnapshot();
   });

--- a/packages/supermassive/src/utilities/__tests__/fixtures/schemaWithBooleanParameter.ts
+++ b/packages/supermassive/src/utilities/__tests__/fixtures/schemaWithBooleanParameter.ts
@@ -1,0 +1,12 @@
+import { gql } from "../../../__testUtils__/gql";
+
+export const schemaWithBooleanParameter = gql`
+  type Query {
+    person(id: Int!): Person
+  }
+
+  type Person {
+    name: String!
+    phones(includeDefault: Boolean = true): [String!]!
+  }
+`;

--- a/packages/supermassive/src/utilities/decodeASTSchema.ts
+++ b/packages/supermassive/src/utilities/decodeASTSchema.ts
@@ -237,6 +237,9 @@ function valueToConstValueNode(
   if (Number.isInteger(jsValue)) {
     return { kind: Kind.INT, value: String(jsValue) };
   }
+  if (typeof jsValue === "boolean") {
+    return { kind: Kind.BOOLEAN, value: jsValue };
+  }
   if (typeof jsValue === "number") {
     return { kind: Kind.FLOAT, value: String(jsValue) };
   }


### PR DESCRIPTION
The following schema encodes correctly.

```graphql
type Query {
    person(id: Int!): Person
  }
  type Person {
    name: String!
    phones(includeDefault: Boolean = true): [String!]!
  }
  ```
However when trying to decode it it will throw reach the invariant and throw an error.

`Unexpected value for type Boolean: true`

This PR adds a test case for this case and fixes the decoding.

In addition I changed the test case name to be the correct name.
