### PR TITLE
Revert afterFieldResolve hook invocation

### DIFF
--- a/change/@graphitation-supermassive-9ce86754-6e03-40f7-b3aa-aff8ceddef1f.json
+++ b/change/@graphitation-supermassive-9ce86754-6e03-40f7-b3aa-aff8ceddef1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert back changes in execution where afterFieldResolve hook can return promise if async",
+  "packageName": "@graphitation/supermassive",
+  "email": "sergeystoyan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/hooks.test.ts
+++ b/packages/supermassive/src/__tests__/hooks.test.ts
@@ -16,7 +16,6 @@ import type {
   ExecutionHooks,
 } from "../hooks/types";
 import { pathToArray } from "../jsutils/Path";
-import { isPromise } from "../jsutils/isPromise";
 
 interface TestCase {
   name: string;
@@ -302,6 +301,23 @@ describe.each([
         query: `
         {
           film(id: 1) {
+            title
+          }
+        }`,
+        resolvers: resolvers as UserResolvers,
+        expectedHookCalls: [
+          "BFR|film",
+          "AFR|film|[object]|undefined",
+          "AFC|film|[object]|undefined",
+        ],
+        resultHasErrors: false,
+      },
+      {
+        name: "do not invoke hooks for the __typename",
+        query: `
+        {
+          film(id: 1) {
+            __typename
             title
           }
         }`,

--- a/packages/supermassive/src/__tests__/hooks.test.ts
+++ b/packages/supermassive/src/__tests__/hooks.test.ts
@@ -99,14 +99,17 @@ describe.each([
           ({
             resolveInfo,
             result,
+            error,
           }: AfterFieldResolveHookArgs<unknown, unknown>) => {
-            const resultValue = isPromise(result) // result is a promise for async resolvers
-              ? "[promise]"
-              : typeof result === "object" && result !== null
-              ? "[object]"
-              : result;
+            const resultValue =
+              typeof result === "object" && result !== null
+                ? "[object]"
+                : result;
+            const errorMessage = error instanceof Error ? error.message : error;
             hookCalls.push(
-              `AFR|${pathToArray(resolveInfo.path).join(".")}|${resultValue}`,
+              `AFR|${pathToArray(resolveInfo.path).join(
+                ".",
+              )}|${resultValue}|${errorMessage}`,
             );
           },
         ),
@@ -156,9 +159,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|person",
-          "AFR|person|[object]",
+          "AFR|person|[object]|undefined",
           "BFR|person.name",
-          "AFR|person.name|Luke Skywalker",
+          "AFR|person.name|Luke Skywalker|undefined",
           "AFC|person.name|Luke Skywalker|undefined",
           "AFC|person|[object]|undefined",
         ],
@@ -182,9 +185,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|person",
-          "AFR|person|[object]",
+          "AFR|person|[object]|undefined",
           "BFR|person.name",
-          "AFR|person.name|[promise]",
+          "AFR|person.name|Luke Skywalker|undefined",
           "AFC|person.name|Luke Skywalker|undefined",
           "AFC|person|[object]|undefined",
         ],
@@ -208,9 +211,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|film",
-          "AFR|film|[object]",
+          "AFR|film|[object]|undefined",
           "BFR|film.producer",
-          "AFR|film.producer|undefined",
+          "AFR|film.producer|undefined|Resolver error",
           "AFC|film.producer|undefined|Resolver error",
           "AFC|film|[object]|undefined",
         ],
@@ -234,9 +237,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|film",
-          "AFR|film|[object]",
+          "AFR|film|[object]|undefined",
           "BFR|film.producer",
-          "AFR|film.producer|[promise]",
+          "AFR|film.producer|undefined|Resolver error",
           "AFC|film.producer|undefined|Resolver error",
           "AFC|film|[object]|undefined",
         ],
@@ -260,9 +263,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|film",
-          "AFR|film|[object]",
+          "AFR|film|[object]|undefined",
           "BFR|film.title",
-          "AFR|film.title|undefined",
+          "AFR|film.title|undefined|Resolver error",
           "AFC|film.title|undefined|Resolver error",
           "AFC|film|undefined|Resolver error",
         ],
@@ -286,9 +289,9 @@ describe.each([
         } as UserResolvers,
         expectedHookCalls: [
           "BFR|film",
-          "AFR|film|[object]",
+          "AFR|film|[object]|undefined",
           "BFR|film.title",
-          "AFR|film.title|[promise]",
+          "AFR|film.title|undefined|Resolver error",
           "AFC|film.title|undefined|Resolver error",
           "AFC|film|undefined|Resolver error",
         ],
@@ -305,7 +308,7 @@ describe.each([
         resolvers: resolvers as UserResolvers,
         expectedHookCalls: [
           "BFR|film",
-          "AFR|film|[object]",
+          "AFR|film|[object]|undefined",
           "AFC|film|[object]|undefined",
         ],
         resultHasErrors: false,

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -831,7 +831,8 @@ function resolveAndCompleteField(
     path,
   );
 
-  const isDefaultResolverUsed = resolveFn === exeContext.fieldResolver;
+  const isDefaultResolverUsed =
+    resolveFn === exeContext.fieldResolver || fieldName === "__typename";
   const hooks = exeContext.fieldExecutionHooks;
   let hookContext: unknown = undefined;
 

--- a/packages/supermassive/src/hooks/types.ts
+++ b/packages/supermassive/src/hooks/types.ts
@@ -16,13 +16,8 @@ export interface PostExecuteFieldHookArgs<ResolveContext, HookContext>
 
 export interface AfterFieldResolveHookArgs<ResolveContext, HookContext>
   extends PostExecuteFieldHookArgs<ResolveContext, HookContext> {
-  /**
-   * The result of the field execution _before_ completing the value. This
-   * means the result may be a promise that is still pending, and the delta
-   * between the time this hook and the `afterFieldComplete` hook is called
-   * is the time it takes for the promise to resolve.
-   */
-  result?: unknown | Promise<unknown>;
+  result?: unknown;
+  error?: unknown;
 }
 
 export interface AfterFieldCompleteHookArgs<ResolveContext, HookContext>

--- a/packages/supermassive/src/jsutils/printPathArray.ts
+++ b/packages/supermassive/src/jsutils/printPathArray.ts
@@ -2,9 +2,16 @@
  * Build a string describing the path.
  */
 export function printPathArray(path: ReadonlyArray<string | number>): string {
-  return path
-    .map((key) =>
-      typeof key === "number" ? "[" + key.toString() + "]" : "." + key,
-    )
-    .join("");
+  let result = "";
+  for (let i = 0; i < path.length; i++) {
+    if (typeof path[i] === "number") {
+      result += `[${path[i].toString()}]`;
+    } else {
+      if (i > 0) {
+        result += ".";
+      }
+      result += path[i];
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
- Revert back afterFieldResolve hook invocation way: it is called now when the field is actually resolved.
- Do not call execution hooks for `__typename`.
- Minor improvements in `printPathArray`: remove beginning `.` and use `+=` instead of map/join to speed up strings merging.