### PR TITLE
Remove trailing interpolations from Nova queries and mutations

### DIFF
--- a/change/@graphitation-embedded-document-artefact-loader-26192454-96cc-4c82-89dd-3af55914610a.json
+++ b/change/@graphitation-embedded-document-artefact-loader-26192454-96cc-4c82-89dd-3af55914610a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove trailing interpolations from Nova queries",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "iukondra@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/embedded-document-artefact-loader/src/__tests__/__snapshots__/webpack.test.ts.snap
+++ b/packages/embedded-document-artefact-loader/src/__tests__/__snapshots__/webpack.test.ts.snap
@@ -70,3 +70,11 @@ exports[`webpackLoader works with invalid documents by not replacing them 1`] = 
         );
       "
 `;
+
+exports[`webpackLoader works with trailing interpolations 1`] = `
+"
+        import { graphql } from "@nova/react";
+        const doc = require("./__generated__/SomeComponentQuery.graphql").default;
+        console.log()
+      "
+`;

--- a/packages/embedded-document-artefact-loader/src/__tests__/webpack.test.ts
+++ b/packages/embedded-document-artefact-loader/src/__tests__/webpack.test.ts
@@ -334,5 +334,37 @@ describe("webpackLoader", () => {
       const sourceMap = result.result![1];
       expect(sourceMap).toMatchSnapshot();
     });
+
+    it("emits source-map for tagged template with trailing interpolations", async () => {
+      const source = `
+        import { graphql } from "@nova/react";
+        const doc = graphql\`
+          query SomeComponentQuery($id: ID!) {
+            helloWorld
+            \$\{Trailing_Interpolation\}
+          }
+        \`;
+        console.log()
+      `;
+
+      const result = await runLoader(source);
+      const transpiled = result.result![0]?.toString();
+      const sourceMap = result.result![1];
+      const consumer = new SourceMapConsumer(sourceMap! as any);
+
+      // fs.writeFileSync(__dirname + "/tmp/test.out", transpiled!);
+      // fs.writeFileSync(__dirname + "/tmp/test.map", sourceMap!);
+
+      expect(
+        getGeneratedCodeForOriginalRange(
+          { line: 3, column: 20 },
+          { line: 8, column: 9 },
+          consumer,
+          transpiled!,
+        ),
+      ).toMatchInlineSnapshot(
+        `"require("./__generated__/SomeComponentQuery.graphql").default"`,
+      );
+    });
   });
 });

--- a/packages/embedded-document-artefact-loader/src/__tests__/webpack.test.ts
+++ b/packages/embedded-document-artefact-loader/src/__tests__/webpack.test.ts
@@ -168,6 +168,19 @@ describe("webpackLoader", () => {
         );
       `,
     },
+    {
+      name: "trailing interpolations",
+      source: `
+        import { graphql } from "@nova/react";
+        const doc = graphql\`
+          query SomeComponentQuery($id: ID!) {
+            helloWorld
+            \$\{Trailing_Interpolation\}
+          }
+        \`;
+        console.log()
+      `,
+    },
   ])("works with $name", async ({ source }) => {
     const result = await runLoader(source);
     expect(result.result![0]).toMatchSnapshot();

--- a/packages/embedded-document-artefact-loader/src/transform.ts
+++ b/packages/embedded-document-artefact-loader/src/transform.ts
@@ -28,6 +28,9 @@ export function transform(
     (taggedTemplateExpression: string, sdl: string, offset: number) => {
       let documentName: string | undefined;
       try {
+        // Remove trailing interpolations from Nova queries and mutations
+        sdl = sdl.replace(/\$\{[a-zA-Z_][a-zA-Z0-9_.]*\}/g, '');
+
         // In the absence of parsing the full JS/TS file, we may run into false
         // positives. We detect this by attempting to parse the tagged template
         // expression. If it fails, we assume it is not a [valid] graphql tag.


### PR DESCRIPTION
We can't use this loader with Nova components right now as a parser doesn't understand trailing interpolations in GQL queries and mutation. In this PR I remove these interpolations to pass a parsing logic 