### PR TITLE
Naming convention rule

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-a4ed667c-b920-4ee2-b354-0934fed94850.json
+++ b/change/@graphitation-graphql-eslint-rules-a4ed667c-b920-4ee2-b354-0934fed94850.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add naming convention rule based on version from graphql-eslint",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/package.json
+++ b/packages/graphql-eslint-rules/package.json
@@ -20,16 +20,19 @@
     "@types/jest": "^26.0.22",
     "@types/lodash.camelcase": "^4.3.6",
     "@types/lodash.kebabcase": "^4.1.6",
+    "@types/lodash.lowercase": "^4.3.9",
     "graphql": "^15.0.0",
     "json-schema-to-ts": "2.9.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
+    "lodash.lowercase": "^4.3.0",
     "monorepo-scripts": "*"
   },
   "peerDependencies": {
     "graphql": "^15.0.0",
     "lodash.camelcase": "^4.3.0",
-    "lodash.kebabcase": "^4.1.1"
+    "lodash.kebabcase": "^4.1.1",
+    "lodash.lowercase": "^4.3.0"
   },
   "publishConfig": {
     "main": "./lib/index",

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/naming-convention.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/naming-convention.test.ts.snap
@@ -3,6 +3,90 @@
 exports[`Invalid #1 1`] = `
 "#### ⌨️ Code
 
+      1 | type Two_Namespaces_Foo { test: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "Namespaced_PascalCase"
+    }
+
+#### ❌ Error
+
+    > 1 | type Two_Namespaces_Foo { test: String }
+        |      ^^^^^^^^^^^^^^^^^^ Type "Two_Namespaces_Foo" should be in Namespaced_PascalCase format
+
+#### 💡 Suggestion: Rename to \`TwoNamespacesFoo\`
+
+    1 | type TwoNamespacesFoo { test: String }"
+`;
+
+exports[`Invalid #2 1`] = `
+"#### ⌨️ Code
+
+      1 | type Namespaced_foo { test: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "Namespaced_PascalCase"
+    }
+
+#### ❌ Error
+
+    > 1 | type Namespaced_foo { test: String }
+        |      ^^^^^^^^^^^^^^ Type "Namespaced_foo" should be in Namespaced_PascalCase format
+
+#### 💡 Suggestion: Rename to \`NamespacedFoo\`
+
+    1 | type NamespacedFoo { test: String }"
+`;
+
+exports[`Invalid #3 1`] = `
+"#### ⌨️ Code
+
+      1 | type namespaced_Bar { test: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "Namespaced_PascalCase"
+    }
+
+#### ❌ Error
+
+    > 1 | type namespaced_Bar { test: String }
+        |      ^^^^^^^^^^^^^^ Type "namespaced_Bar" should be in Namespaced_PascalCase format
+
+#### 💡 Suggestion: Rename to \`NamespacedBar\`
+
+    1 | type NamespacedBar { test: String }"
+`;
+
+exports[`Invalid #4 1`] = `
+"#### ⌨️ Code
+
+      1 | type baz { test: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "Namespaced_PascalCase"
+    }
+
+#### ❌ Error
+
+    > 1 | type baz { test: String }
+        |      ^^^ Type "baz" should be in Namespaced_PascalCase format
+
+#### 💡 Suggestion: Rename to \`Baz\`
+
+    1 | type Baz { test: String }"
+`;
+
+exports[`Invalid #5 1`] = `
+"#### ⌨️ Code
+
       1 | type b { test: String }
 
 #### ⚙️ Options
@@ -31,7 +115,7 @@ exports[`Invalid #1 1`] = `
     1 | type b { Test: String }"
 `;
 
-exports[`Invalid #2 1`] = `
+exports[`Invalid #6 1`] = `
 "#### ⌨️ Code
 
       1 | type __b { test__: String }
@@ -62,7 +146,7 @@ exports[`Invalid #2 1`] = `
     1 | type __b { test: String }"
 `;
 
-exports[`Invalid #3 1`] = `
+exports[`Invalid #7 1`] = `
 "#### ⌨️ Code
 
       1 | scalar BSONDecimal
@@ -83,7 +167,7 @@ exports[`Invalid #3 1`] = `
     1 | scalar bson_decimal"
 `;
 
-exports[`Invalid #4 1`] = `
+exports[`Invalid #8 1`] = `
 "#### ⌨️ Code
 
       1 | enum B { test }
@@ -114,7 +198,7 @@ exports[`Invalid #4 1`] = `
     1 | enum B { TEST }"
 `;
 
-exports[`Invalid #5 1`] = `
+exports[`Invalid #9 1`] = `
 "#### ⌨️ Code
 
       1 | input test { _Value: String }
@@ -154,7 +238,7 @@ exports[`Invalid #5 1`] = `
     1 | input test { Value: String }"
 `;
 
-exports[`Invalid #6 1`] = `
+exports[`Invalid #10 1`] = `
 "#### ⌨️ Code
 
       1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
@@ -212,7 +296,7 @@ exports[`Invalid #6 1`] = `
     1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWOENUM }"
 `;
 
-exports[`Invalid #7 1`] = `
+exports[`Invalid #11 1`] = `
 "#### ⌨️ Code
 
       1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
@@ -261,7 +345,7 @@ exports[`Invalid #7 1`] = `
     1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE ENUMVALUE_TWO }"
 `;
 
-exports[`Invalid #8 1`] = `
+exports[`Invalid #12 1`] = `
 "#### ⌨️ Code
 
       1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
@@ -340,7 +424,7 @@ exports[`Invalid #8 1`] = `
     1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { C: String }"
 `;
 
-exports[`Invalid #9 1`] = `
+exports[`Invalid #13 1`] = `
 "#### ⌨️ Code
 
       1 | query Foo { foo } query getBar { bar }
@@ -375,7 +459,7 @@ exports[`Invalid #9 1`] = `
     1 | query Foo { foo } query Bar { bar }"
 `;
 
-exports[`Invalid #10 1`] = `
+exports[`Invalid #14 1`] = `
 "#### ⌨️ Code
 
        1 |         type Query {
@@ -1126,7 +1210,7 @@ exports[`Invalid #10 1`] = `
     33 |         }"
 `;
 
-exports[`Invalid #11 1`] = `
+exports[`Invalid #15 1`] = `
 "#### ⌨️ Code
 
        1 |         query TestQuery { test }
@@ -1378,7 +1462,7 @@ exports[`Invalid #11 1`] = `
     13 |         fragment Test on Test { id }"
 `;
 
-exports[`Invalid #12 1`] = `
+exports[`Invalid #16 1`] = `
 "#### ⌨️ Code
 
       1 |         {
@@ -1427,7 +1511,7 @@ exports[`Invalid #12 1`] = `
     8 |         }"
 `;
 
-exports[`Invalid #13 1`] = `
+exports[`Invalid #17 1`] = `
 "#### ⌨️ Code
 
        1 |         scalar Secret
@@ -1543,7 +1627,7 @@ exports[`Invalid #13 1`] = `
     11 |         }"
 `;
 
-exports[`Invalid #14 1`] = `
+exports[`Invalid #18 1`] = `
 "#### ⌨️ Code
 
       1 |         scalar IpAddress

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/naming-convention.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/naming-convention.test.ts.snap
@@ -1,0 +1,1613 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Invalid #1 1`] = `
+"#### ⌨️ Code
+
+      1 | type b { test: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "PascalCase",
+      "FieldDefinition": "PascalCase"
+    }
+
+#### ❌ Error 1/2
+
+    > 1 | type b { test: String }
+        |      ^ Type "b" should be in PascalCase format
+
+#### 💡 Suggestion: Rename to \`B\`
+
+    1 | type B { test: String }
+
+#### ❌ Error 2/2
+
+    > 1 | type b { test: String }
+        |          ^^^^ Field "test" should be in PascalCase format
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+    1 | type b { Test: String }"
+`;
+
+exports[`Invalid #2 1`] = `
+"#### ⌨️ Code
+
+      1 | type __b { test__: String }
+
+#### ⚙️ Options
+
+    {
+      "allowLeadingUnderscore": false,
+      "allowTrailingUnderscore": false
+    }
+
+#### ❌ Error 1/2
+
+    > 1 | type __b { test__: String }
+        |      ^^^ Leading underscores are not allowed
+
+#### 💡 Suggestion: Rename to \`b\`
+
+    1 | type b { test__: String }
+
+#### ❌ Error 2/2
+
+    > 1 | type __b { test__: String }
+        |            ^^^^^^ Trailing underscores are not allowed
+
+#### 💡 Suggestion: Rename to \`test\`
+
+    1 | type __b { test: String }"
+`;
+
+exports[`Invalid #3 1`] = `
+"#### ⌨️ Code
+
+      1 | scalar BSONDecimal
+
+#### ⚙️ Options
+
+    {
+      "ScalarTypeDefinition": "snake_case"
+    }
+
+#### ❌ Error
+
+    > 1 | scalar BSONDecimal
+        |        ^^^^^^^^^^^ Scalar "BSONDecimal" should be in snake_case format
+
+#### 💡 Suggestion: Rename to \`bson_decimal\`
+
+    1 | scalar bson_decimal"
+`;
+
+exports[`Invalid #4 1`] = `
+"#### ⌨️ Code
+
+      1 | enum B { test }
+
+#### ⚙️ Options
+
+    {
+      "EnumTypeDefinition": "camelCase",
+      "EnumValueDefinition": "UPPER_CASE"
+    }
+
+#### ❌ Error 1/2
+
+    > 1 | enum B { test }
+        |      ^ Enumerator "B" should be in camelCase format
+
+#### 💡 Suggestion: Rename to \`b\`
+
+    1 | enum b { test }
+
+#### ❌ Error 2/2
+
+    > 1 | enum B { test }
+        |          ^^^^ Enumeration value "test" should be in UPPER_CASE format
+
+#### 💡 Suggestion: Rename to \`TEST\`
+
+    1 | enum B { TEST }"
+`;
+
+exports[`Invalid #5 1`] = `
+"#### ⌨️ Code
+
+      1 | input test { _Value: String }
+
+#### ⚙️ Options
+
+    {
+      "types": "PascalCase",
+      "InputValueDefinition": "snake_case"
+    }
+
+#### ❌ Error 1/3
+
+    > 1 | input test { _Value: String }
+        |       ^^^^ Input type "test" should be in PascalCase format
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+    1 | input Test { _Value: String }
+
+#### ❌ Error 2/3
+
+    > 1 | input test { _Value: String }
+        |              ^^^^^^ Input property "_Value" should be in snake_case format
+
+#### 💡 Suggestion: Rename to \`_value\`
+
+    1 | input test { _value: String }
+
+#### ❌ Error 3/3
+
+    > 1 | input test { _Value: String }
+        |              ^^^^^^ Leading underscores are not allowed
+
+#### 💡 Suggestion: Rename to \`Value\`
+
+    1 | input test { Value: String }"
+`;
+
+exports[`Invalid #6 1`] = `
+"#### ⌨️ Code
+
+      1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+
+#### ⚙️ Options
+
+    {
+      "ObjectTypeDefinition": {
+        "style": "camelCase"
+      },
+      "FieldDefinition": {
+        "style": "camelCase",
+        "suffix": "AAA"
+      },
+      "EnumValueDefinition": {
+        "style": "camelCase",
+        "suffix": "ENUM"
+      }
+    }
+
+#### ❌ Error 1/4
+
+    > 1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+        |      ^^^^^^^ Type "TypeOne" should be in camelCase format
+
+#### 💡 Suggestion: Rename to \`typeOne\`
+
+    1 | type typeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+
+#### ❌ Error 2/4
+
+    > 1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+        |                ^^^^^^ Field "aField" should have "AAA" suffix
+
+#### 💡 Suggestion: Rename to \`aFieldAAA\`
+
+    1 | type TypeOne { aFieldAAA: String } enum Z { VALUE_ONE VALUE_TWO }
+
+#### ❌ Error 3/4
+
+    > 1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+        |                                          ^^^^^^^^^ Enumeration value "VALUE_ONE" should have "ENUM" suffix
+
+#### 💡 Suggestion: Rename to \`VALUE_ONEENUM\`
+
+    1 | type TypeOne { aField: String } enum Z { VALUE_ONEENUM VALUE_TWO }
+
+#### ❌ Error 4/4
+
+    > 1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }
+        |                                                    ^^^^^^^^^ Enumeration value "VALUE_TWO" should have "ENUM" suffix
+
+#### 💡 Suggestion: Rename to \`VALUE_TWOENUM\`
+
+    1 | type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWOENUM }"
+`;
+
+exports[`Invalid #7 1`] = `
+"#### ⌨️ Code
+
+      1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
+
+#### ⚙️ Options
+
+    {
+      "ObjectTypeDefinition": {
+        "style": "PascalCase"
+      },
+      "FieldDefinition": {
+        "style": "camelCase",
+        "prefix": "Field"
+      },
+      "EnumValueDefinition": {
+        "style": "UPPER_CASE",
+        "prefix": "ENUM"
+      }
+    }
+
+#### ❌ Error 1/3
+
+    > 1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
+        |            ^^^^^^ Field "aField" should have "Field" prefix
+
+#### 💡 Suggestion: Rename to \`FieldaField\`
+
+    1 | type One { FieldaField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
+
+#### ❌ Error 2/3
+
+    > 1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
+        |                                      ^^^^^^^^^^^^^^^^ Enumeration value "A_ENUM_VALUE_ONE" should have "ENUM" prefix
+
+#### 💡 Suggestion: Rename to \`ENUMA_ENUM_VALUE_ONE\`
+
+    1 | type One { aField: String } enum Z { ENUMA_ENUM_VALUE_ONE VALUE_TWO }
+
+#### ❌ Error 3/3
+
+    > 1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }
+        |                                                       ^^^^^^^^^ Enumeration value "VALUE_TWO" should have "ENUM" prefix
+
+#### 💡 Suggestion: Rename to \`ENUMVALUE_TWO\`
+
+    1 | type One { aField: String } enum Z { A_ENUM_VALUE_ONE ENUMVALUE_TWO }"
+`;
+
+exports[`Invalid #8 1`] = `
+"#### ⌨️ Code
+
+      1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+
+#### ⚙️ Options
+
+    {
+      "ObjectTypeDefinition": {
+        "style": "PascalCase",
+        "forbiddenPrefixes": [
+          "On"
+        ]
+      },
+      "FieldDefinition": {
+        "style": "camelCase",
+        "forbiddenPrefixes": [
+          "foo",
+          "bar"
+        ],
+        "forbiddenSuffixes": [
+          "Foo"
+        ]
+      },
+      "FieldDefinition[parent.name.value=Query]": {
+        "style": "camelCase",
+        "forbiddenPrefixes": [
+          "get",
+          "query"
+        ]
+      }
+    }
+
+#### ❌ Error 1/5
+
+    > 1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+        |      ^^^ Type "One" should not have "On" prefix
+
+#### 💡 Suggestion: Rename to \`e\`
+
+    1 | type e { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+
+#### ❌ Error 2/5
+
+    > 1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+        |            ^^^^^^ Field "getFoo" should not have "Foo" suffix
+
+#### 💡 Suggestion: Rename to \`get\`
+
+    1 | type One { get: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+
+#### ❌ Error 3/5
+
+    > 1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+        |                                                            ^^^^ Field "getA" should not have "get" prefix
+
+#### 💡 Suggestion: Rename to \`A\`
+
+    1 | type One { getFoo: String, queryBar: String } type Query { A(id: ID!): String, queryB: String } extend type Query { getC: String }
+
+#### ❌ Error 4/5
+
+    > 1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+        |                                                                                   ^^^^^^ Field "queryB" should not have "query" prefix
+
+#### 💡 Suggestion: Rename to \`B\`
+
+    1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, B: String } extend type Query { getC: String }
+
+#### ❌ Error 5/5
+
+    > 1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }
+        |                                                                                                                        ^^^^ Field "getC" should not have "get" prefix
+
+#### 💡 Suggestion: Rename to \`C\`
+
+    1 | type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { C: String }"
+`;
+
+exports[`Invalid #9 1`] = `
+"#### ⌨️ Code
+
+      1 | query Foo { foo } query getBar { bar }
+
+#### ⚙️ Options
+
+    {
+      "OperationDefinition": {
+        "style": "camelCase",
+        "forbiddenPrefixes": [
+          "get"
+        ]
+      }
+    }
+
+#### ❌ Error 1/2
+
+    > 1 | query Foo { foo } query getBar { bar }
+        |       ^^^ Operation "Foo" should be in camelCase format
+
+#### 💡 Suggestion: Rename to \`foo\`
+
+    1 | query foo { foo } query getBar { bar }
+
+#### ❌ Error 2/2
+
+    > 1 | query Foo { foo } query getBar { bar }
+        |                         ^^^^^^ Operation "getBar" should not have "get" prefix
+
+#### 💡 Suggestion: Rename to \`Bar\`
+
+    1 | query Foo { foo } query Bar { bar }"
+`;
+
+exports[`Invalid #10 1`] = `
+"#### ⌨️ Code
+
+       1 |         type Query {
+       2 |           fieldQuery: ID
+       3 |           queryField: ID
+       4 |           getField: ID
+       5 |         }
+       6 |
+       7 |         type Mutation {
+       8 |           fieldMutation: ID
+       9 |           mutationField: ID
+      10 |         }
+      11 |
+      12 |         type Subscription {
+      13 |           fieldSubscription: ID
+      14 |           subscriptionField: ID
+      15 |         }
+      16 |
+      17 |         enum TestEnum
+      18 |         extend enum EnumTest {
+      19 |           A
+      20 |         }
+      21 |
+      22 |         interface TestInterface
+      23 |         extend interface InterfaceTest {
+      24 |           id: ID
+      25 |         }
+      26 |
+      27 |         union TestUnion
+      28 |         extend union UnionTest = TestInterface
+      29 |
+      30 |         type TestType
+      31 |         extend type TypeTest {
+      32 |           id: ID
+      33 |         }
+
+#### ⚙️ Options
+
+    {
+      "types": "PascalCase",
+      "FieldDefinition": "camelCase",
+      "InputValueDefinition": "camelCase",
+      "Argument": "camelCase",
+      "DirectiveDefinition": "camelCase",
+      "EnumValueDefinition": "UPPER_CASE",
+      "FieldDefinition[parent.name.value=Query]": {
+        "forbiddenPrefixes": [
+          "query",
+          "get"
+        ],
+        "forbiddenSuffixes": [
+          "Query"
+        ]
+      },
+      "FieldDefinition[parent.name.value=Mutation]": {
+        "forbiddenPrefixes": [
+          "mutation"
+        ],
+        "forbiddenSuffixes": [
+          "Mutation"
+        ]
+      },
+      "FieldDefinition[parent.name.value=Subscription]": {
+        "forbiddenPrefixes": [
+          "subscription"
+        ],
+        "forbiddenSuffixes": [
+          "Subscription"
+        ]
+      },
+      "EnumTypeDefinition,EnumTypeExtension": {
+        "forbiddenPrefixes": [
+          "Enum"
+        ],
+        "forbiddenSuffixes": [
+          "Enum"
+        ]
+      },
+      "InterfaceTypeDefinition,InterfaceTypeExtension": {
+        "forbiddenPrefixes": [
+          "Interface"
+        ],
+        "forbiddenSuffixes": [
+          "Interface"
+        ]
+      },
+      "UnionTypeDefinition,UnionTypeExtension": {
+        "forbiddenPrefixes": [
+          "Union"
+        ],
+        "forbiddenSuffixes": [
+          "Union"
+        ]
+      },
+      "ObjectTypeDefinition,ObjectTypeExtension": {
+        "forbiddenPrefixes": [
+          "Type"
+        ],
+        "forbiddenSuffixes": [
+          "Type"
+        ]
+      }
+    }
+
+#### ❌ Error 1/15
+
+      1 |         type Query {
+    > 2 |           fieldQuery: ID
+        |           ^^^^^^^^^^ Field "fieldQuery" should not have "Query" suffix
+      3 |           queryField: ID
+
+#### 💡 Suggestion: Rename to \`field\`
+
+     1 |         type Query {
+     2 |           field: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 2/15
+
+      2 |           fieldQuery: ID
+    > 3 |           queryField: ID
+        |           ^^^^^^^^^^ Field "queryField" should not have "query" prefix
+      4 |           getField: ID
+
+#### 💡 Suggestion: Rename to \`Field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           Field: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 3/15
+
+      3 |           queryField: ID
+    > 4 |           getField: ID
+        |           ^^^^^^^^ Field "getField" should not have "get" prefix
+      5 |         }
+
+#### 💡 Suggestion: Rename to \`Field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           Field: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 4/15
+
+      7 |         type Mutation {
+    > 8 |           fieldMutation: ID
+        |           ^^^^^^^^^^^^^ Field "fieldMutation" should not have "Mutation" suffix
+      9 |           mutationField: ID
+
+#### 💡 Suggestion: Rename to \`field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           field: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 5/15
+
+       8 |           fieldMutation: ID
+    >  9 |           mutationField: ID
+         |           ^^^^^^^^^^^^^ Field "mutationField" should not have "mutation" prefix
+      10 |         }
+
+#### 💡 Suggestion: Rename to \`Field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           Field: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 6/15
+
+      12 |         type Subscription {
+    > 13 |           fieldSubscription: ID
+         |           ^^^^^^^^^^^^^^^^^ Field "fieldSubscription" should not have "Subscription" suffix
+      14 |           subscriptionField: ID
+
+#### 💡 Suggestion: Rename to \`field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           field: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 7/15
+
+      13 |           fieldSubscription: ID
+    > 14 |           subscriptionField: ID
+         |           ^^^^^^^^^^^^^^^^^ Field "subscriptionField" should not have "subscription" prefix
+      15 |         }
+
+#### 💡 Suggestion: Rename to \`Field\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           Field: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 8/15
+
+      16 |
+    > 17 |         enum TestEnum
+         |              ^^^^^^^^ Enumerator "TestEnum" should not have "Enum" suffix
+      18 |         extend enum EnumTest {
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum Test
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 9/15
+
+      17 |         enum TestEnum
+    > 18 |         extend enum EnumTest {
+         |                     ^^^^^^^^ EnumTypeExtension "EnumTest" should not have "Enum" prefix
+      19 |           A
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum Test {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 10/15
+
+      21 |
+    > 22 |         interface TestInterface
+         |                   ^^^^^^^^^^^^^ Interface "TestInterface" should not have "Interface" suffix
+      23 |         extend interface InterfaceTest {
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface Test
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 11/15
+
+      22 |         interface TestInterface
+    > 23 |         extend interface InterfaceTest {
+         |                          ^^^^^^^^^^^^^ InterfaceTypeExtension "InterfaceTest" should not have "Interface" prefix
+      24 |           id: ID
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface Test {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 12/15
+
+      26 |
+    > 27 |         union TestUnion
+         |               ^^^^^^^^^ Union "TestUnion" should not have "Union" suffix
+      28 |         extend union UnionTest = TestInterface
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union Test
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 13/15
+
+      27 |         union TestUnion
+    > 28 |         extend union UnionTest = TestInterface
+         |                      ^^^^^^^^^ UnionTypeExtension "UnionTest" should not have "Union" prefix
+      29 |
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union Test = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 14/15
+
+      29 |
+    > 30 |         type TestType
+         |              ^^^^^^^^ Type "TestType" should not have "Type" suffix
+      31 |         extend type TypeTest {
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type Test
+    31 |         extend type TypeTest {
+    32 |           id: ID
+    33 |         }
+
+#### ❌ Error 15/15
+
+      30 |         type TestType
+    > 31 |         extend type TypeTest {
+         |                     ^^^^^^^^ ObjectTypeExtension "TypeTest" should not have "Type" prefix
+      32 |           id: ID
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         type Query {
+     2 |           fieldQuery: ID
+     3 |           queryField: ID
+     4 |           getField: ID
+     5 |         }
+     6 |
+     7 |         type Mutation {
+     8 |           fieldMutation: ID
+     9 |           mutationField: ID
+    10 |         }
+    11 |
+    12 |         type Subscription {
+    13 |           fieldSubscription: ID
+    14 |           subscriptionField: ID
+    15 |         }
+    16 |
+    17 |         enum TestEnum
+    18 |         extend enum EnumTest {
+    19 |           A
+    20 |         }
+    21 |
+    22 |         interface TestInterface
+    23 |         extend interface InterfaceTest {
+    24 |           id: ID
+    25 |         }
+    26 |
+    27 |         union TestUnion
+    28 |         extend union UnionTest = TestInterface
+    29 |
+    30 |         type TestType
+    31 |         extend type Test {
+    32 |           id: ID
+    33 |         }"
+`;
+
+exports[`Invalid #11 1`] = `
+"#### ⌨️ Code
+
+       1 |         query TestQuery { test }
+       2 |         query QueryTest { test }
+       3 |         query GetQuery { test }
+       4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+       5 |
+       6 |         mutation TestMutation { test }
+       7 |         mutation MutationTest { test }
+       8 |
+       9 |         subscription TestSubscription { test }
+      10 |         subscription SubscriptionTest { test }
+      11 |
+      12 |         fragment TestFragment on Test { id }
+      13 |         fragment FragmentTest on Test { id }
+
+#### ⚙️ Options
+
+    {
+      "VariableDefinition": "camelCase",
+      "OperationDefinition": {
+        "style": "PascalCase",
+        "forbiddenPrefixes": [
+          "Query",
+          "Mutation",
+          "Subscription",
+          "Get"
+        ],
+        "forbiddenSuffixes": [
+          "Query",
+          "Mutation",
+          "Subscription"
+        ]
+      },
+      "FragmentDefinition": {
+        "style": "PascalCase",
+        "forbiddenPrefixes": [
+          "Fragment"
+        ],
+        "forbiddenSuffixes": [
+          "Fragment"
+        ]
+      }
+    }
+
+#### ❌ Error 1/9
+
+    > 1 |         query TestQuery { test }
+        |               ^^^^^^^^^ Operation "TestQuery" should not have "Query" suffix
+      2 |         query QueryTest { test }
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query Test { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 2/9
+
+      1 |         query TestQuery { test }
+    > 2 |         query QueryTest { test }
+        |               ^^^^^^^^^ Operation "QueryTest" should not have "Query" prefix
+      3 |         query GetQuery { test }
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query Test { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 3/9
+
+      2 |         query QueryTest { test }
+    > 3 |         query GetQuery { test }
+        |               ^^^^^^^^ Operation "GetQuery" should not have "Get" prefix
+      4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+
+#### 💡 Suggestion: Rename to \`Query\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query Query { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 4/9
+
+      5 |
+    > 6 |         mutation TestMutation { test }
+        |                  ^^^^^^^^^^^^ Operation "TestMutation" should not have "Mutation" suffix
+      7 |         mutation MutationTest { test }
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation Test { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 5/9
+
+      6 |         mutation TestMutation { test }
+    > 7 |         mutation MutationTest { test }
+        |                  ^^^^^^^^^^^^ Operation "MutationTest" should not have "Mutation" prefix
+      8 |
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation Test { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 6/9
+
+       8 |
+    >  9 |         subscription TestSubscription { test }
+         |                      ^^^^^^^^^^^^^^^^ Operation "TestSubscription" should not have "Subscription" suffix
+      10 |         subscription SubscriptionTest { test }
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription Test { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 7/9
+
+       9 |         subscription TestSubscription { test }
+    > 10 |         subscription SubscriptionTest { test }
+         |                      ^^^^^^^^^^^^^^^^ Operation "SubscriptionTest" should not have "Subscription" prefix
+      11 |
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription Test { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 8/9
+
+      11 |
+    > 12 |         fragment TestFragment on Test { id }
+         |                  ^^^^^^^^^^^^ Fragment "TestFragment" should not have "Fragment" suffix
+      13 |         fragment FragmentTest on Test { id }
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment Test on Test { id }
+    13 |         fragment FragmentTest on Test { id }
+
+#### ❌ Error 9/9
+
+      12 |         fragment TestFragment on Test { id }
+    > 13 |         fragment FragmentTest on Test { id }
+         |                  ^^^^^^^^^^^^ Fragment "FragmentTest" should not have "Fragment" prefix
+
+#### 💡 Suggestion: Rename to \`Test\`
+
+     1 |         query TestQuery { test }
+     2 |         query QueryTest { test }
+     3 |         query GetQuery { test }
+     4 |         query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+     5 |
+     6 |         mutation TestMutation { test }
+     7 |         mutation MutationTest { test }
+     8 |
+     9 |         subscription TestSubscription { test }
+    10 |         subscription SubscriptionTest { test }
+    11 |
+    12 |         fragment TestFragment on Test { id }
+    13 |         fragment Test on Test { id }"
+`;
+
+exports[`Invalid #12 1`] = `
+"#### ⌨️ Code
+
+      1 |         {
+      2 |           test {
+      3 |             _badAlias: foo
+      4 |             badAlias_: bar
+      5 |             _ok
+      6 |             ok_
+      7 |           }
+      8 |         }
+
+#### ❌ Error 1/2
+
+      2 |           test {
+    > 3 |             _badAlias: foo
+        |             ^^^^^^^^^ Leading underscores are not allowed
+      4 |             badAlias_: bar
+
+#### 💡 Suggestion: Rename to \`badAlias\`
+
+    1 |         {
+    2 |           test {
+    3 |             badAlias: foo
+    4 |             badAlias_: bar
+    5 |             _ok
+    6 |             ok_
+    7 |           }
+    8 |         }
+
+#### ❌ Error 2/2
+
+      3 |             _badAlias: foo
+    > 4 |             badAlias_: bar
+        |             ^^^^^^^^^ Trailing underscores are not allowed
+      5 |             _ok
+
+#### 💡 Suggestion: Rename to \`badAlias\`
+
+    1 |         {
+    2 |           test {
+    3 |             _badAlias: foo
+    4 |             badAlias: bar
+    5 |             _ok
+    6 |             ok_
+    7 |           }
+    8 |         }"
+`;
+
+exports[`Invalid #13 1`] = `
+"#### ⌨️ Code
+
+       1 |         scalar Secret
+       2 |
+       3 |         interface Snake {
+       4 |           value: String!
+       5 |         }
+       6 |
+       7 |         type Test {
+       8 |           enabled: Boolean!
+       9 |           secret: Secret!
+      10 |           snake: Snake
+      11 |         }
+
+#### ⚙️ Options
+
+    {
+      "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+        "style": "camelCase",
+        "requiredPrefixes": [
+          "is",
+          "has"
+        ]
+      },
+      "FieldDefinition[gqlType.gqlType.name.value=Secret]": {
+        "requiredPrefixes": [
+          "SUPER_SECRET_"
+        ]
+      },
+      "FieldDefinition[gqlType.name.value=Snake]": {
+        "style": "snake_case",
+        "requiredPrefixes": [
+          "hiss"
+        ]
+      }
+    }
+
+#### ❌ Error 1/3
+
+      7 |         type Test {
+    > 8 |           enabled: Boolean!
+        |           ^^^^^^^ Field "enabled" should have one of the following prefixes: is, has
+      9 |           secret: Secret!
+
+#### 💡 Suggestion 1/2: Rename to \`isEnabled\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           isEnabled: Boolean!
+     9 |           secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### 💡 Suggestion 2/2: Rename to \`hasEnabled\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           hasEnabled: Boolean!
+     9 |           secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### ❌ Error 2/3
+
+       8 |           enabled: Boolean!
+    >  9 |           secret: Secret!
+         |           ^^^^^^ Field "secret" should have one of the following prefixes: SUPER_SECRET_
+      10 |           snake: Snake
+
+#### 💡 Suggestion: Rename to \`SUPER_SECRET_secret\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           enabled: Boolean!
+     9 |           SUPER_SECRET_secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### ❌ Error 3/3
+
+       9 |           secret: Secret!
+    > 10 |           snake: Snake
+         |           ^^^^^ Field "snake" should have one of the following prefixes: hiss
+      11 |         }
+
+#### 💡 Suggestion: Rename to \`hiss_snake\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           enabled: Boolean!
+     9 |           secret: Secret!
+    10 |           hiss_snake: Snake
+    11 |         }"
+`;
+
+exports[`Invalid #14 1`] = `
+"#### ⌨️ Code
+
+      1 |         scalar IpAddress
+      2 |
+      3 |         type Test {
+      4 |           specialFeature: Boolean!
+      5 |           user: IpAddress!
+      6 |         }
+
+#### ⚙️ Options
+
+    {
+      "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+        "style": "camelCase",
+        "requiredSuffixes": [
+          "Enabled",
+          "Disabled"
+        ]
+      },
+      "FieldDefinition[gqlType.gqlType.name.value=IpAddress]": {
+        "requiredSuffixes": [
+          "IpAddress"
+        ]
+      }
+    }
+
+#### ❌ Error 1/2
+
+      3 |         type Test {
+    > 4 |           specialFeature: Boolean!
+        |           ^^^^^^^^^^^^^^ Field "specialFeature" should have one of the following suffixes: Enabled, Disabled
+      5 |           user: IpAddress!
+
+#### 💡 Suggestion 1/2: Rename to \`specialFeatureEnabled\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeatureEnabled: Boolean!
+    5 |           user: IpAddress!
+    6 |         }
+
+#### 💡 Suggestion 2/2: Rename to \`specialFeatureDisabled\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeatureDisabled: Boolean!
+    5 |           user: IpAddress!
+    6 |         }
+
+#### ❌ Error 2/2
+
+      4 |           specialFeature: Boolean!
+    > 5 |           user: IpAddress!
+        |           ^^^^ Field "user" should have one of the following suffixes: IpAddress
+      6 |         }
+
+#### 💡 Suggestion: Rename to \`userIpAddress\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeature: Boolean!
+    5 |           userIpAddress: IpAddress!
+    6 |         }"
+`;

--- a/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
@@ -1,0 +1,527 @@
+import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
+import { rule, RuleOptions } from "../naming-convention";
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests<RuleOptions>("naming-convention", rule, {
+  valid: [
+    {
+      code: /* GraphQL */ `
+        query GetUser($userId: ID!) {
+          user(id: $userId) {
+            id
+            name
+            isViewerFriend
+            profilePicture(size: 50) {
+              ...PictureFragment
+            }
+          }
+        }
+
+        fragment PictureFragment on Picture {
+          uri
+          width
+          height
+        }
+      `,
+      options: [
+        {
+          types: "PascalCase",
+          VariableDefinition: "camelCase",
+          EnumValueDefinition: "UPPER_CASE",
+          OperationDefinition: "PascalCase",
+          FragmentDefinition: "PascalCase",
+        },
+      ],
+    },
+    {
+      code: "type B { test: String }",
+      options: [{ types: "PascalCase" }],
+    },
+    {
+      code: "type my_test_6_t { test: String }",
+      options: [{ types: "snake_case" }],
+    },
+    {
+      code: "type MY_TEST_6_T { test: String }",
+      options: [{ types: "UPPER_CASE" }],
+    },
+    {
+      code: "type B { test: String }",
+      options: [
+        { allowLeadingUnderscore: false, allowTrailingUnderscore: false },
+      ],
+    },
+    {
+      code: "type __B { __test__: String }",
+      options: [
+        {
+          allowLeadingUnderscore: true,
+          allowTrailingUnderscore: true,
+          types: "PascalCase",
+          FieldDefinition: "camelCase",
+        },
+      ],
+    },
+    {
+      code: "scalar BSONDecimal",
+      options: [{ types: "PascalCase" }],
+    },
+    {
+      code: "interface B { test: String }",
+      options: [{ types: "PascalCase" }],
+    },
+    {
+      code: "enum B { TEST }",
+      options: [{ types: "PascalCase", EnumValueDefinition: "UPPER_CASE" }],
+    },
+    {
+      code: "input Test { item: String }",
+      options: [{ types: "PascalCase", InputValueDefinition: "camelCase" }],
+    },
+    "input test { item: String } enum B { Test } interface A { i: String } fragment PictureFragment on Picture { uri } scalar Hello",
+    {
+      code: "type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }",
+      options: [
+        {
+          types: { style: "PascalCase" },
+          FieldDefinition: { style: "camelCase", suffix: "Field" },
+          EnumValueDefinition: { style: "UPPER_CASE", suffix: "" },
+        },
+      ],
+    },
+    {
+      code: "type One { fieldA: String } enum Z { ENUM_VALUE_ONE ENUM_VALUE_TWO }",
+      options: [
+        {
+          types: { style: "PascalCase" },
+          FieldDefinition: { style: "camelCase", prefix: "field" },
+          EnumValueDefinition: { style: "UPPER_CASE", prefix: "ENUM_VALUE_" },
+        },
+      ],
+    },
+    {
+      code: "type One { fieldA: String } type Query { QUERY_A(id: ID!): String }",
+      options: [
+        {
+          "FieldDefinition[parent.name.value=Query]": {
+            style: "UPPER_CASE",
+            prefix: "QUERY",
+          },
+          "FieldDefinition[parent.name.value!=Query]": {
+            style: "camelCase",
+            prefix: "field",
+          },
+        },
+      ],
+    },
+    {
+      code: "query { foo }",
+      options: [{ OperationDefinition: { style: "PascalCase" } }],
+    },
+    "{ test { __typename ok_ } }",
+    {
+      // name: "should ignore fields",
+      code: /* GraphQL */ `
+        type Test {
+          EU: ID
+          EUIntlFlag: ID
+          IE: ID
+          IEIntlFlag: ID
+          GB: ID
+          UKFlag: ID
+          UKService_Badge: ID
+          CCBleaching: ID
+          CCDryCleaning: ID
+          CCIroning: ID
+          UPC: ID
+          CMWA: ID
+          EAN13: ID
+        }
+      `,
+      options: [
+        {
+          FieldDefinition: {
+            style: "camelCase",
+            ignorePattern: "^(EU|IE|GB|UK|CC|UPC|CMWA|EAN13)",
+          },
+        },
+      ],
+    },
+    {
+      // name: "ignore enum value exceptions based on enum name, not value",
+      code: /* GraphQL */ `
+        enum Test {
+          FOO
+          BAR
+          BAZ
+        }
+
+        enum Ignored {
+          foo
+          bar
+        }
+      `,
+      options: [
+        {
+          EnumValueDefinition: {
+            style: "UPPER_CASE",
+            ignorePattern: "^Ignored",
+          },
+        },
+      ],
+    },
+    {
+      // name: "should allow single letter for camelCase",
+      code: "type t",
+      options: [{ ObjectTypeDefinition: "camelCase" }],
+    },
+    {
+      // name: "should allow single letter for PascalCase",
+      code: "type T",
+      options: [{ ObjectTypeDefinition: "PascalCase" }],
+    },
+    {
+      // name: "should allow single letter for snake_case",
+      code: "type t",
+      options: [{ ObjectTypeDefinition: "snake_case" }],
+    },
+    {
+      // name: "should allow single letter for UPPER_CASE",
+      code: "type T",
+      options: [{ ObjectTypeDefinition: "UPPER_CASE" }],
+    },
+    {
+      code: /* GraphQL */ `
+        scalar Secret
+
+        interface Snake {
+          value: String!
+        }
+
+        type Test {
+          isEnabled: Boolean!
+          SUPER_SECRET_secret: Secret!
+          hiss_snake: Snake
+        }
+      `,
+      options: [
+        {
+          "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+            style: "camelCase",
+            requiredPrefixes: ["is", "has"],
+          },
+          "FieldDefinition[gqlType.gqlType.name.value=Secret]": {
+            requiredPrefixes: ["SUPER_SECRET_"],
+          },
+          "FieldDefinition[gqlType.name.value=Snake]": {
+            style: "snake_case",
+            requiredPrefixes: ["hiss_"],
+          },
+        },
+      ],
+    },
+    {
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeatureEnabled: Boolean!
+          userIpAddress: IpAddress!
+        }
+      `,
+      options: [
+        {
+          "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+            style: "camelCase",
+            requiredSuffixes: ["Enabled", "Disabled"],
+          },
+          "FieldDefinition[gqlType.gqlType.name.value=IpAddress]": {
+            requiredSuffixes: ["IpAddress"],
+          },
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: "type b { test: String }",
+      options: [{ types: "PascalCase", FieldDefinition: "PascalCase" }],
+      errors: [
+        { message: 'Type "b" should be in PascalCase format' },
+        { message: 'Field "test" should be in PascalCase format' },
+      ],
+    },
+    {
+      code: "type __b { test__: String }",
+      options: [
+        { allowLeadingUnderscore: false, allowTrailingUnderscore: false },
+      ],
+      errors: [
+        { message: "Leading underscores are not allowed" },
+        { message: "Trailing underscores are not allowed" },
+      ],
+    },
+    {
+      code: "scalar BSONDecimal",
+      options: [{ ScalarTypeDefinition: "snake_case" }],
+      errors: [
+        { message: 'Scalar "BSONDecimal" should be in snake_case format' },
+      ],
+    },
+    {
+      code: "enum B { test }",
+      options: [
+        {
+          EnumTypeDefinition: "camelCase",
+          EnumValueDefinition: "UPPER_CASE",
+        },
+      ],
+      errors: [
+        { message: 'Enumerator "B" should be in camelCase format' },
+        { message: 'Enumeration value "test" should be in UPPER_CASE format' },
+      ],
+    },
+    {
+      code: "input test { _Value: String }",
+      options: [{ types: "PascalCase", InputValueDefinition: "snake_case" }],
+      errors: [
+        { message: 'Input type "test" should be in PascalCase format' },
+        { message: 'Input property "_Value" should be in snake_case format' },
+        { message: "Leading underscores are not allowed" },
+      ],
+    },
+    {
+      code: "type TypeOne { aField: String } enum Z { VALUE_ONE VALUE_TWO }",
+      options: [
+        {
+          ObjectTypeDefinition: { style: "camelCase" },
+          FieldDefinition: { style: "camelCase", suffix: "AAA" },
+          EnumValueDefinition: { style: "camelCase", suffix: "ENUM" },
+        },
+      ],
+      errors: [
+        { message: 'Type "TypeOne" should be in camelCase format' },
+        { message: 'Field "aField" should have "AAA" suffix' },
+        { message: 'Enumeration value "VALUE_ONE" should have "ENUM" suffix' },
+        { message: 'Enumeration value "VALUE_TWO" should have "ENUM" suffix' },
+      ],
+    },
+    {
+      code: "type One { aField: String } enum Z { A_ENUM_VALUE_ONE VALUE_TWO }",
+      options: [
+        {
+          ObjectTypeDefinition: { style: "PascalCase" },
+          FieldDefinition: { style: "camelCase", prefix: "Field" },
+          EnumValueDefinition: { style: "UPPER_CASE", prefix: "ENUM" },
+        },
+      ],
+      errors: [
+        { message: 'Field "aField" should have "Field" prefix' },
+        {
+          message:
+            'Enumeration value "A_ENUM_VALUE_ONE" should have "ENUM" prefix',
+        },
+        { message: 'Enumeration value "VALUE_TWO" should have "ENUM" prefix' },
+      ],
+    },
+    {
+      code: "type One { getFoo: String, queryBar: String } type Query { getA(id: ID!): String, queryB: String } extend type Query { getC: String }",
+      options: [
+        {
+          ObjectTypeDefinition: {
+            style: "PascalCase",
+            forbiddenPrefixes: ["On"],
+          },
+          FieldDefinition: {
+            style: "camelCase",
+            forbiddenPrefixes: ["foo", "bar"],
+            forbiddenSuffixes: ["Foo"],
+          },
+          "FieldDefinition[parent.name.value=Query]": {
+            style: "camelCase",
+            forbiddenPrefixes: ["get", "query"],
+          },
+        },
+      ],
+      errors: [
+        { message: 'Type "One" should not have "On" prefix' },
+        { message: 'Field "getFoo" should not have "Foo" suffix' },
+        { message: 'Field "getA" should not have "get" prefix' },
+        { message: 'Field "queryB" should not have "query" prefix' },
+        { message: 'Field "getC" should not have "get" prefix' },
+      ],
+    },
+    {
+      code: "query Foo { foo } query getBar { bar }",
+      options: [
+        {
+          OperationDefinition: {
+            style: "camelCase",
+            forbiddenPrefixes: ["get"],
+          },
+        },
+      ],
+      errors: [
+        { message: 'Operation "Foo" should be in camelCase format' },
+        { message: 'Operation "getBar" should not have "get" prefix' },
+      ],
+    },
+    {
+      // name: "schema-recommended config",
+      code: /* GraphQL */ `
+        type Query {
+          fieldQuery: ID
+          queryField: ID
+          getField: ID
+        }
+
+        type Mutation {
+          fieldMutation: ID
+          mutationField: ID
+        }
+
+        type Subscription {
+          fieldSubscription: ID
+          subscriptionField: ID
+        }
+
+        enum TestEnum
+        extend enum EnumTest {
+          A
+        }
+
+        interface TestInterface
+        extend interface InterfaceTest {
+          id: ID
+        }
+
+        union TestUnion
+        extend union UnionTest = TestInterface
+
+        type TestType
+        extend type TypeTest {
+          id: ID
+        }
+      `,
+      options: (rule.meta.docs!.configOptions as any).schema,
+      errors: 15,
+    },
+    {
+      // name: "operations-recommended config",
+      code: `
+        query TestQuery { test }
+        query QueryTest { test }
+        query GetQuery { test }
+        query Test { test(CONTROLLED_BY_SCHEMA: 0) }
+
+        mutation TestMutation { test }
+        mutation MutationTest { test }
+
+        subscription TestSubscription { test }
+        subscription SubscriptionTest { test }
+
+        fragment TestFragment on Test { id }
+        fragment FragmentTest on Test { id }
+      `,
+      options: (rule.meta.docs!.configOptions as any).operations,
+      errors: [
+        { message: 'Operation "TestQuery" should not have "Query" suffix' },
+        { message: 'Operation "QueryTest" should not have "Query" prefix' },
+        { message: 'Operation "GetQuery" should not have "Get" prefix' },
+        {
+          message: 'Operation "TestMutation" should not have "Mutation" suffix',
+        },
+        {
+          message: 'Operation "MutationTest" should not have "Mutation" prefix',
+        },
+        {
+          message:
+            'Operation "TestSubscription" should not have "Subscription" suffix',
+        },
+        {
+          message:
+            'Operation "SubscriptionTest" should not have "Subscription" prefix',
+        },
+        {
+          message: 'Fragment "TestFragment" should not have "Fragment" suffix',
+        },
+        {
+          message: 'Fragment "FragmentTest" should not have "Fragment" prefix',
+        },
+      ],
+    },
+    {
+      // name: "should ignore selections fields but check alias renaming",
+      code: /* GraphQL */ `
+        {
+          test {
+            _badAlias: foo
+            badAlias_: bar
+            _ok
+            ok_
+          }
+        }
+      `,
+      errors: [
+        { message: "Leading underscores are not allowed" },
+        { message: "Trailing underscores are not allowed" },
+      ],
+    },
+    {
+      // name: "should error when selected type names do not match require prefixes",
+      code: /* GraphQL */ `
+        scalar Secret
+
+        interface Snake {
+          value: String!
+        }
+
+        type Test {
+          enabled: Boolean!
+          secret: Secret!
+          snake: Snake
+        }
+      `,
+      options: [
+        {
+          "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+            style: "camelCase",
+            requiredPrefixes: ["is", "has"],
+          },
+          "FieldDefinition[gqlType.gqlType.name.value=Secret]": {
+            requiredPrefixes: ["SUPER_SECRET_"],
+          },
+          "FieldDefinition[gqlType.name.value=Snake]": {
+            style: "snake_case",
+            requiredPrefixes: ["hiss"],
+          },
+        },
+      ],
+      errors: 3,
+    },
+    {
+      // name: "should error when selected type names do not match require suffixes",
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeature: Boolean!
+          user: IpAddress!
+        }
+      `,
+      options: [
+        {
+          "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+            style: "camelCase",
+            requiredSuffixes: ["Enabled", "Disabled"],
+          },
+          "FieldDefinition[gqlType.gqlType.name.value=IpAddress]": {
+            requiredSuffixes: ["IpAddress"],
+          },
+        },
+      ],
+      errors: 2,
+    },
+  ],
+});

--- a/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
@@ -39,6 +39,14 @@ ruleTester.runGraphQLTests<RuleOptions>("naming-convention", rule, {
       options: [{ types: "PascalCase" }],
     },
     {
+      code: "type Foo { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+    },
+    {
+      code: "type Namespace_Foo { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+    },
+    {
       code: "type my_test_6_t { test: String }",
       options: [{ types: "snake_case" }],
     },
@@ -244,6 +252,26 @@ ruleTester.runGraphQLTests<RuleOptions>("naming-convention", rule, {
     },
   ],
   invalid: [
+    {
+      code: "type Two_Namespaces_Foo { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+      errors: 1,
+    },
+    {
+      code: "type Namespaced_foo { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+      errors: 1,
+    },
+    {
+      code: "type namespaced_Bar { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+      errors: 1,
+    },
+    {
+      code: "type baz { test: String }",
+      options: [{ types: "Namespaced_PascalCase" }],
+      errors: 1,
+    },
     {
       code: "type b { test: String }",
       options: [{ types: "PascalCase", FieldDefinition: "PascalCase" }],

--- a/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/naming-convention.test.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
-import { rule, RuleOptions } from "../naming-convention";
+import rule, { RuleOptions } from "../naming-convention";
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/graphql-eslint-rules/src/index.ts
+++ b/packages/graphql-eslint-rules/src/index.ts
@@ -8,6 +8,8 @@ import banDirectives from "./ban-directives";
 export { banDirectives as banDirectivesRule };
 import strictNonNullableVariables from "./strict-non-nullable-variables";
 export { strictNonNullableVariables as strictNonNullableVariablesRule };
+import namingConvention from "./naming-convention";
+export { namingConvention as namingConventionRule };
 import nonNullableFields from "./non-nullable-fields";
 export { nonNullableFields as nonNullableFieldsRule };
 import nonNullableListItems from "./non-nullable-list-items";

--- a/packages/graphql-eslint-rules/src/naming-convention.ts
+++ b/packages/graphql-eslint-rules/src/naming-convention.ts
@@ -197,7 +197,7 @@ type PropertySchema = {
 
 type Options = AllowedStyle | PropertySchema;
 
-export const rule: GraphQLESLintRule<RuleOptions> & {
+const rule: GraphQLESLintRule<RuleOptions> & {
   meta: { hasSuggestions: boolean };
 } = {
   meta: {
@@ -460,3 +460,5 @@ export const rule: GraphQLESLintRule<RuleOptions> & {
     return listeners;
   },
 };
+
+export default rule;

--- a/packages/graphql-eslint-rules/src/naming-convention.ts
+++ b/packages/graphql-eslint-rules/src/naming-convention.ts
@@ -29,6 +29,7 @@ type CaseStyle =
   | "camelCase"
   | "kebab-case"
   | "PascalCase"
+  | "Namespaced_PascalCase"
   | "snake_case"
   | "UPPER_CASE";
 
@@ -43,6 +44,7 @@ const convertCase = (style: CaseStyle, str: string): string => {
     case "camelCase":
       return camelCase(str);
     case "PascalCase":
+    case "Namespaced_PascalCase":
       return pascalCase(str);
     case "snake_case":
       return lowerCase(str).replace(/ /g, "_");
@@ -86,11 +88,17 @@ const KindToDisplayName = {
 };
 
 type AllowedKind = keyof typeof KindToDisplayName;
-type AllowedStyle = "camelCase" | "PascalCase" | "snake_case" | "UPPER_CASE";
+type AllowedStyle =
+  | "camelCase"
+  | "PascalCase"
+  | "Namespaced_PascalCase"
+  | "snake_case"
+  | "UPPER_CASE";
 
 const StyleToRegex: Record<AllowedStyle, RegExp> = {
   camelCase: /^[a-z][\dA-Za-z]*$/,
   PascalCase: /^[A-Z][\dA-Za-z]*$/,
+  Namespaced_PascalCase: /^([A-Z][\dA-Za-z]*_)?[A-Z][\dA-Za-z]*$/,
   snake_case: /^[a-z][\d_a-z]*[\da-z]*$/,
   UPPER_CASE: /^[A-Z][\dA-Z_]*[\dA-Z]*$/,
 };

--- a/packages/graphql-eslint-rules/src/naming-convention.ts
+++ b/packages/graphql-eslint-rules/src/naming-convention.ts
@@ -1,0 +1,454 @@
+// https://github.com/dimaMachina/graphql-eslint/blob/master/packages/plugin/src/rules/naming-convention.ts
+import { Kind } from "graphql";
+import { FromSchema } from "json-schema-to-ts";
+import camelCase from "lodash.camelcase";
+import lowerCase from "lodash.lowercase";
+import {
+  GraphQLESLintRule,
+  GraphQLESLintRuleListener,
+} from "@graphql-eslint/eslint-plugin";
+
+const TYPES_KINDS = [
+  Kind.OBJECT_TYPE_DEFINITION,
+  Kind.INTERFACE_TYPE_DEFINITION,
+  Kind.ENUM_TYPE_DEFINITION,
+  Kind.SCALAR_TYPE_DEFINITION,
+  Kind.INPUT_OBJECT_TYPE_DEFINITION,
+  Kind.UNION_TYPE_DEFINITION,
+] as const;
+
+type Truthy<T> = T extends "" | 0 | false | null | undefined ? never : T;
+
+function truthy<T>(value: T): value is Truthy<T> {
+  return !!value;
+}
+
+const englishJoinWords = (words: string[]): string => words.join(", ");
+
+type CaseStyle =
+  | "camelCase"
+  | "kebab-case"
+  | "PascalCase"
+  | "snake_case"
+  | "UPPER_CASE";
+
+const pascalCase = (str: string): string =>
+  lowerCase(str)
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join("");
+
+const convertCase = (style: CaseStyle, str: string): string => {
+  switch (style) {
+    case "camelCase":
+      return camelCase(str);
+    case "PascalCase":
+      return pascalCase(str);
+    case "snake_case":
+      return lowerCase(str).replace(/ /g, "_");
+    case "UPPER_CASE":
+      return lowerCase(str).replace(/ /g, "_").toUpperCase();
+    case "kebab-case":
+      return lowerCase(str).replace(/ /g, "-");
+  }
+};
+
+const ARRAY_DEFAULT_OPTIONS = {
+  type: "array",
+  uniqueItems: true,
+  minItems: 1,
+  items: {
+    type: "string",
+  },
+} as const;
+
+// FIXME https://github.com/dimaMachina/graphql-eslint/blob/5cb2d8f9048cf86a785db6f816113275571bc7ec/packages/plugin/src/estree-converter/types.ts#L123
+type GraphQLESTreeNode = any;
+
+const KindToDisplayName = {
+  // types
+  [Kind.OBJECT_TYPE_DEFINITION]: "Type",
+  [Kind.INTERFACE_TYPE_DEFINITION]: "Interface",
+  [Kind.ENUM_TYPE_DEFINITION]: "Enumerator",
+  [Kind.SCALAR_TYPE_DEFINITION]: "Scalar",
+  [Kind.INPUT_OBJECT_TYPE_DEFINITION]: "Input type",
+  [Kind.UNION_TYPE_DEFINITION]: "Union",
+  // fields
+  [Kind.FIELD_DEFINITION]: "Field",
+  [Kind.INPUT_VALUE_DEFINITION]: "Input property",
+  [Kind.ARGUMENT]: "Argument",
+  [Kind.DIRECTIVE_DEFINITION]: "Directive",
+  // rest
+  [Kind.ENUM_VALUE_DEFINITION]: "Enumeration value",
+  [Kind.OPERATION_DEFINITION]: "Operation",
+  [Kind.FRAGMENT_DEFINITION]: "Fragment",
+  [Kind.VARIABLE_DEFINITION]: "Variable",
+};
+
+type AllowedKind = keyof typeof KindToDisplayName;
+type AllowedStyle = "camelCase" | "PascalCase" | "snake_case" | "UPPER_CASE";
+
+const StyleToRegex: Record<AllowedStyle, RegExp> = {
+  camelCase: /^[a-z][\dA-Za-z]*$/,
+  PascalCase: /^[A-Z][\dA-Za-z]*$/,
+  snake_case: /^[a-z][\d_a-z]*[\da-z]*$/,
+  UPPER_CASE: /^[A-Z][\dA-Z_]*[\dA-Z]*$/,
+};
+
+const ALLOWED_KINDS = Object.keys(KindToDisplayName).sort() as AllowedKind[];
+const ALLOWED_STYLES = Object.keys(StyleToRegex) as AllowedStyle[];
+
+const schemaOption = {
+  oneOf: [
+    { $ref: "#/definitions/asString" },
+    { $ref: "#/definitions/asObject" },
+  ],
+} as const;
+
+const schema = {
+  definitions: {
+    asString: {
+      enum: ALLOWED_STYLES,
+      description: `One of: ${ALLOWED_STYLES.map((t) => `\`${t}\``).join(
+        ", ",
+      )}`,
+    },
+    asObject: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        style: { enum: ALLOWED_STYLES },
+        prefix: { type: "string" },
+        suffix: { type: "string" },
+        forbiddenPrefixes: ARRAY_DEFAULT_OPTIONS,
+        forbiddenSuffixes: ARRAY_DEFAULT_OPTIONS,
+        requiredPrefixes: ARRAY_DEFAULT_OPTIONS,
+        requiredSuffixes: ARRAY_DEFAULT_OPTIONS,
+        ignorePattern: {
+          type: "string",
+          description: "Option to skip validation of some words, e.g. acronyms",
+        },
+      },
+    },
+  },
+  type: "array",
+  maxItems: 1,
+  items: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      types: {
+        ...schemaOption,
+        description: `Includes:\n${TYPES_KINDS.map(
+          (kind) => `- \`${kind}\``,
+        ).join("\n")}`,
+      },
+      ...Object.fromEntries(
+        ALLOWED_KINDS.map((kind) => [
+          kind,
+          {
+            ...schemaOption,
+            description: `Read more about this kind on [spec.graphql.org](https://spec.graphql.org/October2021/#${kind}).`,
+          },
+        ]),
+      ),
+      allowLeadingUnderscore: {
+        type: "boolean",
+        default: false,
+      },
+      allowTrailingUnderscore: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    patternProperties: {
+      [`^(${ALLOWED_KINDS.join("|")})(.+)?$`]: schemaOption,
+    },
+    description: [
+      "> It's possible to use a [`selector`](https://eslint.org/docs/developer-guide/selectors) that starts with allowed `ASTNode` names which are described below.",
+      ">",
+      "> Paste or drop code into the editor in [ASTExplorer](https://astexplorer.net) and inspect the generated AST to compose your selector.",
+      ">",
+      "> Example: pattern property `FieldDefinition[parent.name.value=Query]` will match only fields for type `Query`.",
+    ].join("\n"),
+  },
+} as const;
+
+export type RuleOptions = FromSchema<typeof schema>;
+
+type PropertySchema = {
+  style?: AllowedStyle;
+  suffix?: string;
+  prefix?: string;
+  forbiddenPrefixes?: string[];
+  forbiddenSuffixes?: string[];
+  requiredPrefixes?: string[];
+  requiredSuffixes?: string[];
+  ignorePattern?: string;
+};
+
+type Options = AllowedStyle | PropertySchema;
+
+export const rule: GraphQLESLintRule<RuleOptions> & {
+  meta: { hasSuggestions: boolean };
+} = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Require names to follow specified conventions.",
+      category: ["Schema", "Operations"],
+      recommended: true,
+      url: "https://the-guild.dev/graphql/eslint/rules/naming-convention",
+      examples: [],
+      configOptions: {
+        schema: [
+          {
+            types: "PascalCase",
+            FieldDefinition: "camelCase",
+            InputValueDefinition: "camelCase",
+            Argument: "camelCase",
+            DirectiveDefinition: "camelCase",
+            EnumValueDefinition: "UPPER_CASE",
+            "FieldDefinition[parent.name.value=Query]": {
+              forbiddenPrefixes: ["query", "get"],
+              forbiddenSuffixes: ["Query"],
+            },
+            "FieldDefinition[parent.name.value=Mutation]": {
+              forbiddenPrefixes: ["mutation"],
+              forbiddenSuffixes: ["Mutation"],
+            },
+            "FieldDefinition[parent.name.value=Subscription]": {
+              forbiddenPrefixes: ["subscription"],
+              forbiddenSuffixes: ["Subscription"],
+            },
+            "EnumTypeDefinition,EnumTypeExtension": {
+              forbiddenPrefixes: ["Enum"],
+              forbiddenSuffixes: ["Enum"],
+            },
+            "InterfaceTypeDefinition,InterfaceTypeExtension": {
+              forbiddenPrefixes: ["Interface"],
+              forbiddenSuffixes: ["Interface"],
+            },
+            "UnionTypeDefinition,UnionTypeExtension": {
+              forbiddenPrefixes: ["Union"],
+              forbiddenSuffixes: ["Union"],
+            },
+            "ObjectTypeDefinition,ObjectTypeExtension": {
+              forbiddenPrefixes: ["Type"],
+              forbiddenSuffixes: ["Type"],
+            },
+          },
+        ],
+        operations: [
+          {
+            VariableDefinition: "camelCase",
+            OperationDefinition: {
+              style: "PascalCase",
+              forbiddenPrefixes: ["Query", "Mutation", "Subscription", "Get"],
+              forbiddenSuffixes: ["Query", "Mutation", "Subscription"],
+            },
+            FragmentDefinition: {
+              style: "PascalCase",
+              forbiddenPrefixes: ["Fragment"],
+              forbiddenSuffixes: ["Fragment"],
+            },
+          },
+        ],
+      },
+    },
+    hasSuggestions: true,
+    schema,
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const {
+      allowLeadingUnderscore,
+      allowTrailingUnderscore,
+      types,
+      ...restOptions
+    } = options;
+
+    function normalisePropertyOption(kind: string): PropertySchema {
+      const style = (restOptions[kind] || types) as Options;
+      return typeof style === "object" ? style : { style };
+    }
+
+    function report(
+      node: GraphQLESTreeNode,
+      message: string,
+      suggestedNames: string[],
+    ): void {
+      context.report({
+        node,
+        message,
+        suggest: suggestedNames.map((suggestedName) => ({
+          desc: `Rename to \`${suggestedName}\``,
+          fix: (fixer) => fixer.replaceText(node as any, suggestedName),
+        })),
+      });
+    }
+
+    const checkNode = (selector: string) => (n: GraphQLESTreeNode) => {
+      const { name: node } =
+        n.kind === Kind.VARIABLE_DEFINITION ? n.variable : n;
+      if (!node) {
+        return;
+      }
+      const {
+        prefix,
+        suffix,
+        forbiddenPrefixes,
+        forbiddenSuffixes,
+        style,
+        ignorePattern,
+        requiredPrefixes,
+        requiredSuffixes,
+      } = normalisePropertyOption(selector);
+      const nodeType = (KindToDisplayName as any)[n.kind] || n.kind;
+      const nodeName = node.value;
+      const error = getError();
+      if (error) {
+        const { errorMessage, renameToNames } = error;
+        const [leadingUnderscores] = nodeName.match(/^_*/) as RegExpMatchArray;
+        const [trailingUnderscores] = nodeName.match(/_*$/) as RegExpMatchArray;
+        const suggestedNames = renameToNames.map(
+          (renameToName) =>
+            leadingUnderscores + renameToName + trailingUnderscores,
+        );
+        report(
+          node,
+          `${nodeType} "${nodeName}" should ${errorMessage}`,
+          suggestedNames,
+        );
+      }
+
+      function getError(): {
+        errorMessage: string;
+        renameToNames: string[];
+      } | void {
+        const name = nodeName.replace(/(^_+)|(_+$)/g, "");
+        // ignore enum value definition exceptions based on enum name, not the value itself
+        const ignorePatternTarget =
+          n.kind === Kind.ENUM_VALUE_DEFINITION ? n.parent?.name?.value : name;
+        if (
+          ignorePattern &&
+          new RegExp(ignorePattern, "u").test(ignorePatternTarget)
+        ) {
+          return;
+        }
+
+        if (prefix && !name.startsWith(prefix)) {
+          return {
+            errorMessage: `have "${prefix}" prefix`,
+            renameToNames: [prefix + name],
+          };
+        }
+        if (suffix && !name.endsWith(suffix)) {
+          return {
+            errorMessage: `have "${suffix}" suffix`,
+            renameToNames: [name + suffix],
+          };
+        }
+        const forbiddenPrefix = forbiddenPrefixes?.find((prefix) =>
+          name.startsWith(prefix),
+        );
+        if (forbiddenPrefix) {
+          return {
+            errorMessage: `not have "${forbiddenPrefix}" prefix`,
+            renameToNames: [
+              name.replace(new RegExp(`^${forbiddenPrefix}`), ""),
+            ],
+          };
+        }
+        const forbiddenSuffix = forbiddenSuffixes?.find((suffix) =>
+          name.endsWith(suffix),
+        );
+        if (forbiddenSuffix) {
+          return {
+            errorMessage: `not have "${forbiddenSuffix}" suffix`,
+            renameToNames: [
+              name.replace(new RegExp(`${forbiddenSuffix}$`), ""),
+            ],
+          };
+        }
+        if (
+          requiredPrefixes &&
+          !requiredPrefixes.some((requiredPrefix) =>
+            name.startsWith(requiredPrefix),
+          )
+        ) {
+          return {
+            errorMessage: `have one of the following prefixes: ${englishJoinWords(
+              requiredPrefixes,
+            )}`,
+            renameToNames: style
+              ? requiredPrefixes.map((prefix) =>
+                  convertCase(style, `${prefix} ${name}`),
+                )
+              : requiredPrefixes.map((prefix) => `${prefix}${name}`),
+          };
+        }
+        if (
+          requiredSuffixes &&
+          !requiredSuffixes.some((requiredSuffix) =>
+            name.endsWith(requiredSuffix),
+          )
+        ) {
+          return {
+            errorMessage: `have one of the following suffixes: ${englishJoinWords(
+              requiredSuffixes,
+            )}`,
+            renameToNames: style
+              ? requiredSuffixes.map((suffix) =>
+                  convertCase(style, `${name} ${suffix}`),
+                )
+              : requiredSuffixes.map((suffix) => `${name}${suffix}`),
+          };
+        }
+        // Style is optional
+        if (!style) {
+          return;
+        }
+        const caseRegex = StyleToRegex[style];
+        if (!caseRegex.test(name)) {
+          return {
+            errorMessage: `be in ${style} format`,
+            renameToNames: [convertCase(style, name)],
+          };
+        }
+      }
+    };
+
+    const checkUnderscore =
+      (isLeading: boolean) => (node: GraphQLESTreeNode) => {
+        const suggestedName = node.value.replace(isLeading ? /^_+/ : /_+$/, "");
+        report(
+          node,
+          `${isLeading ? "Leading" : "Trailing"} underscores are not allowed`,
+          [suggestedName],
+        );
+      };
+
+    const listeners: GraphQLESLintRuleListener = {};
+
+    if (!allowLeadingUnderscore) {
+      listeners[
+        "Name[value=/^_/]:matches([parent.kind!=Field], [parent.kind=Field][parent.alias])"
+      ] = checkUnderscore(true);
+    }
+    if (!allowTrailingUnderscore) {
+      listeners[
+        "Name[value=/_$/]:matches([parent.kind!=Field], [parent.kind=Field][parent.alias])"
+      ] = checkUnderscore(false);
+    }
+
+    const selectors = new Set(
+      [types && TYPES_KINDS, Object.keys(restOptions)].flat().filter(truthy),
+    );
+
+    for (const selector of selectors) {
+      listeners[selector] = checkNode(selector);
+    }
+    return listeners;
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3666,6 +3666,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.lowercase@^4.3.9":
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.lowercase/-/lodash.lowercase-4.3.9.tgz#f3d95b446382de2efaf79ccc13de4136ef26739a"
+  integrity sha512-nLcYAb5Rz6SzOeoOWmT1hMDEicMAsRIunDLnCxaWSAjHTsx3Sf8aknbKFIQl+RMevZbGmw2j8qydKb9YcwMExg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*", "@types/lodash@^4.14.175", "@types/lodash@^4.14.176":
   version "4.14.180"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
@@ -5718,7 +5725,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.4, cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.4, cross-fetch@^3.1.5:
+cross-fetch@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
+cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.4:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
@@ -7268,7 +7282,22 @@ glob-hasher@^1.3.0:
     glob-hasher-win32-arm64-msvc "1.3.0"
     glob-hasher-win32-x64-msvc "1.3.0"
 
-glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@^6.0.2, glob-parent@~5.1.2:
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
+glob-parent@^5.1.2, glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -8200,7 +8229,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.1:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
@@ -8233,6 +8262,13 @@ is-glob@4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==
+  dependencies:
+    is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -9823,7 +9859,12 @@ minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@1.2.5, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -9982,14 +10023,24 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.5, node-fetch@^2.6.7:
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.5:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0, node-forge@^1, node-forge@^1.3.1:
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
+node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -10486,6 +10537,11 @@ path-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -12340,11 +12396,6 @@ tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
-
-trim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
-  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 ts-algebra@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
Adds a modified version of [graphql-eslint/naming-convention](https://github.com/dimaMachina/graphql-eslint/blob/master/packages/plugin/src/rules/naming-convention.ts) rule that:
- allows to introduce exception to enum values based on enum name
- adds new `Namespaced_PascalCase` case style