### PR TITLE
Add artifactDirectory option support to embedded-document-artefact-loader/ts-jest

### DIFF
--- a/change/@graphitation-embedded-document-artefact-loader-12b10da8-592d-4657-b0b2-50a40585c63d.json
+++ b/change/@graphitation-embedded-document-artefact-loader-12b10da8-592d-4657-b0b2-50a40585c63d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add artifactDirectory option support to ts-jest",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "mwanginjuguna59@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/embedded-document-artefact-loader/README.md
+++ b/packages/embedded-document-artefact-loader/README.md
@@ -63,6 +63,21 @@ const jestConfig = {
 };
 ```
 
+If you are using the `artifactDirectory` option in your relay config you will need to direct the loader to the same folder.
+
+```js
+const jestConfig = {
+  transform: {
+    "^.+\\.tsx?$": [
+      "@graphitation/embedded-document-artefact-loader/ts-jest",
+      {
+        artifactDirectory: "path/to/your/artifact/directory",
+      },
+    ],
+  },
+};
+```
+
 ## TODO
 
 - SourceMap support needs to be finished

--- a/packages/embedded-document-artefact-loader/src/ts-jest.ts
+++ b/packages/embedded-document-artefact-loader/src/ts-jest.ts
@@ -7,9 +7,13 @@ import type {
   SyncTransformer,
   TransformedSource,
 } from "@jest/transform";
-import type { TsJestGlobalOptions } from "ts-jest";
+import type { TsJestTransformerOptions, TsJestGlobalOptions } from "ts-jest";
 import { extractInlineSourceMap } from "./addInlineSourceMap";
 import { applySourceMap } from "./source-map-utils";
+
+type Options = TsJestTransformerOptions & {
+  artifactDirectory?: string;
+};
 
 const transformerFactory: TransformerFactory<SyncTransformer<unknown>> = {
   createTransformer(config) {
@@ -24,6 +28,7 @@ const transformerFactory: TransformerFactory<SyncTransformer<unknown>> = {
           generateSourceMap,
           sourcePath,
           sourceText,
+          options.transformerConfig as Options,
         );
 
         const tsResult = tsLoaderInstance.process(
@@ -44,6 +49,7 @@ const transformerFactory: TransformerFactory<SyncTransformer<unknown>> = {
           generateSourceMap,
           sourcePath,
           sourceText,
+          options.transformerConfig as Options,
         );
 
         const tsResult = await tsLoaderInstance.processAsync(
@@ -89,10 +95,11 @@ function applyTransform(
   generateSourceMap: boolean,
   sourcePath: string,
   sourceText: string,
+  options: Options,
 ) {
   const sourceMap = generateSourceMap ? new SourceMapGenerator() : undefined;
   sourceMap?.setSourceContent(sourcePath, sourceText);
-  const transformed = transform(sourceText, sourcePath, sourceMap);
+  const transformed = transform(sourceText, sourcePath, sourceMap, options);
   return { transformed, sourceMap };
 }
 


### PR DESCRIPTION
Adds support for explicitly passing `artifactDirectory` option in jest-config when using artifactDirectory in relay config.