### PR TITLE
fix(apollo-react-relay-duct-tape): use correct id for compiler fragment, add check for partial result

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-e1ec4234-3d44-4be3-9a6c-4e1bf7a52336.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-e1ec4234-3d44-4be3-9a6c-4e1bf7a52336.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use correct id for compiled fragment, add check for partial result",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/schema.graphql
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/schema.graphql
@@ -5,7 +5,7 @@ interface Node {
 }
 
 type Query {
-  user(id: Int!): User!
+  user(id: Int!, idThatDoesntOverride: String): User!
   node(id: ID!): Node
   nonNode: NonNode!
 }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
@@ -8,6 +8,7 @@ export type compiledHooks_Root_executionQueryVariables = {
     avatarSize?: number | null | undefined;
     messagesBackwardCount: number;
     messagesBeforeCursor: string;
+    id?: string | null | undefined;
 };
 export type compiledHooks_Root_executionQueryResponse = {
     readonly user: {
@@ -23,8 +24,8 @@ export type compiledHooks_Root_executionQuery = {
 
 
 /*
-query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!) {
-  user(id: $userId) {
+query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId") {
+  user(id: $userId, idThatDoesntOverride: $id) {
     name
     ...compiledHooks_ChildFragment
     ...compiledHooks_RefetchableFragment
@@ -93,8 +94,8 @@ fragment compiledHooks_RefetchableFragment on User {
 */
 
 /*
-query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!) {
-  user(id: $userId) {
+query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId") {
+  user(id: $userId, idThatDoesntOverride: $id) {
     name
     id
     ... on Node {
@@ -149,7 +150,22 @@ v6 = {
     "value": "messagesBeforeCursor"
   }
 },
-v7 = [
+v7 = {
+  "kind": "NamedType",
+  "name": {
+    "kind": "Name",
+    "value": "String"
+  }
+},
+v8 = {
+  "kind": "Name",
+  "value": "id"
+},
+v9 = {
+  "kind": "Variable",
+  "name": (v8/*: any*/)
+},
+v10 = [
   {
     "kind": "VariableDefinition",
     "variable": (v1/*: any*/),
@@ -174,112 +190,120 @@ v7 = [
     "variable": (v6/*: any*/),
     "type": {
       "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "String"
-        }
-      }
+      "type": (v7/*: any*/)
+    }
+  },
+  {
+    "kind": "VariableDefinition",
+    "variable": (v9/*: any*/),
+    "type": (v7/*: any*/),
+    "defaultValue": {
+      "kind": "StringValue",
+      "value": "shouldNotOverrideCompiledFragmentId",
+      "block": false
     }
   }
 ],
-v8 = {
+v11 = {
   "kind": "Name",
   "value": "user"
 },
-v9 = {
-  "kind": "Name",
-  "value": "id"
-},
-v10 = [
+v12 = [
   {
     "kind": "Argument",
-    "name": (v9/*: any*/),
+    "name": (v8/*: any*/),
     "value": (v1/*: any*/)
+  },
+  {
+    "kind": "Argument",
+    "name": {
+      "kind": "Name",
+      "value": "idThatDoesntOverride"
+    },
+    "value": (v9/*: any*/)
   }
 ],
-v11 = {
+v13 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "name"
   }
 },
-v12 = {
+v14 = {
   "kind": "Name",
   "value": "compiledHooks_ChildFragment"
 },
-v13 = {
+v15 = {
   "kind": "Name",
   "value": "compiledHooks_RefetchableFragment"
 },
-v14 = {
+v16 = {
   "kind": "Name",
   "value": "compiledHooks_ForwardPaginationFragment"
 },
-v15 = {
-  "kind": "Field",
-  "name": (v9/*: any*/)
-},
-v16 = {
-  "kind": "Name",
-  "value": "compiledHooks_QueryTypeFragment"
-},
 v17 = {
-  "kind": "Name",
-  "value": "compiledHooks_BackwardPaginationFragment"
+  "kind": "Field",
+  "name": (v8/*: any*/)
 },
 v18 = {
   "kind": "Name",
-  "value": "connection"
+  "value": "compiledHooks_QueryTypeFragment"
 },
 v19 = {
   "kind": "Name",
-  "value": "key"
+  "value": "compiledHooks_BackwardPaginationFragment"
 },
 v20 = {
   "kind": "Name",
-  "value": "edges"
+  "value": "connection"
 },
 v21 = {
   "kind": "Name",
-  "value": "node"
+  "value": "key"
 },
 v22 = {
   "kind": "Name",
-  "value": "__typename"
+  "value": "edges"
 },
 v23 = {
-  "kind": "Field",
-  "name": (v22/*: any*/)
+  "kind": "Name",
+  "value": "node"
 },
 v24 = {
+  "kind": "Name",
+  "value": "__typename"
+},
+v25 = {
+  "kind": "Field",
+  "name": (v24/*: any*/)
+},
+v26 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "cursor"
   }
 },
-v25 = {
+v27 = {
   "kind": "Name",
   "value": "pageInfo"
 },
-v26 = {
+v28 = {
   "kind": "NamedType",
   "name": {
     "kind": "Name",
     "value": "User"
   }
 },
-v27 = {
+v29 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "petName"
   }
 },
-v28 = {
+v30 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
@@ -296,7 +320,7 @@ v28 = {
     }
   ]
 },
-v29 = {
+v31 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
@@ -320,44 +344,44 @@ return {
         "kind": "OperationDefinition",
         "operation": "query",
         "name": (v0/*: any*/),
-        "variableDefinitions": (v7/*: any*/),
+        "variableDefinitions": (v10/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
             {
               "kind": "Field",
-              "name": (v8/*: any*/),
-              "arguments": (v10/*: any*/),
+              "name": (v11/*: any*/),
+              "arguments": (v12/*: any*/),
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v11/*: any*/),
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v12/*: any*/)
-                  },
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v13/*: any*/)
-                  },
+                  (v13/*: any*/),
                   {
                     "kind": "FragmentSpread",
                     "name": (v14/*: any*/)
                   },
-                  (v15/*: any*/)
+                  {
+                    "kind": "FragmentSpread",
+                    "name": (v15/*: any*/)
+                  },
+                  {
+                    "kind": "FragmentSpread",
+                    "name": (v16/*: any*/)
+                  },
+                  (v17/*: any*/)
                 ]
               }
             },
             {
               "kind": "FragmentSpread",
-              "name": (v16/*: any*/)
+              "name": (v18/*: any*/)
             }
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v17/*: any*/),
+        "name": (v19/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -395,11 +419,11 @@ return {
               "directives": [
                 {
                   "kind": "Directive",
-                  "name": (v18/*: any*/),
+                  "name": (v20/*: any*/),
                   "arguments": [
                     {
                       "kind": "Argument",
-                      "name": (v19/*: any*/),
+                      "name": (v21/*: any*/),
                       "value": {
                         "kind": "StringValue",
                         "value": "compiledHooks_conversation_messages",
@@ -414,13 +438,13 @@ return {
                 "selections": [
                   {
                     "kind": "Field",
-                    "name": (v20/*: any*/),
+                    "name": (v22/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
                         {
                           "kind": "Field",
-                          "name": (v21/*: any*/),
+                          "name": (v23/*: any*/),
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -431,18 +455,18 @@ return {
                                   "value": "text"
                                 }
                               },
-                              (v15/*: any*/),
-                              (v23/*: any*/)
+                              (v17/*: any*/),
+                              (v25/*: any*/)
                             ]
                           }
                         },
-                        (v24/*: any*/)
+                        (v26/*: any*/)
                       ]
                     }
                   },
                   {
                     "kind": "Field",
-                    "name": (v25/*: any*/),
+                    "name": (v27/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -466,25 +490,25 @@ return {
                 ]
               }
             },
-            (v15/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v12/*: any*/),
-        "typeCondition": (v26/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v27/*: any*/),
-            (v15/*: any*/)
+            (v17/*: any*/)
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
         "name": (v14/*: any*/),
+        "typeCondition": (v28/*: any*/),
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            (v29/*: any*/),
+            (v17/*: any*/)
+          ]
+        }
+      },
+      {
+        "kind": "FragmentDefinition",
+        "name": (v16/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -501,10 +525,10 @@ return {
                 "kind": "Name",
                 "value": "__isNodeWithPetAvatarAndConversations"
               },
-              "name": (v22/*: any*/)
+              "name": (v24/*: any*/)
             },
-            (v27/*: any*/),
-            (v28/*: any*/),
+            (v29/*: any*/),
+            (v30/*: any*/),
             {
               "kind": "Field",
               "name": {
@@ -539,11 +563,11 @@ return {
               "directives": [
                 {
                   "kind": "Directive",
-                  "name": (v18/*: any*/),
+                  "name": (v20/*: any*/),
                   "arguments": [
                     {
                       "kind": "Argument",
-                      "name": (v19/*: any*/),
+                      "name": (v21/*: any*/),
                       "value": {
                         "kind": "StringValue",
                         "value": "compiledHooks_user_conversations",
@@ -558,13 +582,13 @@ return {
                 "selections": [
                   {
                     "kind": "Field",
-                    "name": (v20/*: any*/),
+                    "name": (v22/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
                         {
                           "kind": "Field",
-                          "name": (v21/*: any*/),
+                          "name": (v23/*: any*/),
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -577,20 +601,20 @@ return {
                               },
                               {
                                 "kind": "FragmentSpread",
-                                "name": (v17/*: any*/)
+                                "name": (v19/*: any*/)
                               },
-                              (v15/*: any*/),
-                              (v23/*: any*/)
+                              (v17/*: any*/),
+                              (v25/*: any*/)
                             ]
                           }
                         },
-                        (v24/*: any*/)
+                        (v26/*: any*/)
                       ]
                     }
                   },
                   {
                     "kind": "Field",
-                    "name": (v25/*: any*/),
+                    "name": (v27/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -614,13 +638,13 @@ return {
                 ]
               }
             },
-            (v15/*: any*/)
+            (v17/*: any*/)
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v16/*: any*/),
+        "name": (v18/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -640,7 +664,7 @@ return {
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v15/*: any*/)
+                  (v17/*: any*/)
                 ]
               }
             }
@@ -649,14 +673,14 @@ return {
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v13/*: any*/),
-        "typeCondition": (v26/*: any*/),
+        "name": (v15/*: any*/),
+        "typeCondition": (v28/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
-            (v27/*: any*/),
-            (v28/*: any*/),
-            (v15/*: any*/)
+            (v29/*: any*/),
+            (v30/*: any*/),
+            (v17/*: any*/)
           ]
         }
       }
@@ -669,19 +693,19 @@ return {
         "kind": "OperationDefinition",
         "operation": "query",
         "name": (v0/*: any*/),
-        "variableDefinitions": (v7/*: any*/),
+        "variableDefinitions": (v10/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
             {
               "kind": "Field",
-              "name": (v8/*: any*/),
-              "arguments": (v10/*: any*/),
+              "name": (v11/*: any*/),
+              "arguments": (v12/*: any*/),
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v11/*: any*/),
-                  (v15/*: any*/),
+                  (v13/*: any*/),
+                  (v17/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "typeCondition": {
@@ -694,14 +718,14 @@ return {
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
-                        (v29/*: any*/)
+                        (v31/*: any*/)
                       ]
                     }
                   }
                 ]
               }
             },
-            (v29/*: any*/)
+            (v31/*: any*/)
           ]
         }
       }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__snapshots__/compiledHooks.test.tsx.snap
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__snapshots__/compiledHooks.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
 {
   "__fragments": {
     "avatarSize": 21,
+    "id": "shouldNotOverrideCompiledFragmentId",
     "messagesBackwardCount": 1,
     "messagesBeforeCursor": "",
     "userId": 42,
@@ -11,6 +12,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
   "user": {
     "__fragments": {
       "avatarSize": 21,
+      "id": "shouldNotOverrideCompiledFragmentId",
       "messagesBackwardCount": 1,
       "messagesBeforeCursor": "",
       "userId": 42,
@@ -84,7 +86,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
     "nonNode": {
       "__ref": "<mock-value-for-field-"id">",
     },
-    "user({"id":42})": {
+    "user({"id":42,"idThatDoesntOverride":"shouldNotOverrideCompiledFragmentId"})": {
       "__ref": "42",
     },
   },
@@ -122,6 +124,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
 {
   "__fragments": {
     "avatarSize": 21,
+    "id": "shouldNotOverrideCompiledFragmentId",
     "messagesBackwardCount": 1,
     "messagesBeforeCursor": "",
     "userId": 42,
@@ -129,6 +132,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
   "user": {
     "__fragments": {
       "avatarSize": 21,
+      "id": "shouldNotOverrideCompiledFragmentId",
       "messagesBackwardCount": 1,
       "messagesBeforeCursor": "",
       "userId": 42,

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/compiledHooks.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/compiledHooks.test.tsx
@@ -117,8 +117,9 @@ const _Root_executionQueryDocument = graphql`
     $avatarSize: Int = 21
     $messagesBackwardCount: Int!
     $messagesBeforeCursor: String!
+    $id: String = "shouldNotOverrideCompiledFragmentId"
   ) {
-    user(id: $userId) {
+    user(id: $userId, idThatDoesntOverride: $id) {
       name
       ...compiledHooks_ChildFragment
       ...compiledHooks_RefetchableFragment
@@ -561,6 +562,7 @@ describe.each([
         {
           "__fragments": {
             "avatarSize": 21,
+            "id": "shouldNotOverrideCompiledFragmentId",
             "messagesBackwardCount": 1,
             "messagesBeforeCursor": "",
             "userId": 42,

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -5,6 +5,7 @@ import { useOverridenOrDefaultApolloClient } from "../../useOverridenOrDefaultAp
 
 import type { FragmentReference } from "./types";
 import type { CompiledArtefactModule } from "@graphitation/apollo-react-relay-duct-tape-compiler";
+import { Cache } from "@apollo/client/core";
 
 /**
  * @param documents Compiled watch query document that is used to setup a narrow
@@ -68,11 +69,15 @@ export function useCompiledFragment(
   if (result.partial) {
     invariant(
       false,
-      "useFragment(): Missing data expected to be seeded by the execution query document",
-      // TODO: queryInfo is private member and we can't access it, can we access last diff in other way?
-      // JSON.stringify(
-      //   observableQuery.queryInfo.lastDiff?.diff?.missing?.map((e) => e.path),
-      // ),
+      "useFragment(): Missing data expected to be seeded by the execution query document %s",
+      JSON.stringify(
+        // we need the cast because queryInfo and lastDiff are private but very useful for debugging
+        (
+          observableQuery as unknown as {
+            queryInfo: { lastDiff: { diff: Cache.DiffResult<unknown> } };
+          }
+        ).queryInfo.lastDiff?.diff?.missing?.map((e) => e.path),
+      ),
     );
   }
   let data = result.data;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -69,12 +69,12 @@ export function useCompiledFragment(
   if (result.partial) {
     invariant(
       false,
-      "useFragment(): Missing data expected to be seeded by the execution query document %s",
+      "useFragment(): Missing data expected to be seeded by the execution query document: %s",
       JSON.stringify(
         // we need the cast because queryInfo and lastDiff are private but very useful for debugging
         (
           observableQuery as unknown as {
-            queryInfo: { lastDiff?: { diff?: Cache.DiffResult<unknown> } };
+            queryInfo?: { lastDiff?: { diff?: Cache.DiffResult<unknown> } };
           }
         ).queryInfo?.lastDiff?.diff?.missing?.map((e) => e.path),
       ),

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -69,7 +69,7 @@ export function useCompiledFragment(
   if (result.partial) {
     invariant(
       false,
-      "useFragment(): Missing data expected to be seeded by the execution query document: %s",
+      "useFragment(): Missing data expected to be seeded by the execution query document: %s. Please check your type policies and possibleTypes configuration. If only subset of properties is missing you might need to configure merge functions for non-normalized types.",
       JSON.stringify(
         // we need the cast because queryInfo and lastDiff are private but very useful for debugging
         (
@@ -82,11 +82,19 @@ export function useCompiledFragment(
   }
   let data = result.data;
   if (metadata?.rootSelection) {
+    invariant(
+      data,
+      "useFragment(): Expected Apollo to respond with previously seeded data of the execution query document: %s. Did you configure your type policies and possibleTypes correctly? Check apollo-react-relay-duct-tape README for more details.",
+      JSON.stringify({
+        selection: metadata.rootSelection,
+        mainFragment: metadata.mainFragment,
+      }),
+    );
     data = data[metadata.rootSelection];
   }
   invariant(
     data,
-    "useFragment(): Expected Apollo to respond with previously seeded data of the execution query document",
+    "useFragment(): Expected Apollo to respond with previously seeded data of the execution query document. Did you configure your type policies and possibleTypes correctly? Check apollo-react-relay-duct-tape README for more details.",
   );
   return data;
 }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -74,9 +74,9 @@ export function useCompiledFragment(
         // we need the cast because queryInfo and lastDiff are private but very useful for debugging
         (
           observableQuery as unknown as {
-            queryInfo: { lastDiff: { diff: Cache.DiffResult<unknown> } };
+            queryInfo: { lastDiff?: { diff?: Cache.DiffResult<unknown> } };
           }
-        ).queryInfo.lastDiff?.diff?.missing?.map((e) => e.path),
+        ).queryInfo?.lastDiff?.diff?.missing?.map((e) => e.path),
       ),
     );
   }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledFragment.ts
@@ -38,9 +38,9 @@ export function useCompiledFragment(
         query: watchQueryDocument,
         returnPartialData: false,
         variables: {
+          ...fragmentReference.__fragments,
           id: fragmentReference.id,
           __fragments: fragmentReference.__fragments,
-          ...fragmentReference.__fragments,
         },
       }),
     [client, fragmentReference.id, fragmentReference.__fragments],
@@ -65,6 +65,16 @@ export function useCompiledFragment(
   }, [observableQuery]);
 
   const result = observableQuery.getCurrentResult();
+  if (result.partial) {
+    invariant(
+      false,
+      "useFragment(): Missing data expected to be seeded by the execution query document",
+      // TODO: queryInfo is private member and we can't access it, can we access last diff in other way?
+      // JSON.stringify(
+      //   observableQuery.queryInfo.lastDiff?.diff?.missing?.map((e) => e.path),
+      // ),
+    );
+  }
   let data = result.data;
   if (metadata?.rootSelection) {
     data = data[metadata.rootSelection];


### PR DESCRIPTION
The aim of this PR is to fix an issue discovered while integrating refetchable fragments for Jana in TMP. In scope of this PR we:
* make sure that if there is an id variable on the query, it doesn't override the `id` used on the compiled fragment (reordering of spread and id in `useCompiledFragment`)
* add one more invariant, checking if `observableQuery` returned partial result (and failing in such case)
* add another invariant in case of data returned being null
* update readme about cache configuration