### PR TITLE
Align generated types with relay-compiler >=15.0.0

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-9dea7f0e-c9d4-4e73-9327-8ef4ebb425b7.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-9dea7f0e-c9d4-4e73-9327-8ef4ebb425b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "align generated types with relay-compiler >=15.0.0",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "dragoshomner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-react-relay-duct-tape-compiler-e4f8cfe1-d73c-45b6-8e06-3ac5db6c1920.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-compiler-e4f8cfe1-d73c-45b6-8e06-3ac5db6c1920.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "align generated types with relay-compiler >=15.0.0",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape-compiler",
+  "email": "dragoshomner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/apollo-watch-fragments/src/__generated__/AppQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/AppQuery.graphql.ts
@@ -11,9 +11,9 @@ export type AppQueryResponse = {
         readonly todoStats: {
             readonly id: string;
             readonly totalCount: number;
-            readonly " $fragmentRefs": FragmentRefs<"TodoListFooter_todosFragment">;
+            readonly " $fragmentSpreads": FragmentRefs<"TodoListFooter_todosFragment">;
         };
-        readonly " $fragmentRefs": FragmentRefs<"TodoList_nodeFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"TodoList_nodeFragment">;
     };
 };
 export type AppQuery = {

--- a/examples/apollo-watch-fragments/src/__generated__/TodoListFooter_todosFragment.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoListFooter_todosFragment.graphql.ts
@@ -5,12 +5,12 @@
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type TodoListFooter_todosFragment = {
     readonly uncompletedCount: number;
-    readonly " $refType": "TodoListFooter_todosFragment";
+    readonly " $fragmentType": "TodoListFooter_todosFragment";
 };
 export type TodoListFooter_todosFragment$data = TodoListFooter_todosFragment;
 export type TodoListFooter_todosFragment$key = {
     readonly " $data"?: TodoListFooter_todosFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"TodoListFooter_todosFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"TodoListFooter_todosFragment">;
 };
 
 

--- a/examples/apollo-watch-fragments/src/__generated__/TodoListPaginationQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoListPaginationQuery.graphql.ts
@@ -12,7 +12,7 @@ export type TodoListPaginationQueryVariables = {
 };
 export type TodoListPaginationQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": FragmentRefs<"TodoList_nodeFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"TodoList_nodeFragment">;
     } | null;
 };
 export type TodoListPaginationQuery = {

--- a/examples/apollo-watch-fragments/src/__generated__/TodoList_nodeFragment.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoList_nodeFragment.graphql.ts
@@ -10,17 +10,17 @@ export type TodoList_nodeFragment = {
             readonly node: {
                 readonly id: string;
                 readonly isCompleted: boolean;
-                readonly " $fragmentRefs": FragmentRefs<"Todo_todoFragment">;
+                readonly " $fragmentSpreads": FragmentRefs<"Todo_todoFragment">;
             };
         }>;
     };
     readonly id: string;
-    readonly " $refType": "TodoList_nodeFragment";
+    readonly " $fragmentType": "TodoList_nodeFragment";
 };
 export type TodoList_nodeFragment$data = TodoList_nodeFragment;
 export type TodoList_nodeFragment$key = {
     readonly " $data"?: TodoList_nodeFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"TodoList_nodeFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"TodoList_nodeFragment">;
 };
 
 

--- a/examples/apollo-watch-fragments/src/__generated__/TodoRefetchQuery.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/TodoRefetchQuery.graphql.ts
@@ -9,7 +9,7 @@ export type TodoRefetchQueryVariables = {
 };
 export type TodoRefetchQueryResponse = {
     readonly node: {
-        readonly " $fragmentRefs": FragmentRefs<"Todo_todoFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"Todo_todoFragment">;
     } | null;
 };
 export type TodoRefetchQuery = {

--- a/examples/apollo-watch-fragments/src/__generated__/Todo_todoFragment.graphql.ts
+++ b/examples/apollo-watch-fragments/src/__generated__/Todo_todoFragment.graphql.ts
@@ -8,12 +8,12 @@ export type Todo_todoFragment = {
     readonly description: string;
     readonly isCompleted: boolean;
     readonly someOtherField?: string | undefined;
-    readonly " $refType": "Todo_todoFragment";
+    readonly " $fragmentType": "Todo_todoFragment";
 };
 export type Todo_todoFragment$data = Todo_todoFragment;
 export type Todo_todoFragment$key = {
     readonly " $data"?: Todo_todoFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"Todo_todoFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"Todo_todoFragment">;
 };
 
 

--- a/examples/supermassive-todomvc/src/components/__generated__/TodoFragment.graphql.ts
+++ b/examples/supermassive-todomvc/src/components/__generated__/TodoFragment.graphql.ts
@@ -7,10 +7,10 @@ export type TodoFragment = {
     readonly id: string;
     readonly text: string;
     readonly isCompleted: boolean;
-    readonly " $refType": "TodoFragment";
+    readonly " $fragmentType": "TodoFragment";
 };
 export type TodoFragment$data = TodoFragment;
 export type TodoFragment$key = {
     readonly " $data"?: TodoFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"TodoFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"TodoFragment">;
 };

--- a/examples/supermassive-todomvc/src/components/__generated__/TodoListQuery.graphql.ts
+++ b/examples/supermassive-todomvc/src/components/__generated__/TodoListQuery.graphql.ts
@@ -7,7 +7,7 @@ export type TodoListQueryVariables = {};
 export type TodoListQueryResponse = {
     readonly allTodos: ReadonlyArray<{
         readonly id: string;
-        readonly " $fragmentRefs": FragmentRefs<"TodoFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"TodoFragment">;
     }>;
 };
 export type TodoListQuery = {

--- a/examples/supermassive-todomvc/src/components/__generated__/TodoUpdatesSubscription.graphql.ts
+++ b/examples/supermassive-todomvc/src/components/__generated__/TodoUpdatesSubscription.graphql.ts
@@ -9,7 +9,7 @@ export type TodoUpdatesSubscriptionVariables = {
 export type TodoUpdatesSubscriptionResponse = {
     readonly emitTodos: {
         readonly id: string;
-        readonly " $fragmentRefs": FragmentRefs<"TodoFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"TodoFragment">;
     } | null;
 };
 export type TodoUpdatesSubscription = {

--- a/packages/apollo-react-relay-duct-tape-compiler/src/typeGenerator.ts
+++ b/packages/apollo-react-relay-duct-tape-compiler/src/typeGenerator.ts
@@ -7,8 +7,8 @@ export function generateFactory(wrappedGenerate: TypeGenerator["generate"]) {
       generated
         .replace("relay-runtime", "@graphitation/apollo-react-relay-duct-tape")
         // Align the generated types with the relay-compiler >= 15.0.0 output
-        .replace("$fragmentRefs", "$fragmentSpreads")
-        .replace("$refType", "$fragmentType")
+        .replace(/\$fragmentRefs/g, "$fragmentSpreads")
+        .replace(/\$refType/g, "$fragmentType")
         // These fields in the `@raw_response_type` output are really just for relay-runtime, so for now we can just
         // strip them out entirely.
         .replace(/^\s+readonly __is[A-Z].+;\n/gm, "")

--- a/packages/apollo-react-relay-duct-tape-compiler/src/typeGenerator.ts
+++ b/packages/apollo-react-relay-duct-tape-compiler/src/typeGenerator.ts
@@ -6,6 +6,9 @@ export function generateFactory(wrappedGenerate: TypeGenerator["generate"]) {
     return (
       generated
         .replace("relay-runtime", "@graphitation/apollo-react-relay-duct-tape")
+        // Align the generated types with the relay-compiler >= 15.0.0 output
+        .replace("$fragmentRefs", "$fragmentSpreads")
+        .replace("$refType", "$fragmentType")
         // These fields in the `@raw_response_type` output are really just for relay-runtime, so for now we can just
         // strip them out entirely.
         .replace(/^\s+readonly __is[A-Z].+;\n/gm, "")

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestFragment.graphql.ts
@@ -4,13 +4,13 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type hooksTestFragment = {
-    readonly id: string;
-    readonly name: string;
-    readonly __typename: "User";
-    readonly " $refType": "hooksTestFragment";
+  readonly id: string;
+  readonly name: string;
+  readonly __typename: "User";
+  readonly " $fragmentType": "hooksTestFragment";
 };
 export type hooksTestFragment$data = hooksTestFragment;
 export type hooksTestFragment$key = {
-    readonly " $data"?: hooksTestFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"hooksTestFragment">;
+  readonly " $data"?: hooksTestFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"hooksTestFragment">;
 };

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestMutation.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestMutation.graphql.ts
@@ -4,15 +4,15 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type hooksTestMutationVariables = {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 };
 export type hooksTestMutationResponse = {
-    readonly updateUserName: {
-        readonly " $fragmentRefs": FragmentRefs<"hooksTestFragment">;
-    };
+  readonly updateUserName: {
+    readonly " $fragmentSpreads": FragmentRefs<"hooksTestFragment">;
+  };
 };
 export type hooksTestMutation = {
-    readonly response: hooksTestMutationResponse;
-    readonly variables: hooksTestMutationVariables;
+  readonly response: hooksTestMutationResponse;
+  readonly variables: hooksTestMutationVariables;
 };

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestQuery.graphql.ts
@@ -4,14 +4,14 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type hooksTestQueryVariables = {
-    id: number;
+  id: number;
 };
 export type hooksTestQueryResponse = {
-    readonly user: {
-        readonly " $fragmentRefs": FragmentRefs<"hooksTestFragment">;
-    };
+  readonly user: {
+    readonly " $fragmentSpreads": FragmentRefs<"hooksTestFragment">;
+  };
 };
 export type hooksTestQuery = {
-    readonly response: hooksTestQueryResponse;
-    readonly variables: hooksTestQueryVariables;
+  readonly response: hooksTestQueryResponse;
+  readonly variables: hooksTestQueryVariables;
 };

--- a/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestSubscription.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/__tests__/__generated__/hooksTestSubscription.graphql.ts
@@ -4,14 +4,14 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type hooksTestSubscriptionVariables = {
-    id: string;
+  id: string;
 };
 export type hooksTestSubscriptionResponse = {
-    readonly userNameChanged: {
-        readonly " $fragmentRefs": FragmentRefs<"hooksTestFragment">;
-    };
+  readonly userNameChanged: {
+    readonly " $fragmentSpreads": FragmentRefs<"hooksTestFragment">;
+  };
 };
 export type hooksTestSubscription = {
-    readonly response: hooksTestSubscriptionResponse;
-    readonly variables: hooksTestSubscriptionVariables;
+  readonly response: hooksTestSubscriptionResponse;
+  readonly variables: hooksTestSubscriptionVariables;
 };

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_BackwardPaginationFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_BackwardPaginationFragment.graphql.ts
@@ -4,22 +4,22 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_BackwardPaginationFragment = {
-    readonly messages: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly text: string;
-            };
-        }>;
-    };
-    readonly id: string;
-    readonly " $refType": "compiledHooks_BackwardPaginationFragment";
+  readonly messages: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly text: string;
+      };
+    }>;
+  };
+  readonly id: string;
+  readonly " $fragmentType": "compiledHooks_BackwardPaginationFragment";
 };
-export type compiledHooks_BackwardPaginationFragment$data = compiledHooks_BackwardPaginationFragment;
+export type compiledHooks_BackwardPaginationFragment$data =
+  compiledHooks_BackwardPaginationFragment;
 export type compiledHooks_BackwardPaginationFragment$key = {
-    readonly " $data"?: compiledHooks_BackwardPaginationFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
+  readonly " $data"?: compiledHooks_BackwardPaginationFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
 };
-
 
 import { documents } from "./compiledHooks_BackwardPaginationFragment_PaginationQuery.graphql";
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_BackwardPaginationFragment_PaginationQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_BackwardPaginationFragment_PaginationQuery.graphql.ts
@@ -3,21 +3,21 @@
 // @ts-nocheck
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
-export type compiledHooks_BackwardPaginationFragment_PaginationQueryVariables = {
+export type compiledHooks_BackwardPaginationFragment_PaginationQueryVariables =
+  {
     messagesBackwardCount: number;
     messagesBeforeCursor: string;
     id: string;
-};
+  };
 export type compiledHooks_BackwardPaginationFragment_PaginationQueryResponse = {
-    readonly node: {
-        readonly " $fragmentRefs": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
-    } | null;
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
+  } | null;
 };
 export type compiledHooks_BackwardPaginationFragment_PaginationQuery = {
-    readonly response: compiledHooks_BackwardPaginationFragment_PaginationQueryResponse;
-    readonly variables: compiledHooks_BackwardPaginationFragment_PaginationQueryVariables;
+  readonly response: compiledHooks_BackwardPaginationFragment_PaginationQueryResponse;
+  readonly variables: compiledHooks_BackwardPaginationFragment_PaginationQueryVariables;
 };
-
 
 /*
 query compiledHooks_BackwardPaginationFragment_PaginationQuery($messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: ID!) {
@@ -78,347 +78,342 @@ fragment compiledHooks_BackwardPaginationFragment on Conversation {
 }
 */
 
-export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule = (function(){
-var v0 = {
-  "kind": "Name",
-  "value": "compiledHooks_BackwardPaginationFragment_PaginationQuery"
-},
-v1 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBackwardCount"
-  }
-},
-v2 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBeforeCursor"
-  }
-},
-v3 = {
-  "kind": "Name",
-  "value": "id"
-},
-v4 = {
-  "kind": "Variable",
-  "name": (v3/*: any*/)
-},
-v5 = [
-  {
-    "kind": "VariableDefinition",
-    "variable": (v1/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "Int"
-        }
-      }
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v2/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "String"
-        }
-      }
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v4/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "ID"
-        }
-      }
-    }
-  }
-],
-v6 = {
-  "kind": "Name",
-  "value": "node"
-},
-v7 = [
-  {
-    "kind": "Argument",
-    "name": (v3/*: any*/),
-    "value": (v4/*: any*/)
-  }
-],
-v8 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "__typename"
-  }
-},
-v9 = {
-  "kind": "Name",
-  "value": "compiledHooks_BackwardPaginationFragment"
-},
-v10 = {
-  "kind": "FragmentSpread",
-  "name": (v9/*: any*/)
-},
-v11 = {
-  "kind": "Field",
-  "name": (v3/*: any*/)
-},
-v12 = {
-  "kind": "FragmentDefinition",
-  "name": (v9/*: any*/),
-  "typeCondition": {
-    "kind": "NamedType",
-    "name": {
-      "kind": "Name",
-      "value": "Conversation"
-    }
-  },
-  "selectionSet": {
-    "kind": "SelectionSet",
-    "selections": [
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "messages"
+export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule =
+  (function () {
+    var v0 = {
+        kind: "Name",
+        value: "compiledHooks_BackwardPaginationFragment_PaginationQuery",
+      },
+      v1 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBackwardCount",
         },
-        "arguments": [
-          {
-            "kind": "Argument",
-            "name": {
-              "kind": "Name",
-              "value": "last"
+      },
+      v2 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBeforeCursor",
+        },
+      },
+      v3 = {
+        kind: "Name",
+        value: "id",
+      },
+      v4 = {
+        kind: "Variable",
+        name: v3 /*: any*/,
+      },
+      v5 = [
+        {
+          kind: "VariableDefinition",
+          variable: v1 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Int",
+              },
             },
-            "value": (v1/*: any*/)
           },
-          {
-            "kind": "Argument",
-            "name": {
-              "kind": "Name",
-              "value": "before"
-            },
-            "value": (v2/*: any*/)
-          }
-        ],
-        "directives": [
-          {
-            "kind": "Directive",
-            "name": {
-              "kind": "Name",
-              "value": "connection"
-            },
-            "arguments": [
-              {
-                "kind": "Argument",
-                "name": {
-                  "kind": "Name",
-                  "value": "key"
-                },
-                "value": {
-                  "kind": "StringValue",
-                  "value": "compiledHooks_conversation_messages",
-                  "block": false
-                }
-              }
-            ]
-          }
-        ],
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "edges"
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v2 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
               },
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v6/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "text"
-                          }
-                        },
-                        (v11/*: any*/),
-                        (v8/*: any*/)
-                      ]
-                    }
-                  },
-                  {
-                    "kind": "Field",
-                    "name": {
-                      "kind": "Name",
-                      "value": "cursor"
-                    }
-                  }
-                ]
-              }
             },
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "pageInfo"
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v4 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "ID",
               },
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": {
-                      "kind": "Name",
-                      "value": "hasPreviousPage"
-                    }
-                  },
-                  {
-                    "kind": "Field",
-                    "name": {
-                      "kind": "Name",
-                      "value": "startCursor"
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      (v11/*: any*/)
-    ]
-  }
-};
-return {
-  "executionQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v5/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v6/*: any*/),
-              "arguments": (v7/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v8/*: any*/),
-                  (v10/*: any*/),
-                  (v11/*: any*/)
-                ]
-              }
-            }
-          ]
-        }
-      },
-      (v12/*: any*/)
-    ]
-  },
-  "watchQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v5/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v6/*: any*/),
-              "arguments": (v7/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v8/*: any*/),
-                  (v10/*: any*/),
-                  (v11/*: any*/),
-                  {
-                    "kind": "InlineFragment",
-                    "typeCondition": {
-                      "kind": "NamedType",
-                      "name": {
-                        "kind": "Name",
-                        "value": "Node"
-                      }
-                    },
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "__fragments"
-                          },
-                          "directives": [
-                            {
-                              "kind": "Directive",
-                              "name": {
-                                "kind": "Name",
-                                "value": "client"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      (v12/*: any*/)
-    ]
-  },
-  "metadata": {
-    "rootSelection": "node",
-    "mainFragment": {
-      "name": "compiledHooks_BackwardPaginationFragment",
-      "typeCondition": "Conversation"
-    },
-    "connection": {
-      "selectionPath": [
-        "messages"
+            },
+          },
+        },
       ],
-      "backwardCountVariable": "messagesBackwardCount",
-      "backwardCursorVariable": "messagesBeforeCursor"
-    }
-  }
-};
-})();
+      v6 = {
+        kind: "Name",
+        value: "node",
+      },
+      v7 = [
+        {
+          kind: "Argument",
+          name: v3 /*: any*/,
+          value: v4 /*: any*/,
+        },
+      ],
+      v8 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "__typename",
+        },
+      },
+      v9 = {
+        kind: "Name",
+        value: "compiledHooks_BackwardPaginationFragment",
+      },
+      v10 = {
+        kind: "FragmentSpread",
+        name: v9 /*: any*/,
+      },
+      v11 = {
+        kind: "Field",
+        name: v3 /*: any*/,
+      },
+      v12 = {
+        kind: "FragmentDefinition",
+        name: v9 /*: any*/,
+        typeCondition: {
+          kind: "NamedType",
+          name: {
+            kind: "Name",
+            value: "Conversation",
+          },
+        },
+        selectionSet: {
+          kind: "SelectionSet",
+          selections: [
+            {
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "messages",
+              },
+              arguments: [
+                {
+                  kind: "Argument",
+                  name: {
+                    kind: "Name",
+                    value: "last",
+                  },
+                  value: v1 /*: any*/,
+                },
+                {
+                  kind: "Argument",
+                  name: {
+                    kind: "Name",
+                    value: "before",
+                  },
+                  value: v2 /*: any*/,
+                },
+              ],
+              directives: [
+                {
+                  kind: "Directive",
+                  name: {
+                    kind: "Name",
+                    value: "connection",
+                  },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "key",
+                      },
+                      value: {
+                        kind: "StringValue",
+                        value: "compiledHooks_conversation_messages",
+                        block: false,
+                      },
+                    },
+                  ],
+                },
+              ],
+              selectionSet: {
+                kind: "SelectionSet",
+                selections: [
+                  {
+                    kind: "Field",
+                    name: {
+                      kind: "Name",
+                      value: "edges",
+                    },
+                    selectionSet: {
+                      kind: "SelectionSet",
+                      selections: [
+                        {
+                          kind: "Field",
+                          name: v6 /*: any*/,
+                          selectionSet: {
+                            kind: "SelectionSet",
+                            selections: [
+                              {
+                                kind: "Field",
+                                name: {
+                                  kind: "Name",
+                                  value: "text",
+                                },
+                              },
+                              v11 /*: any*/,
+                              v8 /*: any*/,
+                            ],
+                          },
+                        },
+                        {
+                          kind: "Field",
+                          name: {
+                            kind: "Name",
+                            value: "cursor",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    kind: "Field",
+                    name: {
+                      kind: "Name",
+                      value: "pageInfo",
+                    },
+                    selectionSet: {
+                      kind: "SelectionSet",
+                      selections: [
+                        {
+                          kind: "Field",
+                          name: {
+                            kind: "Name",
+                            value: "hasPreviousPage",
+                          },
+                        },
+                        {
+                          kind: "Field",
+                          name: {
+                            kind: "Name",
+                            value: "startCursor",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+            v11 /*: any*/,
+          ],
+        },
+      };
+    return {
+      executionQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v5 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v6 /*: any*/,
+                  arguments: v7 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [v8 /*: any*/, v10 /*: any*/, v11 /*: any*/],
+                  },
+                },
+              ],
+            },
+          },
+          v12 /*: any*/,
+        ],
+      },
+      watchQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v5 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v6 /*: any*/,
+                  arguments: v7 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      v8 /*: any*/,
+                      v10 /*: any*/,
+                      v11 /*: any*/,
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "Node",
+                          },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "__fragments",
+                              },
+                              directives: [
+                                {
+                                  kind: "Directive",
+                                  name: {
+                                    kind: "Name",
+                                    value: "client",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          v12 /*: any*/,
+        ],
+      },
+      metadata: {
+        rootSelection: "node",
+        mainFragment: {
+          name: "compiledHooks_BackwardPaginationFragment",
+          typeCondition: "Conversation",
+        },
+        connection: {
+          selectionPath: ["messages"],
+          backwardCountVariable: "messagesBackwardCount",
+          backwardCursorVariable: "messagesBeforeCursor",
+        },
+      },
+    };
+  })();
 
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ChildFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ChildFragment.graphql.ts
@@ -4,15 +4,14 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_ChildFragment = {
-    readonly petName: string;
-    readonly " $refType": "compiledHooks_ChildFragment";
+  readonly petName: string;
+  readonly " $fragmentType": "compiledHooks_ChildFragment";
 };
 export type compiledHooks_ChildFragment$data = compiledHooks_ChildFragment;
 export type compiledHooks_ChildFragment$key = {
-    readonly " $data"?: compiledHooks_ChildFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_ChildFragment">;
+  readonly " $data"?: compiledHooks_ChildFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_ChildFragment">;
 };
-
 
 import { documents } from "./compiledHooks_ChildWatchNodeQuery.graphql";
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment.graphql.ts
@@ -4,25 +4,25 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_ForwardPaginationFragment = {
-    readonly petName: string;
-    readonly avatarUrl: string;
-    readonly conversations: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly title: string;
-                readonly " $fragmentRefs": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
-            };
-        }>;
-    };
-    readonly id: string;
-    readonly " $refType": "compiledHooks_ForwardPaginationFragment";
+  readonly petName: string;
+  readonly avatarUrl: string;
+  readonly conversations: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly title: string;
+        readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_BackwardPaginationFragment">;
+      };
+    }>;
+  };
+  readonly id: string;
+  readonly " $fragmentType": "compiledHooks_ForwardPaginationFragment";
 };
-export type compiledHooks_ForwardPaginationFragment$data = compiledHooks_ForwardPaginationFragment;
+export type compiledHooks_ForwardPaginationFragment$data =
+  compiledHooks_ForwardPaginationFragment;
 export type compiledHooks_ForwardPaginationFragment$key = {
-    readonly " $data"?: compiledHooks_ForwardPaginationFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_ForwardPaginationFragment">;
+  readonly " $data"?: compiledHooks_ForwardPaginationFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_ForwardPaginationFragment">;
 };
-
 
 import { documents } from "./compiledHooks_ForwardPaginationFragment_PaginationQuery.graphql";
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment_PaginationQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment_PaginationQuery.graphql.ts
@@ -4,24 +4,23 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_ForwardPaginationFragment_PaginationQueryVariables = {
-    addExtra: boolean;
-    avatarSize: number;
-    conversationsAfterCursor: string;
-    conversationsForwardCount: number;
-    messagesBackwardCount: number;
-    messagesBeforeCursor: string;
-    id: string;
+  addExtra: boolean;
+  avatarSize: number;
+  conversationsAfterCursor: string;
+  conversationsForwardCount: number;
+  messagesBackwardCount: number;
+  messagesBeforeCursor: string;
+  id: string;
 };
 export type compiledHooks_ForwardPaginationFragment_PaginationQueryResponse = {
-    readonly node: {
-        readonly " $fragmentRefs": FragmentRefs<"compiledHooks_ForwardPaginationFragment">;
-    } | null;
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_ForwardPaginationFragment">;
+  } | null;
 };
 export type compiledHooks_ForwardPaginationFragment_PaginationQuery = {
-    readonly response: compiledHooks_ForwardPaginationFragment_PaginationQueryResponse;
-    readonly variables: compiledHooks_ForwardPaginationFragment_PaginationQueryVariables;
+  readonly response: compiledHooks_ForwardPaginationFragment_PaginationQueryResponse;
+  readonly variables: compiledHooks_ForwardPaginationFragment_PaginationQueryVariables;
 };
-
 
 /*
 query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!, $conversationsAfterCursor: String! = "", $conversationsForwardCount: Int! = 1, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: ID!) {
@@ -116,612 +115,607 @@ fragment compiledHooks_ForwardPaginationFragment_pmmUt on NodeWithPetAvatarAndCo
 }
 */
 
-export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule = (function(){
-var v0 = {
-  "kind": "Name",
-  "value": "compiledHooks_ForwardPaginationFragment_PaginationQuery"
-},
-v1 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "avatarSize"
-  }
-},
-v2 = {
-  "kind": "NonNullType",
-  "type": {
-    "kind": "NamedType",
-    "name": {
-      "kind": "Name",
-      "value": "Int"
-    }
-  }
-},
-v3 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "conversationsAfterCursor"
-  }
-},
-v4 = {
-  "kind": "NonNullType",
-  "type": {
-    "kind": "NamedType",
-    "name": {
-      "kind": "Name",
-      "value": "String"
-    }
-  }
-},
-v5 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "conversationsForwardCount"
-  }
-},
-v6 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBackwardCount"
-  }
-},
-v7 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBeforeCursor"
-  }
-},
-v8 = {
-  "kind": "Name",
-  "value": "id"
-},
-v9 = {
-  "kind": "Variable",
-  "name": (v8/*: any*/)
-},
-v10 = [
-  {
-    "kind": "VariableDefinition",
-    "variable": (v1/*: any*/),
-    "type": (v2/*: any*/)
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v3/*: any*/),
-    "type": (v4/*: any*/),
-    "defaultValue": {
-      "kind": "StringValue",
-      "value": "",
-      "block": false
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v5/*: any*/),
-    "type": (v2/*: any*/),
-    "defaultValue": {
-      "kind": "IntValue",
-      "value": "1"
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v6/*: any*/),
-    "type": (v2/*: any*/)
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v7/*: any*/),
-    "type": (v4/*: any*/)
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v9/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "ID"
-        }
-      }
-    }
-  }
-],
-v11 = {
-  "kind": "Name",
-  "value": "node"
-},
-v12 = [
-  {
-    "kind": "Argument",
-    "name": (v8/*: any*/),
-    "value": (v9/*: any*/)
-  }
-],
-v13 = {
-  "kind": "Name",
-  "value": "__typename"
-},
-v14 = {
-  "kind": "Field",
-  "name": (v13/*: any*/)
-},
-v15 = {
-  "kind": "Name",
-  "value": "compiledHooks_ForwardPaginationFragment_pmmUt"
-},
-v16 = {
-  "kind": "FragmentSpread",
-  "name": (v15/*: any*/)
-},
-v17 = {
-  "kind": "Field",
-  "name": (v8/*: any*/)
-},
-v18 = {
-  "kind": "Name",
-  "value": "compiledHooks_BackwardPaginationFragment"
-},
-v19 = {
-  "kind": "Name",
-  "value": "connection"
-},
-v20 = {
-  "kind": "Name",
-  "value": "key"
-},
-v21 = {
-  "kind": "Name",
-  "value": "edges"
-},
-v22 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "cursor"
-  }
-},
-v23 = {
-  "kind": "Name",
-  "value": "pageInfo"
-},
-v24 = {
-  "kind": "NamedType",
-  "name": {
-    "kind": "Name",
-    "value": "NodeWithPetAvatarAndConversations"
-  }
-},
-v25 = {
-  "kind": "Field",
-  "alias": {
-    "kind": "Name",
-    "value": "__isNodeWithPetAvatarAndConversations"
-  },
-  "name": (v13/*: any*/)
-},
-v26 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "petName"
-  }
-},
-v27 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "avatarUrl"
-  },
-  "arguments": [
-    {
-      "kind": "Argument",
-      "name": {
-        "kind": "Name",
-        "value": "size"
+export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule =
+  (function () {
+    var v0 = {
+        kind: "Name",
+        value: "compiledHooks_ForwardPaginationFragment_PaginationQuery",
       },
-      "value": (v1/*: any*/)
-    }
-  ]
-},
-v28 = {
-  "kind": "Name",
-  "value": "conversations"
-},
-v29 = [
-  {
-    "kind": "Argument",
-    "name": {
-      "kind": "Name",
-      "value": "first"
-    },
-    "value": (v5/*: any*/)
-  },
-  {
-    "kind": "Argument",
-    "name": {
-      "kind": "Name",
-      "value": "after"
-    },
-    "value": (v3/*: any*/)
-  }
-],
-v30 = [
-  {
-    "kind": "Directive",
-    "name": (v19/*: any*/),
-    "arguments": [
-      {
-        "kind": "Argument",
-        "name": (v20/*: any*/),
-        "value": {
-          "kind": "StringValue",
-          "value": "compiledHooks_user_conversations",
-          "block": false
-        }
-      }
-    ]
-  }
-],
-v31 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "title"
-  }
-},
-v32 = {
-  "kind": "Field",
-  "name": (v23/*: any*/),
-  "selectionSet": {
-    "kind": "SelectionSet",
-    "selections": [
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "endCursor"
-        }
-      },
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "hasNextPage"
-        }
-      }
-    ]
-  }
-},
-v33 = {
-  "kind": "InlineFragment",
-  "typeCondition": {
-    "kind": "NamedType",
-    "name": {
-      "kind": "Name",
-      "value": "Node"
-    }
-  },
-  "selectionSet": {
-    "kind": "SelectionSet",
-    "selections": [
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "__fragments"
+      v1 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "avatarSize",
         },
-        "directives": [
-          {
-            "kind": "Directive",
-            "name": {
-              "kind": "Name",
-              "value": "client"
-            }
-          }
-        ]
-      }
-    ]
-  }
-};
-return {
-  "executionQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v10/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v11/*: any*/),
-              "arguments": (v12/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v14/*: any*/),
-                  (v16/*: any*/),
-                  (v17/*: any*/)
-                ]
-              }
-            }
-          ]
-        }
       },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v18/*: any*/),
-        "typeCondition": {
-          "kind": "NamedType",
-          "name": {
-            "kind": "Name",
-            "value": "Conversation"
-          }
+      v2 = {
+        kind: "NonNullType",
+        type: {
+          kind: "NamedType",
+          name: {
+            kind: "Name",
+            value: "Int",
+          },
         },
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "messages"
+      },
+      v3 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "conversationsAfterCursor",
+        },
+      },
+      v4 = {
+        kind: "NonNullType",
+        type: {
+          kind: "NamedType",
+          name: {
+            kind: "Name",
+            value: "String",
+          },
+        },
+      },
+      v5 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "conversationsForwardCount",
+        },
+      },
+      v6 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBackwardCount",
+        },
+      },
+      v7 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBeforeCursor",
+        },
+      },
+      v8 = {
+        kind: "Name",
+        value: "id",
+      },
+      v9 = {
+        kind: "Variable",
+        name: v8 /*: any*/,
+      },
+      v10 = [
+        {
+          kind: "VariableDefinition",
+          variable: v1 /*: any*/,
+          type: v2 /*: any*/,
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v3 /*: any*/,
+          type: v4 /*: any*/,
+          defaultValue: {
+            kind: "StringValue",
+            value: "",
+            block: false,
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v5 /*: any*/,
+          type: v2 /*: any*/,
+          defaultValue: {
+            kind: "IntValue",
+            value: "1",
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v6 /*: any*/,
+          type: v2 /*: any*/,
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v7 /*: any*/,
+          type: v4 /*: any*/,
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v9 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "ID",
               },
-              "arguments": [
-                {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "last"
-                  },
-                  "value": (v6/*: any*/)
-                },
-                {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "before"
-                  },
-                  "value": (v7/*: any*/)
-                }
-              ],
-              "directives": [
-                {
-                  "kind": "Directive",
-                  "name": (v19/*: any*/),
-                  "arguments": [
-                    {
-                      "kind": "Argument",
-                      "name": (v20/*: any*/),
-                      "value": {
-                        "kind": "StringValue",
-                        "value": "compiledHooks_conversation_messages",
-                        "block": false
-                      }
-                    }
-                  ]
-                }
-              ],
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v21/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": (v11/*: any*/),
-                          "selectionSet": {
-                            "kind": "SelectionSet",
-                            "selections": [
-                              {
-                                "kind": "Field",
-                                "name": {
-                                  "kind": "Name",
-                                  "value": "text"
-                                }
-                              },
-                              (v17/*: any*/),
-                              (v14/*: any*/)
-                            ]
-                          }
-                        },
-                        (v22/*: any*/)
-                      ]
-                    }
-                  },
-                  {
-                    "kind": "Field",
-                    "name": (v23/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "hasPreviousPage"
-                          }
-                        },
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "startCursor"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
             },
-            (v17/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v15/*: any*/),
-        "typeCondition": (v24/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v25/*: any*/),
-            (v26/*: any*/),
-            (v27/*: any*/),
-            {
-              "kind": "Field",
-              "name": (v28/*: any*/),
-              "arguments": (v29/*: any*/),
-              "directives": (v30/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v21/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": (v11/*: any*/),
-                          "selectionSet": {
-                            "kind": "SelectionSet",
-                            "selections": [
-                              (v31/*: any*/),
-                              {
-                                "kind": "FragmentSpread",
-                                "name": (v18/*: any*/)
-                              },
-                              (v17/*: any*/),
-                              (v14/*: any*/)
-                            ]
-                          }
-                        },
-                        (v22/*: any*/)
-                      ]
-                    }
-                  },
-                  (v32/*: any*/)
-                ]
-              }
-            },
-            (v17/*: any*/)
-          ]
-        }
-      }
-    ]
-  },
-  "watchQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v10/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v11/*: any*/),
-              "arguments": (v12/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v14/*: any*/),
-                  (v16/*: any*/),
-                  (v17/*: any*/),
-                  (v33/*: any*/)
-                ]
-              }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v15/*: any*/),
-        "typeCondition": (v24/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v25/*: any*/),
-            (v26/*: any*/),
-            (v27/*: any*/),
-            {
-              "kind": "Field",
-              "name": (v28/*: any*/),
-              "arguments": (v29/*: any*/),
-              "directives": (v30/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v21/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": (v11/*: any*/),
-                          "selectionSet": {
-                            "kind": "SelectionSet",
-                            "selections": [
-                              (v31/*: any*/),
-                              (v17/*: any*/),
-                              (v14/*: any*/),
-                              (v33/*: any*/)
-                            ]
-                          }
-                        },
-                        (v22/*: any*/)
-                      ]
-                    }
-                  },
-                  (v32/*: any*/)
-                ]
-              }
-            },
-            (v17/*: any*/)
-          ]
-        }
-      }
-    ]
-  },
-  "metadata": {
-    "rootSelection": "node",
-    "mainFragment": {
-      "name": "compiledHooks_ForwardPaginationFragment_pmmUt",
-      "typeCondition": "NodeWithPetAvatarAndConversations"
-    },
-    "connection": {
-      "selectionPath": [
-        "conversations"
+          },
+        },
       ],
-      "forwardCountVariable": "conversationsForwardCount",
-      "forwardCursorVariable": "conversationsAfterCursor"
-    }
-  }
-};
-})();
+      v11 = {
+        kind: "Name",
+        value: "node",
+      },
+      v12 = [
+        {
+          kind: "Argument",
+          name: v8 /*: any*/,
+          value: v9 /*: any*/,
+        },
+      ],
+      v13 = {
+        kind: "Name",
+        value: "__typename",
+      },
+      v14 = {
+        kind: "Field",
+        name: v13 /*: any*/,
+      },
+      v15 = {
+        kind: "Name",
+        value: "compiledHooks_ForwardPaginationFragment_pmmUt",
+      },
+      v16 = {
+        kind: "FragmentSpread",
+        name: v15 /*: any*/,
+      },
+      v17 = {
+        kind: "Field",
+        name: v8 /*: any*/,
+      },
+      v18 = {
+        kind: "Name",
+        value: "compiledHooks_BackwardPaginationFragment",
+      },
+      v19 = {
+        kind: "Name",
+        value: "connection",
+      },
+      v20 = {
+        kind: "Name",
+        value: "key",
+      },
+      v21 = {
+        kind: "Name",
+        value: "edges",
+      },
+      v22 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "cursor",
+        },
+      },
+      v23 = {
+        kind: "Name",
+        value: "pageInfo",
+      },
+      v24 = {
+        kind: "NamedType",
+        name: {
+          kind: "Name",
+          value: "NodeWithPetAvatarAndConversations",
+        },
+      },
+      v25 = {
+        kind: "Field",
+        alias: {
+          kind: "Name",
+          value: "__isNodeWithPetAvatarAndConversations",
+        },
+        name: v13 /*: any*/,
+      },
+      v26 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "petName",
+        },
+      },
+      v27 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "avatarUrl",
+        },
+        arguments: [
+          {
+            kind: "Argument",
+            name: {
+              kind: "Name",
+              value: "size",
+            },
+            value: v1 /*: any*/,
+          },
+        ],
+      },
+      v28 = {
+        kind: "Name",
+        value: "conversations",
+      },
+      v29 = [
+        {
+          kind: "Argument",
+          name: {
+            kind: "Name",
+            value: "first",
+          },
+          value: v5 /*: any*/,
+        },
+        {
+          kind: "Argument",
+          name: {
+            kind: "Name",
+            value: "after",
+          },
+          value: v3 /*: any*/,
+        },
+      ],
+      v30 = [
+        {
+          kind: "Directive",
+          name: v19 /*: any*/,
+          arguments: [
+            {
+              kind: "Argument",
+              name: v20 /*: any*/,
+              value: {
+                kind: "StringValue",
+                value: "compiledHooks_user_conversations",
+                block: false,
+              },
+            },
+          ],
+        },
+      ],
+      v31 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "title",
+        },
+      },
+      v32 = {
+        kind: "Field",
+        name: v23 /*: any*/,
+        selectionSet: {
+          kind: "SelectionSet",
+          selections: [
+            {
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "endCursor",
+              },
+            },
+            {
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "hasNextPage",
+              },
+            },
+          ],
+        },
+      },
+      v33 = {
+        kind: "InlineFragment",
+        typeCondition: {
+          kind: "NamedType",
+          name: {
+            kind: "Name",
+            value: "Node",
+          },
+        },
+        selectionSet: {
+          kind: "SelectionSet",
+          selections: [
+            {
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "__fragments",
+              },
+              directives: [
+                {
+                  kind: "Directive",
+                  name: {
+                    kind: "Name",
+                    value: "client",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+    return {
+      executionQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v10 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v11 /*: any*/,
+                  arguments: v12 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [v14 /*: any*/, v16 /*: any*/, v17 /*: any*/],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v18 /*: any*/,
+            typeCondition: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Conversation",
+              },
+            },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: {
+                    kind: "Name",
+                    value: "messages",
+                  },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "last",
+                      },
+                      value: v6 /*: any*/,
+                    },
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "before",
+                      },
+                      value: v7 /*: any*/,
+                    },
+                  ],
+                  directives: [
+                    {
+                      kind: "Directive",
+                      name: v19 /*: any*/,
+                      arguments: [
+                        {
+                          kind: "Argument",
+                          name: v20 /*: any*/,
+                          value: {
+                            kind: "StringValue",
+                            value: "compiledHooks_conversation_messages",
+                            block: false,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: v21 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: v11 /*: any*/,
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: {
+                                      kind: "Name",
+                                      value: "text",
+                                    },
+                                  },
+                                  v17 /*: any*/,
+                                  v14 /*: any*/,
+                                ],
+                              },
+                            },
+                            v22 /*: any*/,
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: v23 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "hasPreviousPage",
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "startCursor",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                v17 /*: any*/,
+              ],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v15 /*: any*/,
+            typeCondition: v24 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                v25 /*: any*/,
+                v26 /*: any*/,
+                v27 /*: any*/,
+                {
+                  kind: "Field",
+                  name: v28 /*: any*/,
+                  arguments: v29 /*: any*/,
+                  directives: v30 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: v21 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: v11 /*: any*/,
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  v31 /*: any*/,
+                                  {
+                                    kind: "FragmentSpread",
+                                    name: v18 /*: any*/,
+                                  },
+                                  v17 /*: any*/,
+                                  v14 /*: any*/,
+                                ],
+                              },
+                            },
+                            v22 /*: any*/,
+                          ],
+                        },
+                      },
+                      v32 /*: any*/,
+                    ],
+                  },
+                },
+                v17 /*: any*/,
+              ],
+            },
+          },
+        ],
+      },
+      watchQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v10 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v11 /*: any*/,
+                  arguments: v12 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      v14 /*: any*/,
+                      v16 /*: any*/,
+                      v17 /*: any*/,
+                      v33 /*: any*/,
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v15 /*: any*/,
+            typeCondition: v24 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                v25 /*: any*/,
+                v26 /*: any*/,
+                v27 /*: any*/,
+                {
+                  kind: "Field",
+                  name: v28 /*: any*/,
+                  arguments: v29 /*: any*/,
+                  directives: v30 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: v21 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: v11 /*: any*/,
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  v31 /*: any*/,
+                                  v17 /*: any*/,
+                                  v14 /*: any*/,
+                                  v33 /*: any*/,
+                                ],
+                              },
+                            },
+                            v22 /*: any*/,
+                          ],
+                        },
+                      },
+                      v32 /*: any*/,
+                    ],
+                  },
+                },
+                v17 /*: any*/,
+              ],
+            },
+          },
+        ],
+      },
+      metadata: {
+        rootSelection: "node",
+        mainFragment: {
+          name: "compiledHooks_ForwardPaginationFragment_pmmUt",
+          typeCondition: "NodeWithPetAvatarAndConversations",
+        },
+        connection: {
+          selectionPath: ["conversations"],
+          forwardCountVariable: "conversationsForwardCount",
+          forwardCursorVariable: "conversationsAfterCursor",
+        },
+      },
+    };
+  })();
 
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_QueryTypeFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_QueryTypeFragment.graphql.ts
@@ -4,17 +4,17 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_QueryTypeFragment = {
-    readonly nonNode: {
-        readonly id: string | null;
-    };
-    readonly " $refType": "compiledHooks_QueryTypeFragment";
+  readonly nonNode: {
+    readonly id: string | null;
+  };
+  readonly " $fragmentType": "compiledHooks_QueryTypeFragment";
 };
-export type compiledHooks_QueryTypeFragment$data = compiledHooks_QueryTypeFragment;
+export type compiledHooks_QueryTypeFragment$data =
+  compiledHooks_QueryTypeFragment;
 export type compiledHooks_QueryTypeFragment$key = {
-    readonly " $data"?: compiledHooks_QueryTypeFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_QueryTypeFragment">;
+  readonly " $data"?: compiledHooks_QueryTypeFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_QueryTypeFragment">;
 };
-
 
 import { documents } from "./compiledHooks_QueryTypeWatchNodeQuery.graphql";
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_RefetchableFragment.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_RefetchableFragment.graphql.ts
@@ -4,17 +4,17 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_RefetchableFragment = {
-    readonly petName: string;
-    readonly avatarUrl: string;
-    readonly id: string;
-    readonly " $refType": "compiledHooks_RefetchableFragment";
+  readonly petName: string;
+  readonly avatarUrl: string;
+  readonly id: string;
+  readonly " $fragmentType": "compiledHooks_RefetchableFragment";
 };
-export type compiledHooks_RefetchableFragment$data = compiledHooks_RefetchableFragment;
+export type compiledHooks_RefetchableFragment$data =
+  compiledHooks_RefetchableFragment;
 export type compiledHooks_RefetchableFragment$key = {
-    readonly " $data"?: compiledHooks_RefetchableFragment$data | undefined;
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_RefetchableFragment">;
+  readonly " $data"?: compiledHooks_RefetchableFragment$data | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_RefetchableFragment">;
 };
-
 
 import { documents } from "./compiledHooks_RefetchableFragment_RefetchQuery.graphql";
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_RefetchableFragment_RefetchQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_RefetchableFragment_RefetchQuery.graphql.ts
@@ -4,19 +4,18 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_RefetchableFragment_RefetchQueryVariables = {
-    avatarSize: number;
-    id: string;
+  avatarSize: number;
+  id: string;
 };
 export type compiledHooks_RefetchableFragment_RefetchQueryResponse = {
-    readonly node: {
-        readonly " $fragmentRefs": FragmentRefs<"compiledHooks_RefetchableFragment">;
-    } | null;
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_RefetchableFragment">;
+  } | null;
 };
 export type compiledHooks_RefetchableFragment_RefetchQuery = {
-    readonly response: compiledHooks_RefetchableFragment_RefetchQueryResponse;
-    readonly variables: compiledHooks_RefetchableFragment_RefetchQueryVariables;
+  readonly response: compiledHooks_RefetchableFragment_RefetchQueryResponse;
+  readonly variables: compiledHooks_RefetchableFragment_RefetchQueryVariables;
 };
-
 
 /*
 query compiledHooks_RefetchableFragment_RefetchQuery($avatarSize: Int!, $id: ID!) {
@@ -53,227 +52,224 @@ fragment compiledHooks_RefetchableFragment on User {
 }
 */
 
-export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule = (function(){
-var v0 = {
-  "kind": "Name",
-  "value": "compiledHooks_RefetchableFragment_RefetchQuery"
-},
-v1 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "avatarSize"
-  }
-},
-v2 = {
-  "kind": "Name",
-  "value": "id"
-},
-v3 = {
-  "kind": "Variable",
-  "name": (v2/*: any*/)
-},
-v4 = [
-  {
-    "kind": "VariableDefinition",
-    "variable": (v1/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "Int"
-        }
-      }
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v3/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "ID"
-        }
-      }
-    }
-  }
-],
-v5 = {
-  "kind": "Name",
-  "value": "node"
-},
-v6 = [
-  {
-    "kind": "Argument",
-    "name": (v2/*: any*/),
-    "value": (v3/*: any*/)
-  }
-],
-v7 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "__typename"
-  }
-},
-v8 = {
-  "kind": "Name",
-  "value": "compiledHooks_RefetchableFragment"
-},
-v9 = {
-  "kind": "FragmentSpread",
-  "name": (v8/*: any*/)
-},
-v10 = {
-  "kind": "Field",
-  "name": (v2/*: any*/)
-},
-v11 = {
-  "kind": "FragmentDefinition",
-  "name": (v8/*: any*/),
-  "typeCondition": {
-    "kind": "NamedType",
-    "name": {
-      "kind": "Name",
-      "value": "User"
-    }
-  },
-  "selectionSet": {
-    "kind": "SelectionSet",
-    "selections": [
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "petName"
-        }
+export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule =
+  (function () {
+    var v0 = {
+        kind: "Name",
+        value: "compiledHooks_RefetchableFragment_RefetchQuery",
       },
-      {
-        "kind": "Field",
-        "name": {
-          "kind": "Name",
-          "value": "avatarUrl"
+      v1 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "avatarSize",
         },
-        "arguments": [
-          {
-            "kind": "Argument",
-            "name": {
-              "kind": "Name",
-              "value": "size"
+      },
+      v2 = {
+        kind: "Name",
+        value: "id",
+      },
+      v3 = {
+        kind: "Variable",
+        name: v2 /*: any*/,
+      },
+      v4 = [
+        {
+          kind: "VariableDefinition",
+          variable: v1 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Int",
+              },
             },
-            "value": (v1/*: any*/)
-          }
-        ]
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v3 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "ID",
+              },
+            },
+          },
+        },
+      ],
+      v5 = {
+        kind: "Name",
+        value: "node",
       },
-      (v10/*: any*/)
-    ]
-  }
-};
-return {
-  "executionQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v4/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v5/*: any*/),
-              "arguments": (v6/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v7/*: any*/),
-                  (v9/*: any*/),
-                  (v10/*: any*/)
-                ]
-              }
-            }
-          ]
-        }
+      v6 = [
+        {
+          kind: "Argument",
+          name: v2 /*: any*/,
+          value: v3 /*: any*/,
+        },
+      ],
+      v7 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "__typename",
+        },
       },
-      (v11/*: any*/)
-    ]
-  },
-  "watchQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v4/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
+      v8 = {
+        kind: "Name",
+        value: "compiledHooks_RefetchableFragment",
+      },
+      v9 = {
+        kind: "FragmentSpread",
+        name: v8 /*: any*/,
+      },
+      v10 = {
+        kind: "Field",
+        name: v2 /*: any*/,
+      },
+      v11 = {
+        kind: "FragmentDefinition",
+        name: v8 /*: any*/,
+        typeCondition: {
+          kind: "NamedType",
+          name: {
+            kind: "Name",
+            value: "User",
+          },
+        },
+        selectionSet: {
+          kind: "SelectionSet",
+          selections: [
             {
-              "kind": "Field",
-              "name": (v5/*: any*/),
-              "arguments": (v6/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v7/*: any*/),
-                  (v9/*: any*/),
-                  (v10/*: any*/),
-                  {
-                    "kind": "InlineFragment",
-                    "typeCondition": {
-                      "kind": "NamedType",
-                      "name": {
-                        "kind": "Name",
-                        "value": "Node"
-                      }
-                    },
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "__fragments"
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "petName",
+              },
+            },
+            {
+              kind: "Field",
+              name: {
+                kind: "Name",
+                value: "avatarUrl",
+              },
+              arguments: [
+                {
+                  kind: "Argument",
+                  name: {
+                    kind: "Name",
+                    value: "size",
+                  },
+                  value: v1 /*: any*/,
+                },
+              ],
+            },
+            v10 /*: any*/,
+          ],
+        },
+      };
+    return {
+      executionQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v4 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v5 /*: any*/,
+                  arguments: v6 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [v7 /*: any*/, v9 /*: any*/, v10 /*: any*/],
+                  },
+                },
+              ],
+            },
+          },
+          v11 /*: any*/,
+        ],
+      },
+      watchQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v4 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v5 /*: any*/,
+                  arguments: v6 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      v7 /*: any*/,
+                      v9 /*: any*/,
+                      v10 /*: any*/,
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "Node",
                           },
-                          "directives": [
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
                             {
-                              "kind": "Directive",
-                              "name": {
-                                "kind": "Name",
-                                "value": "client"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "__fragments",
+                              },
+                              directives: [
+                                {
+                                  kind: "Directive",
+                                  name: {
+                                    kind: "Name",
+                                    value: "client",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          v11 /*: any*/,
+        ],
       },
-      (v11/*: any*/)
-    ]
-  },
-  "metadata": {
-    "rootSelection": "node",
-    "mainFragment": {
-      "name": "compiledHooks_RefetchableFragment",
-      "typeCondition": "User"
-    }
-  }
-};
-})();
+      metadata: {
+        rootSelection: "node",
+        mainFragment: {
+          name: "compiledHooks_RefetchableFragment",
+          typeCondition: "User",
+        },
+      },
+    };
+  })();
 
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
@@ -4,24 +4,27 @@
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
 export type compiledHooks_Root_executionQueryVariables = {
-    userId: number;
-    avatarSize?: number | null | undefined;
-    messagesBackwardCount: number;
-    messagesBeforeCursor: string;
-    id?: string | null | undefined;
+  userId: number;
+  avatarSize?: number | null | undefined;
+  messagesBackwardCount: number;
+  messagesBeforeCursor: string;
+  id?: string | null | undefined;
 };
 export type compiledHooks_Root_executionQueryResponse = {
-    readonly user: {
-        readonly name: string;
-        readonly " $fragmentRefs": FragmentRefs<"compiledHooks_ChildFragment" | "compiledHooks_RefetchableFragment" | "compiledHooks_ForwardPaginationFragment">;
-    };
-    readonly " $fragmentRefs": FragmentRefs<"compiledHooks_QueryTypeFragment">;
+  readonly user: {
+    readonly name: string;
+    readonly " $fragmentSpreads": FragmentRefs<
+      | "compiledHooks_ChildFragment"
+      | "compiledHooks_RefetchableFragment"
+      | "compiledHooks_ForwardPaginationFragment"
+    >;
+  };
+  readonly " $fragmentSpreads": FragmentRefs<"compiledHooks_QueryTypeFragment">;
 };
 export type compiledHooks_Root_executionQuery = {
-    readonly response: compiledHooks_Root_executionQueryResponse;
-    readonly variables: compiledHooks_Root_executionQueryVariables;
+  readonly response: compiledHooks_Root_executionQueryResponse;
+  readonly variables: compiledHooks_Root_executionQueryVariables;
 };
-
 
 /*
 query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId") {
@@ -106,632 +109,622 @@ query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $m
 }
 */
 
-export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule = (function(){
-var v0 = {
-  "kind": "Name",
-  "value": "compiledHooks_Root_executionQuery"
-},
-v1 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "userId"
-  }
-},
-v2 = {
-  "kind": "NamedType",
-  "name": {
-    "kind": "Name",
-    "value": "Int"
-  }
-},
-v3 = {
-  "kind": "NonNullType",
-  "type": (v2/*: any*/)
-},
-v4 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "avatarSize"
-  }
-},
-v5 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBackwardCount"
-  }
-},
-v6 = {
-  "kind": "Variable",
-  "name": {
-    "kind": "Name",
-    "value": "messagesBeforeCursor"
-  }
-},
-v7 = {
-  "kind": "NamedType",
-  "name": {
-    "kind": "Name",
-    "value": "String"
-  }
-},
-v8 = {
-  "kind": "Name",
-  "value": "id"
-},
-v9 = {
-  "kind": "Variable",
-  "name": (v8/*: any*/)
-},
-v10 = [
-  {
-    "kind": "VariableDefinition",
-    "variable": (v1/*: any*/),
-    "type": (v3/*: any*/)
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v4/*: any*/),
-    "type": (v2/*: any*/),
-    "defaultValue": {
-      "kind": "IntValue",
-      "value": "21"
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v5/*: any*/),
-    "type": (v3/*: any*/)
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v6/*: any*/),
-    "type": {
-      "kind": "NonNullType",
-      "type": (v7/*: any*/)
-    }
-  },
-  {
-    "kind": "VariableDefinition",
-    "variable": (v9/*: any*/),
-    "type": (v7/*: any*/),
-    "defaultValue": {
-      "kind": "StringValue",
-      "value": "shouldNotOverrideCompiledFragmentId",
-      "block": false
-    }
-  }
-],
-v11 = {
-  "kind": "Name",
-  "value": "user"
-},
-v12 = [
-  {
-    "kind": "Argument",
-    "name": (v8/*: any*/),
-    "value": (v1/*: any*/)
-  },
-  {
-    "kind": "Argument",
-    "name": {
-      "kind": "Name",
-      "value": "idThatDoesntOverride"
-    },
-    "value": (v9/*: any*/)
-  }
-],
-v13 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "name"
-  }
-},
-v14 = {
-  "kind": "Name",
-  "value": "compiledHooks_ChildFragment"
-},
-v15 = {
-  "kind": "Name",
-  "value": "compiledHooks_RefetchableFragment"
-},
-v16 = {
-  "kind": "Name",
-  "value": "compiledHooks_ForwardPaginationFragment"
-},
-v17 = {
-  "kind": "Field",
-  "name": (v8/*: any*/)
-},
-v18 = {
-  "kind": "Name",
-  "value": "compiledHooks_QueryTypeFragment"
-},
-v19 = {
-  "kind": "Name",
-  "value": "compiledHooks_BackwardPaginationFragment"
-},
-v20 = {
-  "kind": "Name",
-  "value": "connection"
-},
-v21 = {
-  "kind": "Name",
-  "value": "key"
-},
-v22 = {
-  "kind": "Name",
-  "value": "edges"
-},
-v23 = {
-  "kind": "Name",
-  "value": "node"
-},
-v24 = {
-  "kind": "Name",
-  "value": "__typename"
-},
-v25 = {
-  "kind": "Field",
-  "name": (v24/*: any*/)
-},
-v26 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "cursor"
-  }
-},
-v27 = {
-  "kind": "Name",
-  "value": "pageInfo"
-},
-v28 = {
-  "kind": "NamedType",
-  "name": {
-    "kind": "Name",
-    "value": "User"
-  }
-},
-v29 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "petName"
-  }
-},
-v30 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "avatarUrl"
-  },
-  "arguments": [
-    {
-      "kind": "Argument",
-      "name": {
-        "kind": "Name",
-        "value": "size"
+export const documents: import("@graphitation/apollo-react-relay-duct-tape-compiler").CompiledArtefactModule =
+  (function () {
+    var v0 = {
+        kind: "Name",
+        value: "compiledHooks_Root_executionQuery",
       },
-      "value": (v4/*: any*/)
-    }
-  ]
-},
-v31 = {
-  "kind": "Field",
-  "name": {
-    "kind": "Name",
-    "value": "__fragments"
-  },
-  "directives": [
-    {
-      "kind": "Directive",
-      "name": {
-        "kind": "Name",
-        "value": "client"
-      }
-    }
-  ]
-};
-return {
-  "executionQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v10/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v11/*: any*/),
-              "arguments": (v12/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v13/*: any*/),
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v14/*: any*/)
-                  },
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v15/*: any*/)
-                  },
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v16/*: any*/)
-                  },
-                  (v17/*: any*/)
-                ]
-              }
-            },
-            {
-              "kind": "FragmentSpread",
-              "name": (v18/*: any*/)
-            }
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v19/*: any*/),
-        "typeCondition": {
-          "kind": "NamedType",
-          "name": {
-            "kind": "Name",
-            "value": "Conversation"
-          }
+      v1 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "userId",
         },
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "messages"
-              },
-              "arguments": [
+      },
+      v2 = {
+        kind: "NamedType",
+        name: {
+          kind: "Name",
+          value: "Int",
+        },
+      },
+      v3 = {
+        kind: "NonNullType",
+        type: v2 /*: any*/,
+      },
+      v4 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "avatarSize",
+        },
+      },
+      v5 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBackwardCount",
+        },
+      },
+      v6 = {
+        kind: "Variable",
+        name: {
+          kind: "Name",
+          value: "messagesBeforeCursor",
+        },
+      },
+      v7 = {
+        kind: "NamedType",
+        name: {
+          kind: "Name",
+          value: "String",
+        },
+      },
+      v8 = {
+        kind: "Name",
+        value: "id",
+      },
+      v9 = {
+        kind: "Variable",
+        name: v8 /*: any*/,
+      },
+      v10 = [
+        {
+          kind: "VariableDefinition",
+          variable: v1 /*: any*/,
+          type: v3 /*: any*/,
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v4 /*: any*/,
+          type: v2 /*: any*/,
+          defaultValue: {
+            kind: "IntValue",
+            value: "21",
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v5 /*: any*/,
+          type: v3 /*: any*/,
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v6 /*: any*/,
+          type: {
+            kind: "NonNullType",
+            type: v7 /*: any*/,
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: v9 /*: any*/,
+          type: v7 /*: any*/,
+          defaultValue: {
+            kind: "StringValue",
+            value: "shouldNotOverrideCompiledFragmentId",
+            block: false,
+          },
+        },
+      ],
+      v11 = {
+        kind: "Name",
+        value: "user",
+      },
+      v12 = [
+        {
+          kind: "Argument",
+          name: v8 /*: any*/,
+          value: v1 /*: any*/,
+        },
+        {
+          kind: "Argument",
+          name: {
+            kind: "Name",
+            value: "idThatDoesntOverride",
+          },
+          value: v9 /*: any*/,
+        },
+      ],
+      v13 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "name",
+        },
+      },
+      v14 = {
+        kind: "Name",
+        value: "compiledHooks_ChildFragment",
+      },
+      v15 = {
+        kind: "Name",
+        value: "compiledHooks_RefetchableFragment",
+      },
+      v16 = {
+        kind: "Name",
+        value: "compiledHooks_ForwardPaginationFragment",
+      },
+      v17 = {
+        kind: "Field",
+        name: v8 /*: any*/,
+      },
+      v18 = {
+        kind: "Name",
+        value: "compiledHooks_QueryTypeFragment",
+      },
+      v19 = {
+        kind: "Name",
+        value: "compiledHooks_BackwardPaginationFragment",
+      },
+      v20 = {
+        kind: "Name",
+        value: "connection",
+      },
+      v21 = {
+        kind: "Name",
+        value: "key",
+      },
+      v22 = {
+        kind: "Name",
+        value: "edges",
+      },
+      v23 = {
+        kind: "Name",
+        value: "node",
+      },
+      v24 = {
+        kind: "Name",
+        value: "__typename",
+      },
+      v25 = {
+        kind: "Field",
+        name: v24 /*: any*/,
+      },
+      v26 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "cursor",
+        },
+      },
+      v27 = {
+        kind: "Name",
+        value: "pageInfo",
+      },
+      v28 = {
+        kind: "NamedType",
+        name: {
+          kind: "Name",
+          value: "User",
+        },
+      },
+      v29 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "petName",
+        },
+      },
+      v30 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "avatarUrl",
+        },
+        arguments: [
+          {
+            kind: "Argument",
+            name: {
+              kind: "Name",
+              value: "size",
+            },
+            value: v4 /*: any*/,
+          },
+        ],
+      },
+      v31 = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "__fragments",
+        },
+        directives: [
+          {
+            kind: "Directive",
+            name: {
+              kind: "Name",
+              value: "client",
+            },
+          },
+        ],
+      };
+    return {
+      executionQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v10 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
                 {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "last"
+                  kind: "Field",
+                  name: v11 /*: any*/,
+                  arguments: v12 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      v13 /*: any*/,
+                      {
+                        kind: "FragmentSpread",
+                        name: v14 /*: any*/,
+                      },
+                      {
+                        kind: "FragmentSpread",
+                        name: v15 /*: any*/,
+                      },
+                      {
+                        kind: "FragmentSpread",
+                        name: v16 /*: any*/,
+                      },
+                      v17 /*: any*/,
+                    ],
                   },
-                  "value": (v5/*: any*/)
                 },
                 {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "before"
-                  },
-                  "value": (v6/*: any*/)
-                }
-              ],
-              "directives": [
-                {
-                  "kind": "Directive",
-                  "name": (v20/*: any*/),
-                  "arguments": [
-                    {
-                      "kind": "Argument",
-                      "name": (v21/*: any*/),
-                      "value": {
-                        "kind": "StringValue",
-                        "value": "compiledHooks_conversation_messages",
-                        "block": false
-                      }
-                    }
-                  ]
-                }
-              ],
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v22/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": (v23/*: any*/),
-                          "selectionSet": {
-                            "kind": "SelectionSet",
-                            "selections": [
-                              {
-                                "kind": "Field",
-                                "name": {
-                                  "kind": "Name",
-                                  "value": "text"
-                                }
-                              },
-                              (v17/*: any*/),
-                              (v25/*: any*/)
-                            ]
-                          }
-                        },
-                        (v26/*: any*/)
-                      ]
-                    }
-                  },
-                  {
-                    "kind": "Field",
-                    "name": (v27/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "hasPreviousPage"
-                          }
-                        },
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "startCursor"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            (v17/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v14/*: any*/),
-        "typeCondition": (v28/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v29/*: any*/),
-            (v17/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v16/*: any*/),
-        "typeCondition": {
-          "kind": "NamedType",
-          "name": {
-            "kind": "Name",
-            "value": "NodeWithPetAvatarAndConversations"
-          }
-        },
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "alias": {
-                "kind": "Name",
-                "value": "__isNodeWithPetAvatarAndConversations"
-              },
-              "name": (v24/*: any*/)
-            },
-            (v29/*: any*/),
-            (v30/*: any*/),
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "conversations"
-              },
-              "arguments": [
-                {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "first"
-                  },
-                  "value": {
-                    "kind": "IntValue",
-                    "value": "1"
-                  }
+                  kind: "FragmentSpread",
+                  name: v18 /*: any*/,
                 },
-                {
-                  "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "after"
-                  },
-                  "value": {
-                    "kind": "StringValue",
-                    "value": "",
-                    "block": false
-                  }
-                }
               ],
-              "directives": [
-                {
-                  "kind": "Directive",
-                  "name": (v20/*: any*/),
-                  "arguments": [
-                    {
-                      "kind": "Argument",
-                      "name": (v21/*: any*/),
-                      "value": {
-                        "kind": "StringValue",
-                        "value": "compiledHooks_user_conversations",
-                        "block": false
-                      }
-                    }
-                  ]
-                }
-              ],
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  {
-                    "kind": "Field",
-                    "name": (v22/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": (v23/*: any*/),
-                          "selectionSet": {
-                            "kind": "SelectionSet",
-                            "selections": [
-                              {
-                                "kind": "Field",
-                                "name": {
-                                  "kind": "Name",
-                                  "value": "title"
-                                }
-                              },
-                              {
-                                "kind": "FragmentSpread",
-                                "name": (v19/*: any*/)
-                              },
-                              (v17/*: any*/),
-                              (v25/*: any*/)
-                            ]
-                          }
-                        },
-                        (v26/*: any*/)
-                      ]
-                    }
-                  },
-                  {
-                    "kind": "Field",
-                    "name": (v27/*: any*/),
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "endCursor"
-                          }
-                        },
-                        {
-                          "kind": "Field",
-                          "name": {
-                            "kind": "Name",
-                            "value": "hasNextPage"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
             },
-            (v17/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v18/*: any*/),
-        "typeCondition": {
-          "kind": "NamedType",
-          "name": {
-            "kind": "Name",
-            "value": "Query"
-          }
-        },
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": {
-                "kind": "Name",
-                "value": "nonNode"
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v19 /*: any*/,
+            typeCondition: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Conversation",
               },
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v17/*: any*/)
-                ]
-              }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v15/*: any*/),
-        "typeCondition": (v28/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v29/*: any*/),
-            (v30/*: any*/),
-            (v17/*: any*/)
-          ]
-        }
-      }
-    ]
-  },
-  "watchQueryDocument": {
-    "kind": "Document",
-    "definitions": [
-      {
-        "kind": "OperationDefinition",
-        "operation": "query",
-        "name": (v0/*: any*/),
-        "variableDefinitions": (v10/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            {
-              "kind": "Field",
-              "name": (v11/*: any*/),
-              "arguments": (v12/*: any*/),
-              "selectionSet": {
-                "kind": "SelectionSet",
-                "selections": [
-                  (v13/*: any*/),
-                  (v17/*: any*/),
-                  {
-                    "kind": "InlineFragment",
-                    "typeCondition": {
-                      "kind": "NamedType",
-                      "name": {
-                        "kind": "Name",
-                        "value": "Node"
-                      }
+            },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: {
+                    kind: "Name",
+                    value: "messages",
+                  },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "last",
+                      },
+                      value: v5 /*: any*/,
                     },
-                    "selectionSet": {
-                      "kind": "SelectionSet",
-                      "selections": [
-                        (v31/*: any*/)
-                      ]
-                    }
-                  }
-                ]
-              }
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "before",
+                      },
+                      value: v6 /*: any*/,
+                    },
+                  ],
+                  directives: [
+                    {
+                      kind: "Directive",
+                      name: v20 /*: any*/,
+                      arguments: [
+                        {
+                          kind: "Argument",
+                          name: v21 /*: any*/,
+                          value: {
+                            kind: "StringValue",
+                            value: "compiledHooks_conversation_messages",
+                            block: false,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: v22 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: v23 /*: any*/,
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: {
+                                      kind: "Name",
+                                      value: "text",
+                                    },
+                                  },
+                                  v17 /*: any*/,
+                                  v25 /*: any*/,
+                                ],
+                              },
+                            },
+                            v26 /*: any*/,
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: v27 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "hasPreviousPage",
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "startCursor",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                v17 /*: any*/,
+              ],
             },
-            (v31/*: any*/)
-          ]
-        }
-      }
-    ]
-  }
-};
-})();
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v14 /*: any*/,
+            typeCondition: v28 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [v29 /*: any*/, v17 /*: any*/],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v16 /*: any*/,
+            typeCondition: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "NodeWithPetAvatarAndConversations",
+              },
+            },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  alias: {
+                    kind: "Name",
+                    value: "__isNodeWithPetAvatarAndConversations",
+                  },
+                  name: v24 /*: any*/,
+                },
+                v29 /*: any*/,
+                v30 /*: any*/,
+                {
+                  kind: "Field",
+                  name: {
+                    kind: "Name",
+                    value: "conversations",
+                  },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "first",
+                      },
+                      value: {
+                        kind: "IntValue",
+                        value: "1",
+                      },
+                    },
+                    {
+                      kind: "Argument",
+                      name: {
+                        kind: "Name",
+                        value: "after",
+                      },
+                      value: {
+                        kind: "StringValue",
+                        value: "",
+                        block: false,
+                      },
+                    },
+                  ],
+                  directives: [
+                    {
+                      kind: "Directive",
+                      name: v20 /*: any*/,
+                      arguments: [
+                        {
+                          kind: "Argument",
+                          name: v21 /*: any*/,
+                          value: {
+                            kind: "StringValue",
+                            value: "compiledHooks_user_conversations",
+                            block: false,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: v22 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: v23 /*: any*/,
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: {
+                                      kind: "Name",
+                                      value: "title",
+                                    },
+                                  },
+                                  {
+                                    kind: "FragmentSpread",
+                                    name: v19 /*: any*/,
+                                  },
+                                  v17 /*: any*/,
+                                  v25 /*: any*/,
+                                ],
+                              },
+                            },
+                            v26 /*: any*/,
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: v27 /*: any*/,
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "endCursor",
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: {
+                                kind: "Name",
+                                value: "hasNextPage",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                v17 /*: any*/,
+              ],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v18 /*: any*/,
+            typeCondition: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Query",
+              },
+            },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: {
+                    kind: "Name",
+                    value: "nonNode",
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [v17 /*: any*/],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "FragmentDefinition",
+            name: v15 /*: any*/,
+            typeCondition: v28 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [v29 /*: any*/, v30 /*: any*/, v17 /*: any*/],
+            },
+          },
+        ],
+      },
+      watchQueryDocument: {
+        kind: "Document",
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: v0 /*: any*/,
+            variableDefinitions: v10 /*: any*/,
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: v11 /*: any*/,
+                  arguments: v12 /*: any*/,
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      v13 /*: any*/,
+                      v17 /*: any*/,
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "Node",
+                          },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [v31 /*: any*/],
+                        },
+                      },
+                    ],
+                  },
+                },
+                v31 /*: any*/,
+              ],
+            },
+          },
+        ],
+      },
+    };
+  })();
 
 export default documents;

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/shallowCompareFragmentReferences.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/shallowCompareFragmentReferences.ts
@@ -31,7 +31,7 @@ import invariant from "invariant";
  */
 export function shallowCompareFragmentReferences<
   K extends string,
-  ComparatorParam extends { [key in K]: { " $fragmentRefs": unknown } },
+  ComparatorParam extends { [key in K]: { " $fragmentSpreads": unknown } },
 >(
   ...fragmentReferenceProps: K[]
 ): (prevProps: ComparatorParam, nextProps: ComparatorParam) => boolean {

--- a/packages/apollo-react-relay-duct-tape/src/types.ts
+++ b/packages/apollo-react-relay-duct-tape/src/types.ts
@@ -43,11 +43,11 @@ export type FetchPolicy =
  */
 
 export interface _RefType<Ref extends string> {
-  " $refType": Ref;
+  " $fragmentType": Ref;
 }
 
 export interface _FragmentRefs<Refs extends string> {
-  " $fragmentRefs": FragmentRefs<Refs>;
+  " $fragmentSpreads": FragmentRefs<Refs>;
 }
 
 // This is used in the actual artifacts to define the various fragment references a container holds.
@@ -68,7 +68,7 @@ export type FragmentReference = unknown;
 
 export type KeyType<TData = unknown> = Readonly<{
   " $data"?: TData;
-  " $fragmentRefs": FragmentReference;
+  " $fragmentSpreads": FragmentReference;
 }>;
 
 export type KeyTypeData<


### PR DESCRIPTION
In Relay Compiler >=15.0.0, the generated types have two differences:
- `$fragmentSpreads` instead of `$fragmentRefs` 
- `$fragmentType` instead of `$refType`

Here you can see an example, of the same file, once generated with duct-tape-compiler and once with relay-compiler (>=15.0.0)

| duct-tape-compiler  |  relay-compiler  |
|---|---|
| ![image](https://github.com/microsoft/graphitation/assets/43915731/7e0f47e1-34df-40e2-87dc-9d90216f5317) | ![image](https://github.com/microsoft/graphitation/assets/43915731/8d409391-d62d-42d8-b42c-f17c604071f2)  |

The scope of this PR is to align those types with the latest version, so other apps will avoid having typescript differences between those versions