### PR TITLE
fix(apollo-forest-run): improve compatibility with apollo

### DIFF
--- a/change/@graphitation-apollo-forest-run-2d5f966b-964e-4a9f-b6dd-0c63051a3137.json
+++ b/change/@graphitation-apollo-forest-run-2d5f966b-964e-4a9f-b6dd-0c63051a3137.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): improve compatibility with apollo",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -302,11 +302,17 @@ export class ForestRun extends ApolloCache<any> {
   }
 
   public read<T>(options: Cache.ReadOptions): T | null {
-    const diff = this.diff(options);
+    const diff = this.runRead(options);
     return diff.complete || options.returnPartialData ? diff.result : null;
   }
 
   public diff<TData, TVariables = any>(
+    options: Cache.DiffOptions<TData, TVariables>,
+  ): Cache.DiffResult<TData> {
+    return this.runRead(options);
+  }
+
+  private runRead<TData, TVariables = any>(
     options: Cache.DiffOptions<TData, TVariables>,
   ): Cache.DiffResult<TData> {
     const activeTransaction = peek(this.transactionStack);


### PR DESCRIPTION
Align ForestRun behavior of `read` method with that of the InMemoryCache: InMemoryCache doesn't call `diff` under the hood of the `read` method. 

This difference may cause subtle effects when extending cache classes and wrapping/overriding methods, e.g. for telemetry.