### PR TITLE
Fix refetch function to use new variables instead of old ones 

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-dec4e85d-2d4f-451d-abee-b802e11ab911.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-dec4e85d-2d4f-451d-abee-b802e11ab911.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix refetch function to use new variables instead of old ones when those variables are not defaults",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "scheruiyot@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment_PaginationQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_ForwardPaginationFragment_PaginationQuery.graphql.ts
@@ -31,10 +31,10 @@ export type compiledHooks_ForwardPaginationFragment_PaginationQuery = {
 
 
 /*
-query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!, $conversationsAfterCursor: String! = "", $conversationsForwardCount: Int! = 1, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $sortBy: SortByInput = {sortField: NAME, sortDirection: ASC}, $id: ID!) {
+query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!, $conversationsAfterCursor: String! = "", $conversationsForwardCount: Int! = 1, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $sortBy: SortByInput, $id: ID!) {
   node(id: $id) {
     __typename
-    ...compiledHooks_ForwardPaginationFragment_2AFkol
+    ...compiledHooks_ForwardPaginationFragment_pmmUt
     id
   }
 }
@@ -57,7 +57,7 @@ fragment compiledHooks_BackwardPaginationFragment on Conversation {
   id
 }
 
-fragment compiledHooks_ForwardPaginationFragment_2AFkol on NodeWithPetAvatarAndConversations {
+fragment compiledHooks_ForwardPaginationFragment_pmmUt on NodeWithPetAvatarAndConversations {
   __isNodeWithPetAvatarAndConversations: __typename
   petName
   avatarUrl(size: $avatarSize)
@@ -85,10 +85,10 @@ fragment compiledHooks_ForwardPaginationFragment_2AFkol on NodeWithPetAvatarAndC
 */
 
 /*
-query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!, $conversationsAfterCursor: String! = "", $conversationsForwardCount: Int! = 1, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $sortBy: SortByInput = {sortField: NAME, sortDirection: ASC}, $id: ID!) {
+query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!, $conversationsAfterCursor: String! = "", $conversationsForwardCount: Int! = 1, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $sortBy: SortByInput, $id: ID!) {
   node(id: $id) {
     __typename
-    ...compiledHooks_ForwardPaginationFragment_2AFkol
+    ...compiledHooks_ForwardPaginationFragment_pmmUt
     id
     ... on Node {
       __fragments @client
@@ -96,7 +96,7 @@ query compiledHooks_ForwardPaginationFragment_PaginationQuery($avatarSize: Int!,
   }
 }
 
-fragment compiledHooks_ForwardPaginationFragment_2AFkol on NodeWithPetAvatarAndConversations {
+fragment compiledHooks_ForwardPaginationFragment_pmmUt on NodeWithPetAvatarAndConversations {
   __isNodeWithPetAvatarAndConversations: __typename
   petName
   avatarUrl(size: $avatarSize)
@@ -245,33 +245,6 @@ v12 = [
         "kind": "Name",
         "value": "SortByInput"
       }
-    },
-    "defaultValue": {
-      "kind": "ObjectValue",
-      "fields": [
-        {
-          "kind": "ObjectField",
-          "name": {
-            "kind": "Name",
-            "value": "sortField"
-          },
-          "value": {
-            "kind": "EnumValue",
-            "value": "NAME"
-          }
-        },
-        {
-          "kind": "ObjectField",
-          "name": {
-            "kind": "Name",
-            "value": "sortDirection"
-          },
-          "value": {
-            "kind": "EnumValue",
-            "value": "ASC"
-          }
-        }
-      ]
     }
   },
   {
@@ -310,7 +283,7 @@ v16 = {
 },
 v17 = {
   "kind": "Name",
-  "value": "compiledHooks_ForwardPaginationFragment_2AFkol"
+  "value": "compiledHooks_ForwardPaginationFragment_pmmUt"
 },
 v18 = {
   "kind": "FragmentSpread",
@@ -787,7 +760,7 @@ return {
   "metadata": {
     "rootSelection": "node",
     "mainFragment": {
-      "name": "compiledHooks_ForwardPaginationFragment_2AFkol",
+      "name": "compiledHooks_ForwardPaginationFragment_pmmUt",
       "typeCondition": "NodeWithPetAvatarAndConversations"
     },
     "connection": {
@@ -795,13 +768,7 @@ return {
         "conversations"
       ],
       "forwardCountVariable": "conversationsForwardCount",
-      "forwardCursorVariable": "conversationsAfterCursor",
-      "filterVariableDefaults": {
-        "sortBy": {
-          "sortField": "NAME",
-          "sortDirection": "ASC"
-        }
-      }
+      "forwardCursorVariable": "conversationsAfterCursor"
     }
   }
 };

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__generated__/compiledHooks_Root_executionQuery.graphql.ts
@@ -3,9 +3,15 @@
 // @ts-nocheck
 
 import { FragmentRefs } from "@graphitation/apollo-react-relay-duct-tape";
+export type SortDirection = "ASC" | "DESC";
+export type SortField = "CREATED_AT" | "NAME";
 export type FilterByInput = {
     tag?: string | null | undefined;
     keyword?: string | null | undefined;
+};
+export type SortByInput = {
+    sortDirection: SortDirection;
+    sortField: SortField;
 };
 export type compiledHooks_Root_executionQueryVariables = {
     userId: number;
@@ -14,6 +20,7 @@ export type compiledHooks_Root_executionQueryVariables = {
     messagesBeforeCursor: string;
     id?: string | null | undefined;
     filterBy?: FilterByInput | null | undefined;
+    sortBy?: SortByInput | null | undefined;
 };
 export type compiledHooks_Root_executionQueryResponse = {
     readonly user: {
@@ -29,7 +36,7 @@ export type compiledHooks_Root_executionQuery = {
 
 
 /*
-query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId", $filterBy: FilterByInput = {tag: "ALL"}) {
+query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId", $filterBy: FilterByInput = {tag: "ALL"}, $sortBy: SortByInput) {
   user(id: $userId, idThatDoesntOverride: $id, filterBy: $filterBy) {
     name
     ...compiledHooks_ChildFragment
@@ -67,11 +74,7 @@ fragment compiledHooks_ForwardPaginationFragment on NodeWithPetAvatarAndConversa
   __isNodeWithPetAvatarAndConversations: __typename
   petName
   avatarUrl(size: $avatarSize)
-  conversations(
-    first: 1
-    after: ""
-    sortBy: {sortField: NAME, sortDirection: ASC}
-  ) @connection(key: "compiledHooks_user_conversations", filter: ["sortBy"]) {
+  conversations(first: 1, after: "", sortBy: $sortBy) @connection(key: "compiledHooks_user_conversations", filter: ["sortBy"]) {
     edges {
       node {
         title
@@ -103,7 +106,7 @@ fragment compiledHooks_RefetchableFragment on User {
 */
 
 /*
-query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId", $filterBy: FilterByInput = {tag: "ALL"}) {
+query compiledHooks_Root_executionQuery($userId: Int!, $avatarSize: Int = 21, $messagesBackwardCount: Int!, $messagesBeforeCursor: String!, $id: String = "shouldNotOverrideCompiledFragmentId", $filterBy: FilterByInput = {tag: "ALL"}, $sortBy: SortByInput) {
   user(id: $userId, idThatDoesntOverride: $id, filterBy: $filterBy) {
     name
     id
@@ -182,7 +185,15 @@ v11 = {
   "kind": "Variable",
   "name": (v10/*: any*/)
 },
-v12 = [
+v12 = {
+  "kind": "Name",
+  "value": "sortBy"
+},
+v13 = {
+  "kind": "Variable",
+  "name": (v12/*: any*/)
+},
+v14 = [
   {
     "kind": "VariableDefinition",
     "variable": (v1/*: any*/),
@@ -247,13 +258,24 @@ v12 = [
         }
       ]
     }
+  },
+  {
+    "kind": "VariableDefinition",
+    "variable": (v13/*: any*/),
+    "type": {
+      "kind": "NamedType",
+      "name": {
+        "kind": "Name",
+        "value": "SortByInput"
+      }
+    }
   }
 ],
-v13 = {
+v15 = {
   "kind": "Name",
   "value": "user"
 },
-v14 = [
+v16 = [
   {
     "kind": "Argument",
     "name": (v8/*: any*/),
@@ -273,87 +295,87 @@ v14 = [
     "value": (v11/*: any*/)
   }
 ],
-v15 = {
+v17 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "name"
   }
 },
-v16 = {
+v18 = {
   "kind": "Name",
   "value": "compiledHooks_ChildFragment"
 },
-v17 = {
+v19 = {
   "kind": "Name",
   "value": "compiledHooks_RefetchableFragment"
 },
-v18 = {
+v20 = {
   "kind": "Name",
   "value": "compiledHooks_ForwardPaginationFragment"
 },
-v19 = {
+v21 = {
   "kind": "Field",
   "name": (v8/*: any*/)
 },
-v20 = {
+v22 = {
   "kind": "Name",
   "value": "compiledHooks_QueryTypeFragment"
 },
-v21 = {
+v23 = {
   "kind": "Name",
   "value": "compiledHooks_BackwardPaginationFragment"
 },
-v22 = {
+v24 = {
   "kind": "Name",
   "value": "connection"
 },
-v23 = {
+v25 = {
   "kind": "Name",
   "value": "key"
 },
-v24 = {
+v26 = {
   "kind": "Name",
   "value": "edges"
 },
-v25 = {
+v27 = {
   "kind": "Name",
   "value": "node"
 },
-v26 = {
+v28 = {
   "kind": "Name",
   "value": "__typename"
 },
-v27 = {
+v29 = {
   "kind": "Field",
-  "name": (v26/*: any*/)
+  "name": (v28/*: any*/)
 },
-v28 = {
+v30 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "cursor"
   }
 },
-v29 = {
+v31 = {
   "kind": "Name",
   "value": "pageInfo"
 },
-v30 = {
+v32 = {
   "kind": "NamedType",
   "name": {
     "kind": "Name",
     "value": "User"
   }
 },
-v31 = {
+v33 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
     "value": "petName"
   }
 },
-v32 = {
+v34 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
@@ -370,7 +392,7 @@ v32 = {
     }
   ]
 },
-v33 = {
+v35 = {
   "kind": "Field",
   "name": {
     "kind": "Name",
@@ -394,44 +416,44 @@ return {
         "kind": "OperationDefinition",
         "operation": "query",
         "name": (v0/*: any*/),
-        "variableDefinitions": (v12/*: any*/),
+        "variableDefinitions": (v14/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
             {
               "kind": "Field",
-              "name": (v13/*: any*/),
-              "arguments": (v14/*: any*/),
+              "name": (v15/*: any*/),
+              "arguments": (v16/*: any*/),
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v15/*: any*/),
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v16/*: any*/)
-                  },
-                  {
-                    "kind": "FragmentSpread",
-                    "name": (v17/*: any*/)
-                  },
+                  (v17/*: any*/),
                   {
                     "kind": "FragmentSpread",
                     "name": (v18/*: any*/)
                   },
-                  (v19/*: any*/)
+                  {
+                    "kind": "FragmentSpread",
+                    "name": (v19/*: any*/)
+                  },
+                  {
+                    "kind": "FragmentSpread",
+                    "name": (v20/*: any*/)
+                  },
+                  (v21/*: any*/)
                 ]
               }
             },
             {
               "kind": "FragmentSpread",
-              "name": (v20/*: any*/)
+              "name": (v22/*: any*/)
             }
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v21/*: any*/),
+        "name": (v23/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -469,11 +491,11 @@ return {
               "directives": [
                 {
                   "kind": "Directive",
-                  "name": (v22/*: any*/),
+                  "name": (v24/*: any*/),
                   "arguments": [
                     {
                       "kind": "Argument",
-                      "name": (v23/*: any*/),
+                      "name": (v25/*: any*/),
                       "value": {
                         "kind": "StringValue",
                         "value": "compiledHooks_conversation_messages",
@@ -488,13 +510,13 @@ return {
                 "selections": [
                   {
                     "kind": "Field",
-                    "name": (v24/*: any*/),
+                    "name": (v26/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
                         {
                           "kind": "Field",
-                          "name": (v25/*: any*/),
+                          "name": (v27/*: any*/),
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -505,18 +527,18 @@ return {
                                   "value": "text"
                                 }
                               },
-                              (v19/*: any*/),
-                              (v27/*: any*/)
+                              (v21/*: any*/),
+                              (v29/*: any*/)
                             ]
                           }
                         },
-                        (v28/*: any*/)
+                        (v30/*: any*/)
                       ]
                     }
                   },
                   {
                     "kind": "Field",
-                    "name": (v29/*: any*/),
+                    "name": (v31/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -540,25 +562,25 @@ return {
                 ]
               }
             },
-            (v19/*: any*/)
-          ]
-        }
-      },
-      {
-        "kind": "FragmentDefinition",
-        "name": (v16/*: any*/),
-        "typeCondition": (v30/*: any*/),
-        "selectionSet": {
-          "kind": "SelectionSet",
-          "selections": [
-            (v31/*: any*/),
-            (v19/*: any*/)
+            (v21/*: any*/)
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
         "name": (v18/*: any*/),
+        "typeCondition": (v32/*: any*/),
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            (v33/*: any*/),
+            (v21/*: any*/)
+          ]
+        }
+      },
+      {
+        "kind": "FragmentDefinition",
+        "name": (v20/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -575,10 +597,10 @@ return {
                 "kind": "Name",
                 "value": "__isNodeWithPetAvatarAndConversations"
               },
-              "name": (v26/*: any*/)
+              "name": (v28/*: any*/)
             },
-            (v31/*: any*/),
-            (v32/*: any*/),
+            (v33/*: any*/),
+            (v34/*: any*/),
             {
               "kind": "Field",
               "name": {
@@ -611,47 +633,18 @@ return {
                 },
                 {
                   "kind": "Argument",
-                  "name": {
-                    "kind": "Name",
-                    "value": "sortBy"
-                  },
-                  "value": {
-                    "kind": "ObjectValue",
-                    "fields": [
-                      {
-                        "kind": "ObjectField",
-                        "name": {
-                          "kind": "Name",
-                          "value": "sortField"
-                        },
-                        "value": {
-                          "kind": "EnumValue",
-                          "value": "NAME"
-                        }
-                      },
-                      {
-                        "kind": "ObjectField",
-                        "name": {
-                          "kind": "Name",
-                          "value": "sortDirection"
-                        },
-                        "value": {
-                          "kind": "EnumValue",
-                          "value": "ASC"
-                        }
-                      }
-                    ]
-                  }
+                  "name": (v12/*: any*/),
+                  "value": (v13/*: any*/)
                 }
               ],
               "directives": [
                 {
                   "kind": "Directive",
-                  "name": (v22/*: any*/),
+                  "name": (v24/*: any*/),
                   "arguments": [
                     {
                       "kind": "Argument",
-                      "name": (v23/*: any*/),
+                      "name": (v25/*: any*/),
                       "value": {
                         "kind": "StringValue",
                         "value": "compiledHooks_user_conversations",
@@ -683,13 +676,13 @@ return {
                 "selections": [
                   {
                     "kind": "Field",
-                    "name": (v24/*: any*/),
+                    "name": (v26/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
                         {
                           "kind": "Field",
-                          "name": (v25/*: any*/),
+                          "name": (v27/*: any*/),
                           "selectionSet": {
                             "kind": "SelectionSet",
                             "selections": [
@@ -702,20 +695,20 @@ return {
                               },
                               {
                                 "kind": "FragmentSpread",
-                                "name": (v21/*: any*/)
+                                "name": (v23/*: any*/)
                               },
-                              (v19/*: any*/),
-                              (v27/*: any*/)
+                              (v21/*: any*/),
+                              (v29/*: any*/)
                             ]
                           }
                         },
-                        (v28/*: any*/)
+                        (v30/*: any*/)
                       ]
                     }
                   },
                   {
                     "kind": "Field",
-                    "name": (v29/*: any*/),
+                    "name": (v31/*: any*/),
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
@@ -739,13 +732,13 @@ return {
                 ]
               }
             },
-            (v19/*: any*/)
+            (v21/*: any*/)
           ]
         }
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v20/*: any*/),
+        "name": (v22/*: any*/),
         "typeCondition": {
           "kind": "NamedType",
           "name": {
@@ -765,7 +758,7 @@ return {
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v19/*: any*/)
+                  (v21/*: any*/)
                 ]
               }
             }
@@ -774,14 +767,14 @@ return {
       },
       {
         "kind": "FragmentDefinition",
-        "name": (v17/*: any*/),
-        "typeCondition": (v30/*: any*/),
+        "name": (v19/*: any*/),
+        "typeCondition": (v32/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
-            (v31/*: any*/),
-            (v32/*: any*/),
-            (v19/*: any*/)
+            (v33/*: any*/),
+            (v34/*: any*/),
+            (v21/*: any*/)
           ]
         }
       }
@@ -794,19 +787,19 @@ return {
         "kind": "OperationDefinition",
         "operation": "query",
         "name": (v0/*: any*/),
-        "variableDefinitions": (v12/*: any*/),
+        "variableDefinitions": (v14/*: any*/),
         "selectionSet": {
           "kind": "SelectionSet",
           "selections": [
             {
               "kind": "Field",
-              "name": (v13/*: any*/),
-              "arguments": (v14/*: any*/),
+              "name": (v15/*: any*/),
+              "arguments": (v16/*: any*/),
               "selectionSet": {
                 "kind": "SelectionSet",
                 "selections": [
-                  (v15/*: any*/),
-                  (v19/*: any*/),
+                  (v17/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "typeCondition": {
@@ -819,14 +812,14 @@ return {
                     "selectionSet": {
                       "kind": "SelectionSet",
                       "selections": [
-                        (v33/*: any*/)
+                        (v35/*: any*/)
                       ]
                     }
                   }
                 ]
               }
             },
-            (v33/*: any*/)
+            (v35/*: any*/)
           ]
         }
       }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__snapshots__/compiledHooks.test.tsx.snap
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/__snapshots__/compiledHooks.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
     "id": "shouldNotOverrideCompiledFragmentId",
     "messagesBackwardCount": 1,
     "messagesBeforeCursor": "",
+    "sortBy": {
+      "sortDirection": "ASC",
+      "sortField": "NAME",
+    },
     "userId": 42,
   },
   "user": {
@@ -21,6 +25,10 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
       "id": "shouldNotOverrideCompiledFragmentId",
       "messagesBackwardCount": 1,
       "messagesBeforeCursor": "",
+      "sortBy": {
+        "sortDirection": "ASC",
+        "sortField": "NAME",
+      },
       "userId": 42,
     },
     "__typename": "User",
@@ -34,7 +42,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
 {
   "__typename": "User",
   "avatarUrl({"size":21})": "<mock-value-for-field-"avatarUrl">",
-  "conversations:compiledHooks_user_conversations({"sortBy":{"sortDirection":"ASC","sortField":"NAME"}})": {
+  "conversations:compiledHooks_user_conversations({})": {
     "__typename": "ConversationsConnection",
     "edges": [
       {
@@ -62,7 +70,7 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
 {
   "__typename": "User",
   "avatarUrl({"size":21})": "<mock-value-for-field-"avatarUrl">",
-  "conversations:compiledHooks_user_conversations({"sortBy":{"sortDirection":"ASC","sortField":"NAME"}})": {
+  "conversations:compiledHooks_user_conversations({})": {
     "__typename": "ConversationsConnection",
     "edges": [
       {
@@ -164,6 +172,10 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
     "id": "shouldNotOverrideCompiledFragmentId",
     "messagesBackwardCount": 1,
     "messagesBeforeCursor": "",
+    "sortBy": {
+      "sortDirection": "ASC",
+      "sortField": "NAME",
+    },
     "userId": 42,
   },
   "user": {
@@ -175,6 +187,10 @@ exports[`compiledHooks with strict Global Object Id spec type-policies useCompil
       "id": "shouldNotOverrideCompiledFragmentId",
       "messagesBackwardCount": 1,
       "messagesBeforeCursor": "",
+      "sortBy": {
+        "sortDirection": "ASC",
+        "sortField": "NAME",
+      },
       "userId": 42,
     },
     "__typename": "User",

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/compiledHooks.test.tsx
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/__tests__/compiledHooks.test.tsx
@@ -82,10 +82,6 @@ const _ForwardPagination_fragment = graphql`
     conversationsForwardCount: { type: "Int!", defaultValue: 1 }
     conversationsAfterCursor: { type: "String!", defaultValue: "" }
     addExtra: { type: "Boolean!", defaultValue: false }
-    sortBy: {
-      type: "SortByInput"
-      defaultValue: { sortField: NAME, sortDirection: ASC }
-    }
   ) {
     petName
     avatarUrl(size: $avatarSize)
@@ -128,6 +124,7 @@ const _Root_executionQueryDocument = graphql`
     $messagesBeforeCursor: String!
     $id: String = "shouldNotOverrideCompiledFragmentId"
     $filterBy: FilterByInput = { tag: "ALL" }
+    $sortBy: SortByInput
   ) {
     user(id: $userId, idThatDoesntOverride: $id, filterBy: $filterBy) {
       name
@@ -279,6 +276,7 @@ describe.each([
                 userId: 42,
                 messagesBackwardCount: 1,
                 messagesBeforeCursor: "",
+                sortBy: { sortDirection: "ASC", sortField: "NAME" },
               }}
             />
           </ErrorBoundary>
@@ -637,6 +635,10 @@ describe.each([
             "id": "shouldNotOverrideCompiledFragmentId",
             "messagesBackwardCount": 1,
             "messagesBeforeCursor": "",
+            "sortBy": {
+              "sortDirection": "ASC",
+              "sortField": "NAME",
+            },
             "userId": 42,
           },
           "__typename": "Query",
@@ -802,28 +804,92 @@ describe.each([
       ]),
     );
 
+    const resolveOperation = async () => {
+      client.mock.queueOperationResolver((operation) => {
+        const { variables } = operation.request;
+        return MockPayloadGenerator.generate(operation, {
+          Node: () => ({
+            id: 42,
+          }),
+          Conversation: () => ({
+            id: "conv1",
+            title: `Conversation 1 - ${variables.sortBy.sortField}`,
+          }),
+          PageInfo: () => ({
+            endCursor: "first-page-end-cursor",
+            hasNextPage: false,
+          }),
+        });
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+
     describe("when refetching", () => {
-      it("should update refetch function when the variables change back to the initial ones passed to useCompiledRefetchableFragment", async () => {
+      it("should return original data when refetching with original variables after refetch", async () => {
+        // Set up the resolver once for all operations
+        await resolveOperation();
+
+        // Verify initial data
+        let result = last(forwardUsePaginationFragmentResult);
+        expect(result.data.conversations.edges[0].node.title).toBe(
+          '<mock-value-for-field-"title">',
+        );
+        expect(result.data.__fragments.sortBy).toEqual({
+          sortField: "NAME",
+          sortDirection: "ASC",
+        });
+
+        // Refetch with new variables
         await act(async () => {
           const { refetch } = last(forwardUsePaginationFragmentResult);
-          refetch({ addExtra: true });
-          client.mock.resolveMostRecentOperation((operation) =>
-            MockPayloadGenerator.generate(operation),
-          );
-          await new Promise((resolve) => setTimeout(resolve, 0));
+          refetch({
+            sortBy: { sortField: "CREATED_AT", sortDirection: "ASC" },
+          });
         });
+
+        // Verify data after first refetch
+        result = last(forwardUsePaginationFragmentResult);
+        expect(result.data.conversations.edges[0].node.title).toBe(
+          "Conversation 1 - CREATED_AT",
+        );
+        expect(result.data.__fragments.sortBy).toEqual({
+          sortField: "CREATED_AT",
+          sortDirection: "ASC",
+        });
+
+        // Refetch with original variables (should use all previous values)
+        await act(async () => {
+          const { refetch } = last(forwardUsePaginationFragmentResult);
+          refetch({
+            sortBy: { sortField: "NAME", sortDirection: "ASC" },
+          });
+        });
+
+        // Verify data returned to original state with merged variables
+        result = last(forwardUsePaginationFragmentResult);
+        expect(result.data.conversations.edges[0].node.title).toBe(
+          "Conversation 1 - NAME",
+        );
+        expect(result.data.__fragments.sortBy).toEqual({
+          sortField: "NAME",
+          sortDirection: "ASC",
+        });
+
+        // Refetch with no variables (should use all previous values)
         await act(async () => {
           const { refetch } = last(forwardUsePaginationFragmentResult);
           refetch({});
-          client.mock.resolveMostRecentOperation((operation) =>
-            MockPayloadGenerator.generate(operation),
-          );
-          await new Promise((resolve) => setTimeout(resolve, 0));
         });
-        const usedDifferentRefetchFunctions =
-          forwardUsePaginationFragmentResult[0].refetch !==
-          forwardUsePaginationFragmentResult[1].refetch;
-        expect(usedDifferentRefetchFunctions).toBeTruthy();
+
+        // Verify data uses previous variables
+        result = last(forwardUsePaginationFragmentResult);
+        expect(result.data.conversations.edges[0].node.title).toBe(
+          "Conversation 1 - NAME",
+        );
+        expect(result.data.__fragments.sortBy).toEqual({
+          sortField: "NAME",
+          sortDirection: "ASC",
+        });
       });
     });
 

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledPaginationFragment.ts
@@ -266,7 +266,7 @@ export function useCompiledPaginationFragment(
       latestVariablesUsedByStandaloneRefetch.current = variables;
       return refetch(variables, options);
     },
-    [],
+    [refetch],
   );
 
   const commonPaginationParams = {

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
@@ -154,6 +154,7 @@ export function useCompiledRefetchableFragment(
       executionQueryDocument,
       fragmentReference.id,
       fragmentReference.__fragments,
+      fragmentReferenceWithOwnVariables.__fragments,
     ],
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5725,14 +5725,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
-  dependencies:
-    node-fetch "2.6.1"
-
-cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.4:
+cross-fetch@3.1.4, cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
@@ -7282,22 +7275,7 @@ glob-hasher@^1.3.0:
     glob-hasher-win32-arm64-msvc "1.3.0"
     glob-hasher-win32-x64-msvc "1.3.0"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
-glob-parent@^5.1.2, glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
-glob-parent@^6.0.2:
+glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@^6.0.2, glob-parent@~5.1.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -8229,7 +8207,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
@@ -8262,13 +8240,6 @@ is-glob@4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==
-  dependencies:
-    is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -9859,12 +9830,7 @@ minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@1.2.5, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -10023,24 +9989,14 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.5:
+node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.5, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-forge@^1:
+node-forge@^0.10.0, node-forge@^1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -10537,11 +10493,6 @@ path-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
-
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -12396,6 +12347,11 @@ tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+trim@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
+  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 ts-algebra@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
When query variables change for the scenario where the variables are not set as defaults, the refetch function uses old variables instead of new variables and data is not fetched again. This is caused by the `fragmentReferenceWithOwnVariables` and `refetch` function missing as part of the useCallback dependencies. This PR adds those dependencies to fix it