### PR TITLE
[SUPERMASSIVE] Execution hooks context

### DIFF
--- a/change/@graphitation-supermassive-3b9224f6-63b1-455e-9a0f-6a0767000e7b.json
+++ b/change/@graphitation-supermassive-3b9224f6-63b1-455e-9a0f-6a0767000e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Execution hooks context",
+  "packageName": "@graphitation/supermassive",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/hooks.test.ts
+++ b/packages/supermassive/src/__tests__/hooks.test.ts
@@ -12,7 +12,7 @@ import { UserResolvers, TotalExecutionResult } from "../types";
 import {
   AfterFieldCompleteHookArgs,
   AfterFieldResolveHookArgs,
-  BeforeFieldResolveHookArgs,
+  BaseExecuteFieldHookArgs,
   ExecutionHooks,
 } from "../hooks/types";
 import { pathToArray } from "../jsutils/Path";
@@ -87,13 +87,19 @@ describe.each([
     const hooks: ExecutionHooks = {
       beforeFieldResolve: jest
         .fn()
-        .mockImplementation(({ resolveInfo }: BeforeFieldResolveHookArgs) => {
-          hookCalls.push(`BFR|${pathToArray(resolveInfo.path).join(".")}`);
-        }),
+        .mockImplementation(
+          ({ resolveInfo }: BaseExecuteFieldHookArgs<unknown>) => {
+            hookCalls.push(`BFR|${pathToArray(resolveInfo.path).join(".")}`);
+          },
+        ),
       afterFieldResolve: jest
         .fn()
         .mockImplementation(
-          ({ resolveInfo, result, error }: AfterFieldResolveHookArgs) => {
+          ({
+            resolveInfo,
+            result,
+            error,
+          }: AfterFieldResolveHookArgs<unknown, unknown>) => {
             const resultValue =
               typeof result === "object" && result !== null
                 ? "[object]"
@@ -109,7 +115,11 @@ describe.each([
       afterFieldComplete: jest
         .fn()
         .mockImplementation(
-          ({ resolveInfo, result, error }: AfterFieldCompleteHookArgs) => {
+          ({
+            resolveInfo,
+            result,
+            error,
+          }: AfterFieldCompleteHookArgs<unknown, unknown>) => {
             const resultValue =
               typeof result === "object" && result !== null
                 ? "[object]"

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -49,7 +49,7 @@ import {
   getDirectiveValues,
 } from "./values";
 import type { ExecutionHooks } from "./hooks/types";
-// import { arraysAreEqual } from "./utilities/array";
+import { arraysAreEqual } from "./utilities/array";
 import { isAsyncIterable } from "./jsutils/isAsyncIterable";
 import { mapAsyncIterator } from "./utilities/mapAsyncIterator";
 import { GraphQLStreamDirective } from "./schema/directives";
@@ -863,46 +863,18 @@ function resolveAndCompleteField(
 
     let completed;
     if (isPromise(result)) {
-      completed = result.then(
-        (resolved) => {
-          // if (!isDefaultResolverUsed && hooks?.afterFieldResolve) {
-          //   invokeAfterFieldResolveHook(
-          //     info,
-          //     exeContext,
-          //     hookContext,
-          //     resolved,
-          //   );
-          // }
-          return completeValue(
-            exeContext,
-            returnTypeRef,
-            fieldGroup,
-            info,
-            path,
-            resolved,
-            incrementalDataRecord,
-          );
-        },
-        // (rawError) => {
-        //   // That's where afterResolve hook can only be called
-        //   // in the case of async resolver promise rejection.
-        //   if (!isDefaultResolverUsed && hooks?.afterFieldResolve) {
-        //     invokeAfterFieldResolveHook(
-        //       info,
-        //       exeContext,
-        //       hookContext,
-        //       undefined,
-        //       rawError,
-        //     );
-        //   }
-        //   // Error will be handled on field completion
-        //   throw rawError;
-        // },
-      );
+      completed = result.then((resolved) => {
+        return completeValue(
+          exeContext,
+          returnTypeRef,
+          fieldGroup,
+          info,
+          path,
+          resolved,
+          incrementalDataRecord,
+        );
+      });
     } else {
-      // if (!isDefaultResolverUsed && hooks?.afterFieldResolve) {
-      //   invokeAfterFieldResolveHook(info, exeContext, hookContext, result);
-      // }
       completed = completeValue(
         exeContext,
         returnTypeRef,
@@ -963,20 +935,19 @@ function resolveAndCompleteField(
     // it means that field itself resolved fine (so afterFieldResolve has been invoked already),
     // but non-nullable child field resolving throws an error,
     // so that error is propagated to the parent field according to spec
-    // if (
-    //   !isDefaultResolverUsed &&
-    //   hooks?.afterFieldResolve &&
-    //   error.path &&
-    //   arraysAreEqual(pathArray, error.path)
-    // ) {
-    //   hookContext = invokeAfterFieldResolveHook(
-    //     info,
-    //     exeContext,
-    //     hookContext,
-    //     undefined,
-    //     error,
-    //   );
-    // }
+    if (
+      !isDefaultResolverUsed &&
+      hooks?.afterFieldResolve &&
+      error.path &&
+      arraysAreEqual(pathArray, error.path)
+    ) {
+      hookContext = invokeAfterFieldResolveHook(
+        info,
+        exeContext,
+        hookContext,
+        undefined,
+      );
+    }
     if (!isDefaultResolverUsed && hooks?.afterFieldComplete) {
       invokeAfterFieldCompleteHook(
         info,

--- a/packages/supermassive/src/hooks/types.ts
+++ b/packages/supermassive/src/hooks/types.ts
@@ -1,39 +1,73 @@
 import { ResolveInfo } from "../types";
 
-interface BaseExecuteHookArgs {
-  context: unknown;
+interface BaseExecuteHookArgs<ResolveContext> {
+  context: ResolveContext;
 }
 
-interface BaseExecuteFieldHookArgs extends BaseExecuteHookArgs {
+export interface BaseExecuteFieldHookArgs<ResolveContext>
+  extends BaseExecuteHookArgs<ResolveContext> {
   resolveInfo: ResolveInfo;
 }
 
-export type BeforeFieldResolveHookArgs = BaseExecuteFieldHookArgs;
+export interface PostExecuteFieldHookArgs<ResolveContext, HookContext>
+  extends BaseExecuteFieldHookArgs<ResolveContext> {
+  hookContext: HookContext;
+}
 
-export interface AfterFieldResolveHookArgs extends BaseExecuteFieldHookArgs {
+export interface AfterFieldResolveHookArgs<ResolveContext, HookContext>
+  extends PostExecuteFieldHookArgs<ResolveContext, HookContext> {
+  /**
+   * The result of the field execution _before_ completing the value. This
+   * means the result may be a promise that is still pending, and the delta
+   * between the time this hook and the `afterFieldComplete` hook is called
+   * is the time it takes for the promise to resolve.
+   */
+  result?: unknown | Promise<unknown>;
+}
+
+export interface AfterFieldCompleteHookArgs<ResolveContext, HookContext>
+  extends PostExecuteFieldHookArgs<ResolveContext, HookContext> {
   result?: unknown;
   error?: unknown;
 }
 
-export interface AfterFieldCompleteHookArgs extends BaseExecuteFieldHookArgs {
-  result?: unknown;
-  error?: unknown;
+export interface BeforeFieldResolveHook<
+  ResolveContext = unknown,
+  BeforeHookContext = unknown,
+> {
+  (args: BaseExecuteFieldHookArgs<ResolveContext>): BeforeHookContext;
 }
 
-export interface BeforeFieldResolveHook {
-  (args: BeforeFieldResolveHookArgs): void;
+export interface AfterFieldResolveHook<
+  ResolveContext = unknown,
+  BeforeHookContext = unknown,
+  AfterHookContext = BeforeHookContext,
+> {
+  (
+    args: AfterFieldResolveHookArgs<ResolveContext, BeforeHookContext>,
+  ): AfterHookContext;
 }
 
-export interface AfterFieldResolveHook {
-  (args: AfterFieldResolveHookArgs): void;
+export interface AfterFieldCompleteHook<
+  ResolveContext = unknown,
+  AfterHookContext = unknown,
+> {
+  (args: AfterFieldCompleteHookArgs<ResolveContext, AfterHookContext>): void;
 }
 
-export interface AfterFieldCompleteHook {
-  (args: AfterFieldCompleteHookArgs): void;
-}
-
-export interface ExecutionHooks {
-  beforeFieldResolve?: BeforeFieldResolveHook;
-  afterFieldResolve?: AfterFieldResolveHook;
-  afterFieldComplete?: AfterFieldCompleteHook;
+export interface ExecutionHooks<
+  ResolveContext = unknown,
+  BeforeHookContext = unknown,
+  AfterHookContext = BeforeHookContext,
+> {
+  beforeFieldResolve?: BeforeFieldResolveHook<
+    ResolveContext,
+    BeforeHookContext
+  >;
+  afterFieldResolve?: AfterFieldResolveHook<
+    ResolveContext,
+    BeforeHookContext,
+    AfterHookContext
+  >;
+  afterFieldComplete?: AfterFieldCompleteHook<ResolveContext, AfterHookContext>;
 }

--- a/packages/supermassive/src/index.ts
+++ b/packages/supermassive/src/index.ts
@@ -35,6 +35,9 @@ export {
   mergeSchemaDefinitions,
 } from "./utilities/mergeSchemaDefinitions";
 export { schemaFragmentFromMinimalViableSchemaDocument } from "./utilities/schemaFragmentFromMinimalViableSchemaDocument";
+export { pathToArray } from "./jsutils/Path";
+export { isPromise } from "./jsutils/isPromise";
+export { printPathArray } from "./jsutils/printPathArray";
 
 export type {
   CompositeTypeTuple,
@@ -88,6 +91,7 @@ export type {
 } from "./types";
 
 export type { PromiseOrValue } from "./jsutils/PromiseOrValue";
+export type { Path } from "./jsutils/Path";
 
 export type {
   ArgumentNode,
@@ -141,7 +145,7 @@ export type {
   AfterFieldResolveHook,
   AfterFieldResolveHookArgs,
   BeforeFieldResolveHook,
-  BeforeFieldResolveHookArgs,
+  BaseExecuteFieldHookArgs,
   ExecutionHooks,
 } from "./hooks/types";
 


### PR DESCRIPTION
* Introduce custom execution hooks context.
* `afterFieldResolve` hook is now called right after resolver function returns; its `result` argument could now be a promise (for async resolvers).
* Export some `jsutils` functions, like `pathToArray`, `printPathArray` and `isPromise`.