### PR TITLE
refactor(apollo-forest-run): replace const enums with ES modules

### DIFF
--- a/change/@graphitation-apollo-forest-run-20b75c12-cc0e-4285-90e6-ea25ea00f528.json
+++ b/change/@graphitation-apollo-forest-run-20b75c12-cc0e-4285-90e6-ea25ea00f528.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor(apollo-forest-run): replace const enums with ES modules",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/diff/diffErrorKind.ts
+++ b/packages/apollo-forest-run/src/diff/diffErrorKind.ts
@@ -1,0 +1,3 @@
+export const MissingModelValue = 0,
+  MissingModelFields = 1,
+  MissingBaseFields = 2;

--- a/packages/apollo-forest-run/src/diff/differenceKind.ts
+++ b/packages/apollo-forest-run/src/diff/differenceKind.ts
@@ -1,0 +1,5 @@
+export const Replacement = 0,
+  Filler = 1,
+  ObjectDifference = 2,
+  CompositeListDifference = 3,
+  FieldEntryDifference = 4;

--- a/packages/apollo-forest-run/src/diff/types.ts
+++ b/packages/apollo-forest-run/src/diff/types.ts
@@ -8,6 +8,8 @@ import {
   SourceCompositeList,
 } from "../values/types";
 import { FieldInfo, NormalizedFieldEntry } from "../descriptor/types";
+import * as DifferenceKind from "./differenceKind";
+import * as DiffErrorKind from "./diffErrorKind";
 
 export type DiffEnv = {
   allowMissingFields?: boolean;
@@ -38,24 +40,18 @@ export type DiffState = {
   allowMissingFields?: boolean;
 };
 
-export const enum DiffErrorKind {
-  MissingModelValue,
-  MissingModelFields,
-  MissingBaseFields,
-}
-
 export type MissingModelError = {
-  kind: DiffErrorKind.MissingModelValue;
+  kind: typeof DiffErrorKind.MissingModelValue;
 };
 
 export type MissingModelFieldsError = {
-  kind: DiffErrorKind.MissingModelFields;
+  kind: typeof DiffErrorKind.MissingModelFields;
   chunk: ObjectChunk;
   missingFields: FieldInfo[];
 };
 
 export type MissingBaseFieldsError = {
-  kind: DiffErrorKind.MissingBaseFields;
+  kind: typeof DiffErrorKind.MissingBaseFields;
   chunk: ObjectChunk;
   missingFields: FieldInfo[];
 };
@@ -78,16 +74,8 @@ export type DiffError =
  *
  * State is an implementation detail of diffing algorithm and should not be relied upon by consumers: it can change at any time
  */
-export const enum DifferenceKind {
-  Replacement,
-  Filler,
-  ObjectDifference,
-  CompositeListDifference,
-  FieldEntryDifference,
-}
-
 export type ObjectDifference = {
-  readonly kind: DifferenceKind.ObjectDifference;
+  readonly kind: typeof DifferenceKind.ObjectDifference;
   // readonly allFields: Iterable<FieldName>;
 
   fieldQueue: Set<FieldName>;
@@ -97,13 +85,13 @@ export type ObjectDifference = {
 };
 
 export type FieldEntryDifference = {
-  readonly kind: DifferenceKind.FieldEntryDifference;
+  readonly kind: typeof DifferenceKind.FieldEntryDifference;
   fieldEntry: NormalizedFieldEntry;
   state: ValueDifference;
 };
 
 export type CompositeListDifference = {
-  readonly kind: DifferenceKind.CompositeListDifference;
+  readonly kind: typeof DifferenceKind.CompositeListDifference;
   itemQueue: Set<number>;
   itemState: Map<number, ValueDifference>;
   dirtyItems?: Set<number>;
@@ -116,13 +104,13 @@ type AddedValue = CompositeListValue | ObjectValue;
 export type CompositeListLayoutDifference = (number | null | AddedValue)[];
 
 export type Replacement = {
-  readonly kind: DifferenceKind.Replacement;
+  readonly kind: typeof DifferenceKind.Replacement;
   oldValue: GraphValue;
   newValue: GraphValue;
 };
 
 export type Filler = {
-  readonly kind: DifferenceKind.Filler;
+  readonly kind: typeof DifferenceKind.Filler;
   readonly newValue: GraphValue;
 };
 
@@ -133,3 +121,4 @@ export type ValueDifference =
   | Filler;
 
 export type NodeDifferenceMap = Map<string, ObjectDifference>;
+export { DifferenceKind, DiffErrorKind };

--- a/packages/apollo-forest-run/src/values/types.ts
+++ b/packages/apollo-forest-run/src/values/types.ts
@@ -8,6 +8,7 @@ import {
   ResolvedSelection,
   ArgumentValues,
 } from "../descriptor/types";
+import * as ValueKind from "./valueKind";
 
 declare const OpaqueSymbol: unique symbol;
 export type Brand<T, B extends symbol> = T & { [K in typeof OpaqueSymbol]: B };
@@ -59,18 +60,6 @@ export type SourceCompositeValue =
   | SourceCompositeList
   | SourceNull
   | undefined;
-
-export const enum ValueKind {
-  Object,
-  CompositeList,
-  CompositeNull,
-  CompositeUndefined,
-  LeafList,
-  LeafError,
-  LeafUndefined,
-  ComplexScalar,
-  ObjectDraft,
-}
 
 // Raw value wrappers (useful for diffing / updating)
 export type FieldName = string;
@@ -127,7 +116,7 @@ export type CompositeValueChunkReference = GraphChunkReference & {
 };
 
 export type ObjectChunk = {
-  readonly kind: ValueKind.Object;
+  readonly kind: typeof ValueKind.Object;
   readonly isAggregate: false;
   readonly data: SourceObject;
   readonly operation: OperationDescriptor;
@@ -151,7 +140,7 @@ export type ObjectChunk = {
 };
 
 export type ObjectAggregate = {
-  readonly kind: ValueKind.Object;
+  readonly kind: typeof ValueKind.Object;
   readonly isAggregate: true;
   readonly data: SourceObject; // source value from the first chunk
   readonly chunks: ObjectChunk[];
@@ -165,7 +154,7 @@ export type ObjectAggregate = {
 };
 
 export type CompositeListChunk = {
-  readonly kind: ValueKind.CompositeList;
+  readonly kind: typeof ValueKind.CompositeList;
   readonly isAggregate: false;
   readonly data: SourceCompositeList;
   readonly operation: OperationDescriptor;
@@ -186,7 +175,7 @@ export type CompositeListChunk = {
 };
 
 export type CompositeListAggregate = {
-  readonly kind: ValueKind.CompositeList;
+  readonly kind: typeof ValueKind.CompositeList;
   readonly isAggregate: true;
   readonly data: SourceCompositeList;
   readonly chunks: CompositeListChunk[];
@@ -199,7 +188,7 @@ export type CompositeListItemKey = string | number;
 export type CompositeListLayout = CompositeListItemKey[];
 
 export type CompositeNullChunk = {
-  readonly kind: ValueKind.CompositeNull;
+  readonly kind: typeof ValueKind.CompositeNull;
   readonly isAggregate: false;
   readonly data: SourceNull;
   readonly operation: OperationDescriptor;
@@ -208,14 +197,14 @@ export type CompositeNullChunk = {
 };
 
 export type CompositeNullAggregate = {
-  readonly kind: ValueKind.CompositeNull;
+  readonly kind: typeof ValueKind.CompositeNull;
   readonly isAggregate: true;
   readonly data: SourceNull;
   readonly chunks: CompositeNullChunk[];
 };
 
 export type CompositeUndefinedChunk = {
-  readonly kind: ValueKind.CompositeUndefined;
+  readonly kind: typeof ValueKind.CompositeUndefined;
   readonly isAggregate: false;
   readonly data: undefined;
   readonly deleted: boolean;
@@ -225,7 +214,7 @@ export type CompositeUndefinedChunk = {
 };
 
 export type CompositeUndefinedAggregate = {
-  readonly kind: ValueKind.CompositeUndefined;
+  readonly kind: typeof ValueKind.CompositeUndefined;
   readonly isAggregate: true;
   readonly data: undefined;
   readonly deleted: boolean;
@@ -237,25 +226,25 @@ export type CompositeUndefinedAggregate = {
 // Object and Lists of objects replaced with "null" are represented as "CompositeNull" kind
 // (with "error" field set if they were nullified due to an error)
 export type LeafErrorValue = {
-  readonly kind: ValueKind.LeafError;
+  readonly kind: typeof ValueKind.LeafError;
   readonly data: SourceNull;
   readonly error: FormattedError;
 };
 
 export type LeafListValue = {
-  readonly kind: ValueKind.LeafList;
+  readonly kind: typeof ValueKind.LeafList;
   readonly data: SourceLeafList;
 };
 
 export type LeafUndefinedValue = {
-  kind: ValueKind.LeafUndefined;
+  kind: typeof ValueKind.LeafUndefined;
   deleted: boolean;
   data: undefined;
 };
 
 // Custom scalars expressed as objects (JSON, complex dates, etc)
 export type ComplexScalarValue = {
-  readonly kind: ValueKind.ComplexScalar;
+  readonly kind: typeof ValueKind.ComplexScalar;
   readonly data: SourceCustomScalar;
 };
 
@@ -307,7 +296,7 @@ export type FormattedError = {
 };
 
 export type ObjectDraft = {
-  readonly kind: ValueKind.ObjectDraft;
+  readonly kind: typeof ValueKind.ObjectDraft;
   readonly operation: OperationDescriptor;
   readonly possibleSelections: PossibleSelections;
   readonly selection: ResolvedSelection;
@@ -358,3 +347,4 @@ export type ParentLocator = (
 
 export type GraphValueReference = NodeKey | EmbeddedValueReference;
 export type EmbeddedValueReference = [ParentInfo, ParentLocator];
+export { ValueKind };

--- a/packages/apollo-forest-run/src/values/valueKind.ts
+++ b/packages/apollo-forest-run/src/values/valueKind.ts
@@ -1,0 +1,9 @@
+export const Object = 0,
+  CompositeList = 1,
+  CompositeNull = 2,
+  CompositeUndefined = 3,
+  LeafList = 4,
+  LeafError = 5,
+  LeafUndefined = 6,
+  ComplexScalar = 7,
+  ObjectDraft = 8;


### PR DESCRIPTION
Our monorepo builds sources using ESBuild, which doesn't support const enum inlining for typescript: https://github.com/evanw/esbuild/issues/128#issuecomment-1002341244

A quote from there:

> 4. Cross-module inlining only works when bundling

We don't bundle the code with ESBuild, just building ESM from TS, so const enums are not inlined in practice.

This PR implements an alternative approach by replacing const enums with wildcard ES module imports (with re-exports). By itself it doesn't change much, but when combined with minifers like Terser (in the actual bundler), inlining does occur.