### PR TITLE
remove JSON.parse from webpack-loader

### DIFF
--- a/change/@graphitation-webpack-loader-5a513307-cab6-4b02-8810-88af0fd47328.json
+++ b/change/@graphitation-webpack-loader-5a513307-cab6-4b02-8810-88af0fd47328.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove JSON.parse from webpack-loader",
+  "packageName": "@graphitation/webpack-loader",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-loader/src/__tests__/loader.test.ts
+++ b/packages/webpack-loader/src/__tests__/loader.test.ts
@@ -14,9 +14,9 @@ test("basic query", () => {
   `;
   const doc = useLoader(docStr, {});
 
-  const docLine = `var doc = JSON.parse('${JSON.stringify(
+  const docLine = `var doc = ${JSON.stringify(
     parse(docStr, { noLocation: true }),
-  )}');`;
+  )};`;
   const exportLine = `module.exports = doc`;
 
   expect(doc).toContain(docLine);
@@ -24,7 +24,7 @@ test("basic query", () => {
 
   expect(doc).toMatchInlineSnapshot(`
     "
-    var doc = JSON.parse('{"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]}');
+    var doc = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]};
 
     module.exports = doc
     "
@@ -52,9 +52,9 @@ test("basic query with esModules on", () => {
     esModule: true,
   });
 
-  const docLine = `var doc = JSON.parse('${JSON.stringify(
+  const docLine = `var doc = ${JSON.stringify(
     parse(docStr, { noLocation: true }),
-  )}');`;
+  )};`;
   const exportLine = `export default doc`;
 
   expect(doc).toContain(docLine);
@@ -62,7 +62,7 @@ test("basic query with esModules on", () => {
 
   expect(doc).toMatchInlineSnapshot(`
     "
-    var doc = JSON.parse('{"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]}');
+    var doc = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]};
 
     export default doc
     "
@@ -88,9 +88,9 @@ test("basic query with imports", () => {
     esModule: true,
   });
 
-  const docLine = `var doc = JSON.parse('${JSON.stringify(
+  const docLine = `var doc = ${JSON.stringify(
     parse(docStr, { noLocation: true }),
-  )}');`;
+  )};`;
   const exportLine = `export default doc`;
 
   expect(doc).toContain(docLine);
@@ -98,7 +98,7 @@ test("basic query with imports", () => {
 
   expect(doc).toMatchInlineSnapshot(`
     "
-    var doc = JSON.parse('{"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]}');
+    var doc = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]};
 
       var names = {};
       function unique(defs) {
@@ -140,9 +140,9 @@ test("supermassive encoding for SDL", () => {
     supermassiveSDL: true,
   });
 
-  const docLine = `var doc = JSON.parse('${JSON.stringify(
+  const docLine = `var doc = ${JSON.stringify(
     encodeASTSchema(parse(docStr, { noLocation: true })),
-  )}');`;
+  )};`;
   const exportLine = `export default doc`;
 
   expect(doc).toContain(docLine);
@@ -150,7 +150,7 @@ test("supermassive encoding for SDL", () => {
 
   expect(doc).toMatchInlineSnapshot(`
     "
-    var doc = JSON.parse('[{"types":{"Query":[2,{"foo":1}]}}]');
+    var doc = [{"types":{"Query":[2,{"foo":1}]}}];
 
     export default doc
     "
@@ -168,9 +168,9 @@ test("supermassive encoding for SDL doesn't affect operations", () => {
     supermassiveSDL: true,
   });
 
-  const docLine = `var doc = JSON.parse('${JSON.stringify(
+  const docLine = `var doc = ${JSON.stringify(
     parse(docStr, { noLocation: true }),
-  )}');`;
+  )};`;
   const exportLine = `export default doc`;
 
   expect(doc).toContain(docLine);
@@ -178,7 +178,7 @@ test("supermassive encoding for SDL doesn't affect operations", () => {
 
   expect(doc).toMatchInlineSnapshot(`
     "
-    var doc = JSON.parse('{"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]}');
+    var doc = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Foo"},"variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"foo"},"arguments":[],"directives":[]}]}}]};
 
     export default doc
     "

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -85,8 +85,7 @@ export default function graphqlLoader(
 
   const headerCode = [
     options.replaceKinds ? "var Kind = require('graphql/language/kinds');" : "",
-    // See https://v8.dev/blog/cost-of-javascript-2019#json
-    `var doc = JSON.parse('${stringifiedDoc}');`,
+    `var doc = ${stringifiedDoc};`,
   ].join("\n");
 
   let outputCode = "";


### PR DESCRIPTION
JSON.parse was a minor perf optimization, but it is not compatible with some combinations of options.