### PR TITLE
Add support for artifactDirectory to loader

### DIFF
--- a/change/@graphitation-embedded-document-artefact-loader-2132306a-82ce-4957-b3aa-954853bea6f1.json
+++ b/change/@graphitation-embedded-document-artefact-loader-2132306a-82ce-4957-b3aa-954853bea6f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for artifactDirectory to loader",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/embedded-document-artefact-loader/README.md
+++ b/packages/embedded-document-artefact-loader/README.md
@@ -27,6 +27,29 @@ const webpackConfig = {
 };
 ```
 
+If you are using the `artifactDirectory` option in your relay config you will need to direct the loader to the same folder.
+
+```js
+const webpackConfig = {
+  module: {
+    rules: [
+      {
+        test: /.+?\.tsx?$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: "@graphitation/embedded-document-artefact-loader/webpack",
+            options: {
+              artifactDirectory: "path/to/your/artifact/directory",
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## Jest
 
 The jest loader wraps ts-jest because there's no built-in way to chain loaders.

--- a/packages/embedded-document-artefact-loader/src/__tests__/__snapshots__/webpack.test.ts.snap
+++ b/packages/embedded-document-artefact-loader/src/__tests__/__snapshots__/webpack.test.ts.snap
@@ -2,6 +2,14 @@
 
 exports[`webpackLoader concerning source-maps returns the input source-map when no code is transformed 1`] = `"{"version":3,"file":"fixture.js","sourceRoot":"","sources":["fixture.ts"],"names":[],"mappings":"AAEQ,OAAO,CAAC,GAAG,EAAE,CAAA","sourcesContent":["\\n        import { graphql } from \\"@nova/react\\";\\n        console.log()\\n      "]}"`;
 
+exports[`webpackLoader works with artifactDirectory option 1`] = `
+"
+        import { graphql } from "@nova/react";
+        const doc = require("../../__generated__/SomeComponentQuery.graphql").default;
+        console.log()
+      "
+`;
+
 exports[`webpackLoader works with documents captured as variable 1`] = `
 "
         import { graphql } from "@nova/react";

--- a/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
+++ b/packages/embedded-document-artefact-loader/src/__tests__/transform.test.ts
@@ -14,4 +14,85 @@ describe("transform", () => {
       `"{"version":3,"sources":["somepath"],"names":[],"mappings":"AAAA"}"`,
     );
   });
+
+  it("should rewrite the document import", () => {
+    const source = `
+      import { graphql } from "@nova/react";
+      
+      graphql\`
+        fragment MyFragment on MyType {
+          id
+        }
+      \`;
+    `;
+    const sourceMapGenerator = new SourceMapGenerator();
+
+    expect(transform(source, "somepath", sourceMapGenerator))
+      .toMatchInlineSnapshot(`
+      "
+            import { graphql } from "@nova/react";
+            
+            require("./__generated__/MyFragment.graphql").default;
+          "
+    `);
+    expect(sourceMapGenerator.toString()).toMatchInlineSnapshot(
+      `"{"version":3,"sources":["somepath"],"names":[],"mappings":"AAAA;AACA;AACA;AACA,MAAM,AACN,AACA,AACA,AACA,qDAAO;AACP"}"`,
+    );
+  });
+
+  it("should rewrite the document import to `artifactDirectory`", () => {
+    const source = `
+      import { graphql } from "@nova/react";
+      
+      graphql\`
+        fragment MyFragment on MyType {
+          id
+        }
+      \`;
+    `;
+    const sourceMapGenerator = new SourceMapGenerator();
+
+    expect(
+      transform(source, "somepath", sourceMapGenerator, {
+        artifactDirectory: "../../__generated__",
+      }),
+    ).toMatchInlineSnapshot(`
+      "
+            import { graphql } from "@nova/react";
+            
+            require("../../__generated__/MyFragment.graphql").default;
+          "
+    `);
+    expect(sourceMapGenerator.toString()).toMatchInlineSnapshot(
+      `"{"version":3,"sources":["somepath"],"names":[],"mappings":"AAAA;AACA;AACA;AACA,MAAM,AACN,AACA,AACA,AACA,yDAAO;AACP"}"`,
+    );
+  });
+
+  it("should rewrite the document import to default when `artifactDirectory` is undefined", () => {
+    const source = `
+      import { graphql } from "@nova/react";
+      
+      graphql\`
+        fragment MyFragment on MyType {
+          id
+        }
+      \`;
+    `;
+    const sourceMapGenerator = new SourceMapGenerator();
+
+    expect(
+      transform(source, "somepath", sourceMapGenerator, {
+        artifactDirectory: undefined,
+      }),
+    ).toMatchInlineSnapshot(`
+      "
+            import { graphql } from "@nova/react";
+            
+            require("undefined/MyFragment.graphql").default;
+          "
+    `);
+    expect(sourceMapGenerator.toString()).toMatchInlineSnapshot(
+      `"{"version":3,"sources":["somepath"],"names":[],"mappings":"AAAA;AACA;AACA;AACA,MAAM,AACN,AACA,AACA,AACA,+CAAO;AACP"}"`,
+    );
+  });
 });

--- a/packages/embedded-document-artefact-loader/src/transform.ts
+++ b/packages/embedded-document-artefact-loader/src/transform.ts
@@ -1,12 +1,21 @@
 import { SourceMapGenerator } from "source-map-js";
 import { Source, parse } from "graphql";
 
+const defaultOptions = {
+  // Default `artifactDirectory` is relative to the sourceFile
+  artifactDirectory: "./__generated__",
+};
+
 export function transform(
   source: string,
   sourcePath: string,
   sourceMap: SourceMapGenerator | undefined,
+  options: {
+    artifactDirectory?: string;
+  } = defaultOptions,
 ): string | undefined {
   let anyChanges = false;
+  const { artifactDirectory } = { ...defaultOptions, ...options };
 
   if (sourceMap) {
     sourceMap.addMapping({
@@ -29,7 +38,7 @@ export function transform(
       let documentName: string | undefined;
       try {
         // Remove trailing interpolations from Nova queries and mutations
-        sdl = sdl.replace(/\$\{[a-zA-Z_][a-zA-Z0-9_.]*\}/g, '');
+        sdl = sdl.replace(/\$\{[a-zA-Z_][a-zA-Z0-9_.]*\}/g, "");
 
         // In the absence of parsing the full JS/TS file, we may run into false
         // positives. We detect this by attempting to parse the tagged template
@@ -82,7 +91,7 @@ export function transform(
 
       lastChunkOffset = offset + taggedTemplateExpression.length;
 
-      const generated = `require("./__generated__/${documentName}.graphql").default`;
+      const generated = `require("${artifactDirectory}/${documentName}.graphql").default`;
 
       if (sourceMap) {
         const originalStart = offsetToLineColumn(source, offset);

--- a/packages/embedded-document-artefact-loader/src/webpack.ts
+++ b/packages/embedded-document-artefact-loader/src/webpack.ts
@@ -3,12 +3,23 @@ import { SourceMapGenerator } from "source-map-js";
 import { transform } from "./transform";
 import { applySourceMap } from "./source-map-utils";
 
-const webpackLoader: LoaderDefinitionFunction = function (
+type Options = {
+  artifactDirectory?: string;
+};
+
+const webpackLoader: LoaderDefinitionFunction<Options> = function (
   source,
   inputSourceMap,
   _additionalData,
 ) {
   const callback = this.async();
+
+  // Using query instead of getOptions to support webpack 4
+  // and the loader-runner doesn't support getOptions (yet)
+  const options =
+    typeof this.query !== "string" && this.query.artifactDirectory
+      ? { artifactDirectory: this.query.artifactDirectory }
+      : undefined;
 
   let sourceMap: SourceMapGenerator | undefined;
   if (this.sourceMap) {
@@ -18,7 +29,7 @@ const webpackLoader: LoaderDefinitionFunction = function (
     sourceMap.setSourceContent(this.resourcePath, source);
   }
 
-  const transformed = transform(source, this.resourcePath, sourceMap);
+  const transformed = transform(source, this.resourcePath, sourceMap, options);
 
   if (transformed && sourceMap && inputSourceMap) {
     callback(


### PR DESCRIPTION
Relay supports writing artifacts to a separate directory.
https://relay.dev/docs/guides/type-emission/#single-artifact-directory

In a mono repo with multiple packages writing the artefacts inside other packages in the repo isn't ideal. There might also be conflicting compilers.

This PR adds the `artifactDirectory` option to the webpack loader to be able to specify where to get the generated documents.
