### PR TITLE
Add new rules

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-ef083cdd-ec57-4bfc-a21c-9f93a7724b0e.json
+++ b/change/@graphitation-graphql-eslint-rules-ef083cdd-ec57-4bfc-a21c-9f93a7724b0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds new eslit rules",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/non-nullable-fields.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/non-nullable-fields.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Invalid #1 1`] = `
+"#### ⌨️ Code
+
+      1 | type ChatMessage {
+      2 |   id: String
+      3 |   content: String
+      4 |   someOtherImportantField: String
+      5 | }
+
+#### ⚙️ Options
+
+    {
+      "fields": [
+        "id",
+        "someOtherImportantField"
+      ]
+    }
+
+#### ❌ Error 1/2
+
+      1 | type ChatMessage {
+    > 2 |   id: String
+        |   ^^^^ Field "id" cannot be nullable.
+      3 |   content: String
+
+#### ❌ Error 2/2
+
+      3 |   content: String
+    > 4 |   someOtherImportantField: String
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^ Field "someOtherImportantField" cannot be nullable.
+      5 | }"
+`;

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/non-nullable-list-items.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/non-nullable-list-items.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Invalid #1 1`] = `
+"#### ⌨️ Code
+
+      1 | type SomeType {
+      2 |   someArray: [Item]
+      3 | }
+
+#### ❌ Error
+
+      1 | type SomeType {
+    > 2 |   someArray: [Item]
+        |              ^^^^^ List items must be not nullable.
+      3 | }"
+`;

--- a/packages/graphql-eslint-rules/src/__tests__/non-nullable-fields.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/non-nullable-fields.test.ts
@@ -1,0 +1,29 @@
+import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
+import rule from "../non-nullable-fields";
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests("non-nullable-fields", rule, {
+  valid: [
+    {
+      code: `
+type ChatMessage {
+  id: String!
+  content: String
+}`,
+      options: [{ fields: ["id"] }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+type ChatMessage {
+  id: String
+  content: String
+  someOtherImportantField: String
+}`,
+      options: [{ fields: ["id", "someOtherImportantField"] }],
+      errors: 2,
+    },
+  ],
+});

--- a/packages/graphql-eslint-rules/src/__tests__/non-nullable-list-items.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/non-nullable-list-items.test.ts
@@ -1,0 +1,24 @@
+import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
+import rule from "../non-nullable-list-items";
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests("non-nullable-list-items", rule, {
+  valid: [
+    {
+      code: `
+type SomeType {
+  someArray: [Item!]
+}`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+type SomeType {
+  someArray: [Item]
+}`,
+      errors: 1,
+    },
+  ],
+});

--- a/packages/graphql-eslint-rules/src/index.ts
+++ b/packages/graphql-eslint-rules/src/index.ts
@@ -8,3 +8,5 @@ import banDirectives from "./ban-directives";
 export { banDirectives as banDirectivesRule };
 import strictNonNullableVariables from "./strict-non-nullable-variables";
 export { strictNonNullableVariables as strictNonNullableVariablesRule };
+import nonNullableFields from "./non-nullable-fields";
+export { nonNullableFields as nonNullableFieldsRule };

--- a/packages/graphql-eslint-rules/src/index.ts
+++ b/packages/graphql-eslint-rules/src/index.ts
@@ -10,3 +10,5 @@ import strictNonNullableVariables from "./strict-non-nullable-variables";
 export { strictNonNullableVariables as strictNonNullableVariablesRule };
 import nonNullableFields from "./non-nullable-fields";
 export { nonNullableFields as nonNullableFieldsRule };
+import nonNullableListItems from "./non-nullable-list-items";
+export { nonNullableListItems as nonNullableListItemsRule };

--- a/packages/graphql-eslint-rules/src/non-nullable-fields.ts
+++ b/packages/graphql-eslint-rules/src/non-nullable-fields.ts
@@ -1,0 +1,56 @@
+import { GraphQLESLintRule } from "@graphql-eslint/eslint-plugin";
+
+interface Options {
+  fields: string[];
+}
+
+const rule: GraphQLESLintRule<[Options]> = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: `Ensures that fields are not nullable`,
+      category: "Schema",
+    },
+    schema: {
+      type: "array",
+      minItems: 1,
+      maxItems: 1,
+      additionalItems: false,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          fields: {
+            type: "array",
+            description: "List of the fields that must be non-nullable",
+            minItems: 1,
+            additionalItems: false,
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+  },
+  create(context) {
+    const { fields } = context.options[0];
+    return {
+      FieldDefinition(node) {
+        const fieldName = node.name?.value;
+        if (!fields.includes(fieldName)) {
+          return;
+        }
+
+        if (node.gqlType.kind !== "NonNullType") {
+          context.report({
+            message: `Field "${fieldName}" cannot be nullable.`,
+            node,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/graphql-eslint-rules/src/non-nullable-list-items.ts
+++ b/packages/graphql-eslint-rules/src/non-nullable-list-items.ts
@@ -1,0 +1,26 @@
+import { GraphQLESLintRule } from "@graphql-eslint/eslint-plugin";
+
+const rule: GraphQLESLintRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: `Ensures that list items are not nullable`,
+      category: "Schema",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ListType(node) {
+        if (node.gqlType.kind !== "NonNullType") {
+          context.report({
+            message: `List items must be not nullable.`,
+            node,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;


### PR DESCRIPTION
Adds new lint rules:
- `non-nullable-fields` - intended to prohibit nullable `id` fields. Since it was too narrow of a use case I made the rule configurable, so it can take a list of fields that for one reason or another shouldn't be nullable.
- `non-nullable-list-items` - does pretty much what the name suggests