### PR TITLE
Export string unions as types

### DIFF
--- a/change/@graphitation-graphql-codegen-typescript-operations-ee1f4833-5e44-41cc-a3dc-68b5c40ce78a.json
+++ b/change/@graphitation-graphql-codegen-typescript-operations-ee1f4833-5e44-41cc-a3dc-68b5c40ce78a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export string unions as types",
+  "packageName": "@graphitation/graphql-codegen-typescript-operations",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-028349d3-a154-4728-acff-92da6d2835f1.json
+++ b/change/@graphitation-ts-codegen-028349d3-a154-4728-acff-92da6d2835f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export string unions as types",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "jakubvejr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-codegen-typescript-operations/src/config.ts
+++ b/packages/graphql-codegen-typescript-operations/src/config.ts
@@ -120,4 +120,5 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    */
   addOperationExport?: boolean;
   baseTypesPath?: string;
+  isTypeOnly: boolean;
 }

--- a/packages/graphql-codegen-typescript-operations/src/config.ts
+++ b/packages/graphql-codegen-typescript-operations/src/config.ts
@@ -120,5 +120,5 @@ export interface TypeScriptDocumentsPluginConfig extends RawDocumentsConfig {
    */
   addOperationExport?: boolean;
   baseTypesPath?: string;
-  isTypeOnly: boolean;
+  isTypeOnly?: boolean;
 }

--- a/packages/graphql-codegen-typescript-operations/src/visitor.ts
+++ b/packages/graphql-codegen-typescript-operations/src/visitor.ts
@@ -59,6 +59,7 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
         ),
         immutableTypes: getConfigValue(config.immutableTypes, false),
         nonOptionalTypename: getConfigValue(config.nonOptionalTypename, false),
+        isTypeOnly: getConfigValue(config.isTypeOnly, false),
       } as TypeScriptDocumentsParsedConfig,
       schema,
     );

--- a/packages/graphql-codegen-typescript-operations/src/visitor.ts
+++ b/packages/graphql-codegen-typescript-operations/src/visitor.ts
@@ -37,6 +37,7 @@ export interface TypeScriptDocumentsParsedConfig extends ParsedDocumentsConfig {
   immutableTypes: boolean;
   baseTypesPath: string;
   noExport: boolean;
+  isTypeOnly: boolean;
 }
 export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
   TypeScriptDocumentsPluginConfig,
@@ -149,9 +150,9 @@ export class TypeScriptDocumentsVisitor extends BaseDocumentsVisitor<
           )
           .concat(
             this.config.baseTypesPath && this.usedTypes.size
-              ? `export {${Array.from(this.usedTypes).join(",")}} from "${
-                  this.config.baseTypesPath
-                }"`
+              ? `export ${this.config.isTypeOnly ? "type " : ""}{${Array.from(
+                  this.usedTypes,
+                ).join(",")}} from "${this.config.baseTypesPath}"`
               : "",
           )
       : [];

--- a/packages/ts-codegen/src/__tests__/index.test.ts
+++ b/packages/ts-codegen/src/__tests__/index.test.ts
@@ -2143,6 +2143,40 @@ describe(generateTS, () => {
     `);
   });
 
+  it("legacy import string unions", () => {
+    const { models, resolvers, enums, inputs } = runGenerateTest(
+      graphql`
+        enum Foo {
+          Bar
+          Braz
+        }
+      `,
+      {
+        enumsImport: "common-enums",
+        useStringUnionsInsteadOfEnums: true,
+      },
+    );
+
+    expect(enums).toMatchInlineSnapshot(`
+      "export type { Foo } from "common-enums";
+      "
+    `);
+    expect(inputs).toMatchInlineSnapshot(`undefined`);
+    expect(models).toMatchInlineSnapshot(`
+      "export * from "./enums.interface";
+      // Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+      export interface BaseModel {
+          readonly __typename?: string;
+      }
+      "
+    `);
+    expect(resolvers).toMatchInlineSnapshot(`
+      "import type { PromiseOrValue } from "@graphitation/supermassive";
+      import type { ResolveInfo } from "@graphitation/supermassive";
+      import * as Models from "./models.interface";
+      "
+    `);
+  });
   it("legacy import enums", () => {
     const { models, resolvers, enums, inputs } = runGenerateTest(
       graphql`

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -189,7 +189,7 @@ export class TsCodegenContext {
   }
 
   isUseStringUnionsInsteadOfEnumsEnabled(): boolean {
-    return this.options.useStringUnionsInsteadOfEnums;
+    return Boolean(this.options.useStringUnionsInsteadOfEnums);
   }
 
   getTypeReferenceForInputTypeFromTypeNode(

--- a/packages/ts-codegen/src/enums.ts
+++ b/packages/ts-codegen/src/enums.ts
@@ -10,9 +10,13 @@ export function generateEnums(context: TsCodegenContext): ts.SourceFile {
         .getAllTypes()
         .map((type) => {
           if (type.kind === "ENUM") {
+            const isStringUnion =
+              context.isUseStringUnionsInsteadOfEnumsEnabled() &&
+              context.shouldMigrateEnum(type.name);
+
             return factory.createExportDeclaration(
               undefined,
-              false,
+              isStringUnion,
               factory.createNamedExports([
                 factory.createExportSpecifier(
                   false,


### PR DESCRIPTION
Export string unions as types (added `isTypeOnly` config parameter)