### PR TITLE
Fix rule compatibility with newer version of graphql-eslint plugin

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-9e96ee74-8abf-4996-b769-fbdabc593ca5.json
+++ b/change/@graphitation-graphql-eslint-rules-9e96ee74-8abf-4996-b769-fbdabc593ca5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes lint rule compatibility with newer version of eslint plugin",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
+++ b/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
@@ -57,12 +57,6 @@ function checkRequiredParameters(
     );
   }
 
-  if (!context.parserServices.hasTypeInfo) {
-    throw new Error(
-      `Rule '${ruleName}' requires 'parserOptions.schema' to be set and schema to be loaded. See http://bit.ly/graphql-eslint-schema for more info`,
-    );
-  }
-
   if (!context.options[0]?.typePolicies) {
     throw new Error(
       `Rule '${ruleName}' requires option 'typePolicies' to be set.`,


### PR DESCRIPTION
Removes unused check in the lint rule that breaks in newer version of the plugin.