### PR TITLE
[TS-CODEGEN] context types generation re-work

### DIFF
--- a/change/@graphitation-cli-66b66740-d897-4e21-9dce-9f452b45a900.json
+++ b/change/@graphitation-cli-66b66740-d897-4e21-9dce-9f452b45a900.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Context type generation re-worked",
+  "packageName": "@graphitation/cli",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-c09b79fd-44a4-492e-8b1d-f18202a82cd3.json
+++ b/change/@graphitation-ts-codegen-c09b79fd-44a4-492e-8b1d-f18202a82cd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Context type generation re-worked",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -55,19 +55,19 @@ export function supermassive(): Command {
     .option("-cn, --context-type-name [contextTypeName]", "Context type name")
     .option(
       "-dcp, --default-context-sub-type-path [defaultContextSubTypePath]",
-      "from where to import context",
+      "From where the default context type will be exported",
     )
     .option(
       "-dcn, --default-context-sub-type-name [defaultContextSubTypeName]",
-      "Context name",
+      "Default context type which will extend context sub type",
     )
     .option(
       "-cnt, --context-sub-type-name-template [contextSubTypeNameTemplate]",
-      "context namespace name",
+      "context resource name template. You need to specify ${resourceName} in the parameter eg. `${resourceName}Context`",
     )
     .option(
       "-cpt, --context-sub-type-path-template [contextSubTypePathTemplate]",
-      "context namespace path",
+      "context resource path template. You need to specify ${resourceName} in the parameter eg. `@package/preffix-${resourceName}-suffix`",
     )
     .option("-ei, --enums-import [enumsImport]", "from where to import enums")
     .option("-l, --legacy", "generate legacy types")

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -62,11 +62,11 @@ export function supermassive(): Command {
       "Context name",
     )
     .option(
-      "-cm, --context-sub-type-name-template [contextSubTypeNameTemplate]",
+      "-cnt, --context-sub-type-name-template [contextSubTypeNameTemplate]",
       "context namespace name",
     )
     .option(
-      "-cm, --context-sub-type-path-template [contextSubTypePathTemplate]",
+      "-cpt, --context-sub-type-path-template [contextSubTypePathTemplate]",
       "context namespace path",
     )
     .option("-ei, --enums-import [enumsImport]", "from where to import enums")

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -1,0 +1,888 @@
+import ts from "typescript";
+import { parse } from "graphql";
+import { blankGraphQLTag as graphql } from "../utilities";
+import { generateTS } from "..";
+import { ContextMap } from "../context";
+
+describe(generateTS, () => {
+  describe("Tests basic syntax GraphQL syntax", () => {
+    test("all possible nullable and non-nullable combinations", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(
+          graphql`
+            extend schema
+              @import(from: "@msteams/packages-test", defs: ["Avatar"])
+            type Post
+              @model(from: "./post-model.interface", tsType: "PostModel") {
+              id: ID!
+            }
+
+            type Message {
+              id: ID! @context(stateMachines: ["message"])
+            }
+
+            type User @context(stateMachines: ["user"]) {
+              id: ID! @context(stateMachines: ["id-user"])
+              name: String
+              messagesWithAnswersNonRequired: [[Message]]
+              messagesWithAnswersRequired: [[Message]]!
+              messagesWithAnswersAllRequired: [[Message!]!]!
+              messagesNonRequired: [Message]
+              messagesWithArrayRequired: [Message]!
+              messagesRequired: [Message!]!
+              messagesOnlyMessageRequired: [Message!]
+              post: Post @context(stateMachines: ["post"])
+              postRequired: Post!
+              avatar: Avatar
+              avatarRequired: Avatar!
+            }
+
+            extend type Query {
+              requiredUsers: [User!]!
+              optionalUsers: [User]
+              optionalUser: User
+              requiredUser: User!
+              requiredPost: Post!
+              optionalPost: Post
+            }
+          `,
+          {
+            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
+            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+          },
+        );
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`
+        {
+          "Message": {
+            "id": [
+              "message",
+            ],
+          },
+          "User": {
+            "__context": [
+              "user",
+            ],
+            "id": [
+              "id-user",
+            ],
+            "post": [
+              "post",
+            ],
+          },
+        }
+      `);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "import type { Avatar } from "@msteams/packages-test";
+        import type { PostModel as _Post } from "../post-model.interface";
+        // Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Post extends BaseModel, _Post {
+            readonly __typename?: "Post";
+        }
+        export interface Message extends BaseModel {
+            readonly __typename?: "Message";
+            readonly id: string;
+        }
+        export interface User extends BaseModel {
+            readonly __typename?: "User";
+            readonly id: string;
+            readonly name?: string | null;
+            readonly messagesWithAnswersNonRequired?: ReadonlyArray<ReadonlyArray<Message | null> | null> | null;
+            readonly messagesWithAnswersRequired: ReadonlyArray<ReadonlyArray<Message | null> | null>;
+            readonly messagesWithAnswersAllRequired: ReadonlyArray<ReadonlyArray<Message>>;
+            readonly messagesNonRequired?: ReadonlyArray<Message | null> | null;
+            readonly messagesWithArrayRequired: ReadonlyArray<Message | null>;
+            readonly messagesRequired: ReadonlyArray<Message>;
+            readonly messagesOnlyMessageRequired?: ReadonlyArray<Message> | null;
+            readonly post?: Post | null;
+            readonly postRequired: Post;
+            readonly avatar?: Avatar | null;
+            readonly avatarRequired: Avatar;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { Avatar } from "@msteams/packages-test";
+        import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        import type { IMessageStateMachineContext } from "@msteams/core-cdl-sync-message";
+        import type { IUserStateMachineContext } from "@msteams/core-cdl-sync-user";
+        import type { IIdUserStateMachineContext } from "@msteams/core-cdl-sync-id-user";
+        import type { IPostStateMachineContext } from "@msteams/core-cdl-sync-post";
+        export declare namespace Post {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.Post, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Message {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.Message, args: {}, context: IMessageStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+                readonly name?: name;
+                readonly messagesWithAnswersNonRequired?: messagesWithAnswersNonRequired;
+                readonly messagesWithAnswersRequired?: messagesWithAnswersRequired;
+                readonly messagesWithAnswersAllRequired?: messagesWithAnswersAllRequired;
+                readonly messagesNonRequired?: messagesNonRequired;
+                readonly messagesWithArrayRequired?: messagesWithArrayRequired;
+                readonly messagesRequired?: messagesRequired;
+                readonly messagesOnlyMessageRequired?: messagesOnlyMessageRequired;
+                readonly post?: post;
+                readonly postRequired?: postRequired;
+                readonly avatar?: avatar;
+                readonly avatarRequired?: avatarRequired;
+            }
+            export type id = (model: Models.User, args: {}, context: IIdUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+            export type name = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+            export type messagesWithAnswersNonRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined> | null | undefined>;
+            export type messagesWithAnswersRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined>>;
+            export type messagesWithAnswersAllRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message>>>;
+            export type messagesNonRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined> | null | undefined>;
+            export type messagesWithArrayRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined>>;
+            export type messagesRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message>>;
+            export type messagesOnlyMessageRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message> | null | undefined>;
+            export type post = (model: Models.User, args: {}, context: IPostStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
+            export type postRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.Post>;
+            export type avatar = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<Avatar | null | undefined>;
+            export type avatarRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<Avatar>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly requiredUsers?: requiredUsers;
+                readonly optionalUsers?: optionalUsers;
+                readonly optionalUser?: optionalUser;
+                readonly requiredUser?: requiredUser;
+                readonly requiredPost?: requiredPost;
+                readonly optionalPost?: optionalPost;
+            }
+            export type requiredUsers = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User>>;
+            export type optionalUsers = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User | null | undefined> | null | undefined>;
+            export type optionalUser = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User | null | undefined>;
+            export type requiredUser = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User>;
+            export type requiredPost = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Post>;
+            export type optionalPost = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
+        }
+        "
+      `);
+    });
+    test("Subscription", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(graphql`
+          type User {
+            id: ID!
+          }
+
+          extend type Subscription {
+            userUpdated: User!
+          }
+        `);
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`{}`);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface User extends BaseModel {
+            readonly __typename?: "User";
+            readonly id: string;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Subscription {
+            export interface Resolvers {
+                readonly userUpdated?: userUpdated<any>;
+            }
+            export type userUpdated<SubscribeResult = never> = {
+                subscribe: (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<AsyncIterator<{
+                    userUpdated: Models.User;
+                }>>;
+            } | {
+                subscribe: (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<AsyncIterator<SubscribeResult>>;
+                resolve: (subcribeResult: SubscribeResult, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User>;
+            };
+        }
+        "
+      `);
+    });
+    test("Subscription with model", () => {
+      const { resolvers } = runGenerateTest(graphql`
+        type User @model(from: "./user-model.interface", tsType: "UserModel") {
+          id: ID!
+        }
+
+        extend type Subscription {
+          userUpdated: User!
+        }
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Subscription {
+            export interface Resolvers {
+                readonly userUpdated?: userUpdated<any>;
+            }
+            export type userUpdated<SubscribeResult = never> = {
+                subscribe: (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<AsyncIterator<{
+                    userUpdated: Models.User;
+                }>>;
+            } | {
+                subscribe: (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<AsyncIterator<SubscribeResult>>;
+                resolve: (subcribeResult: SubscribeResult, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User>;
+            };
+        }
+        "
+      `);
+    });
+    test("extends by exteding a type with pre-generated BaseModel type", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(graphql`
+          type User {
+            id: ID!
+          }
+
+          extend type Query {
+            users: [User!]!
+          }
+        `);
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`{}`);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface User extends BaseModel {
+            readonly __typename?: "User";
+            readonly id: string;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly users?: users;
+            }
+            export type users = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User>>;
+        }
+        "
+      `);
+    });
+    test("case when interface implements multiple interfaces", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(
+          graphql`
+            interface Node @context(stateMachines: ["node"]) {
+              id: ID!
+            }
+
+            interface Persona @context(stateMachines: ["persona"]) {
+              phone: String!
+            }
+
+            interface User implements Node & Persona {
+              id: ID!
+              name: String!
+            }
+
+            type Admin implements Node & Persona
+              @context(stateMachines: ["admin"]) {
+              id: ID!
+              rank: Int!
+            }
+
+            extend type Query {
+              users: [User]
+              admins: [Admin]
+            }
+          `,
+          {
+            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
+            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+          },
+        );
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`
+        {
+          "Admin": {
+            "__context": [
+              "admin",
+            ],
+          },
+          "Node": {
+            "__context": [
+              "node",
+            ],
+          },
+          "Persona": {
+            "__context": [
+              "persona",
+            ],
+          },
+        }
+      `);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Node extends BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Persona extends BaseModel {
+            readonly __typename?: string;
+        }
+        export interface User extends BaseModel, Node, Persona {
+            readonly __typename?: string;
+        }
+        export interface Admin extends BaseModel, Node, Persona {
+            readonly __typename?: "Admin";
+            readonly id: string;
+            readonly rank: number;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        import type { INodeStateMachineContext } from "@msteams/core-cdl-sync-node";
+        import type { IPersonaStateMachineContext } from "@msteams/core-cdl-sync-persona";
+        import type { IAdminStateMachineContext } from "@msteams/core-cdl-sync-admin";
+        export declare namespace Node {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: INodeStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace Persona {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: IPersonaStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace User {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace Admin {
+            export interface Resolvers {
+                readonly id?: id;
+                readonly rank?: rank;
+            }
+            export type id = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+            export type rank = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<number>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly users?: users;
+                readonly admins?: admins;
+            }
+            export type users = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User | null | undefined> | null | undefined>;
+            export type admins = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Admin | null | undefined> | null | undefined>;
+        }
+        "
+      `);
+    });
+    test("extensions are not generated in the models", () => {
+      const { models } = runGenerateTest(graphql`
+        extend schema @import(from: "@msteams/packages-test", defs: ["User"])
+
+        extend type User {
+          id: ID!
+          name: String!
+        }
+
+        type Post {
+          id: ID!
+          user: User!
+        }
+      `);
+      expect(models).toMatchInlineSnapshot(`
+        "import type { User } from "@msteams/packages-test";
+        // Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Post extends BaseModel {
+            readonly __typename?: "Post";
+            readonly id: string;
+            readonly user: User;
+        }
+        "
+      `);
+    });
+
+    test("implements -> @context in interfaces should be used only in resolveType", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(
+          graphql`
+            interface Node @context(stateMachines: ["node"]) {
+              id: ID!
+            }
+
+            interface Customer implements Node
+              @context(stateMachines: ["customer"]) {
+              id: ID!
+              name: String!
+            }
+
+            type User implements Node & Customer {
+              id: ID!
+              name: String!
+            }
+
+            extend type Query {
+              users: [User]
+            }
+          `,
+          {
+            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
+            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+          },
+        );
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`
+        {
+          "Customer": {
+            "__context": [
+              "customer",
+            ],
+          },
+          "Node": {
+            "__context": [
+              "node",
+            ],
+          },
+        }
+      `);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Node extends BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Customer extends BaseModel, Node {
+            readonly __typename?: string;
+        }
+        export interface User extends BaseModel, Node, Customer {
+            readonly __typename?: "User";
+            readonly id: string;
+            readonly name: string;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        import type { INodeStateMachineContext } from "@msteams/core-cdl-sync-node";
+        import type { ICustomerStateMachineContext } from "@msteams/core-cdl-sync-customer";
+        export declare namespace Node {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: INodeStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace Customer {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: ICustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+                readonly name?: name;
+            }
+            export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+            export type name = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly users?: users;
+            }
+            export type users = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User | null | undefined> | null | undefined>;
+        }
+        "
+      `);
+    });
+
+    test("applying @context to enum shouldn't affect anything", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(graphql`
+          enum PresenceAvailability
+            @context(stateMachines: ["shouldnt-apply"]) {
+            Available
+            Away
+            Offline
+          }
+
+          type User {
+            id: ID!
+            availability: PresenceAvailability!
+          }
+
+          extend type Query {
+            userById(id: ID!): User
+          }
+        `);
+      expect(enums).toMatchInlineSnapshot(`
+        "export enum PresenceAvailability {
+            Available = "Available",
+            Away = "Away",
+            Offline = "Offline"
+        }
+        "
+      `);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`{}`);
+      expect(models).toMatchInlineSnapshot(`
+        "import * as Enums from "./enums.interface";
+        export * from "./enums.interface";
+        // Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface User extends BaseModel {
+            readonly __typename?: "User";
+            readonly id: string;
+            readonly availability: Enums.PresenceAvailability;
+        }
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+                readonly availability?: availability;
+            }
+            export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+            export type availability = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.PresenceAvailability>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly userById?: userById;
+            }
+            export type userById = (model: unknown, args: {
+                readonly id: string;
+            }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User | null | undefined>;
+        }
+        "
+      `);
+    });
+
+    test("Union and interface types", () => {
+      const { resolvers, models, enums, inputs, contextMappingOutput } =
+        runGenerateTest(
+          graphql`
+            type Customer {
+              id: ID!
+            }
+
+            type Company {
+              id: ID!
+            }
+
+            type Admin @context(stateMachines: ["admin"]) {
+              id: ID!
+            }
+
+            type User @context(stateMachines: ["user"]) {
+              id: ID!
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            union UserOrAdmin = User | Admin
+            union UserOrCustomer @context(stateMachines: ["user-or-customer"]) =
+                User
+              | Customer
+            union CompanyOrCustomer
+              @context(stateMachines: ["company-or-customer"]) =
+                Company
+              | Customer
+
+            extend type Query {
+              userById(id: ID!): whatever @context(stateMachines: ["whatever"])
+              userByMail(mail: String): whatever
+                @context(stateMachines: ["different-whatever"])
+              node(id: ID!): Node
+            }
+          `,
+          {
+            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
+            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+          },
+        );
+      expect(enums).toMatchInlineSnapshot(`undefined`);
+      expect(contextMappingOutput).toMatchInlineSnapshot(`
+        {
+          "Admin": {
+            "__context": [
+              "admin",
+            ],
+          },
+          "CompanyOrCustomer": {
+            "__context": [
+              "company-or-customer",
+            ],
+          },
+          "Query": {
+            "userById": [
+              "whatever",
+            ],
+            "userByMail": [
+              "different-whatever",
+            ],
+          },
+          "User": {
+            "__context": [
+              "user",
+            ],
+          },
+          "UserOrCustomer": {
+            "__context": [
+              "user-or-customer",
+            ],
+          },
+        }
+      `);
+      expect(inputs).toMatchInlineSnapshot(`undefined`);
+      expect(models).toMatchInlineSnapshot(`
+        "// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+        export interface BaseModel {
+            readonly __typename?: string;
+        }
+        export interface Customer extends BaseModel {
+            readonly __typename?: "Customer";
+            readonly id: string;
+        }
+        export interface Company extends BaseModel {
+            readonly __typename?: "Company";
+            readonly id: string;
+        }
+        export interface Admin extends BaseModel {
+            readonly __typename?: "Admin";
+            readonly id: string;
+        }
+        export interface User extends BaseModel {
+            readonly __typename?: "User";
+            readonly id: string;
+        }
+        export interface Node extends BaseModel {
+            readonly __typename?: string;
+        }
+        export type UserOrAdmin = User | Admin;
+        export type UserOrCustomer = User | Customer;
+        export type CompanyOrCustomer = Company | Customer;
+        "
+      `);
+      expect(resolvers).toMatchInlineSnapshot(`
+        "import type { PromiseOrValue } from "@graphitation/supermassive";
+        import type { ResolveInfo } from "@graphitation/supermassive";
+        import * as Models from "./models.interface";
+        import type { IAdminStateMachineContext } from "@msteams/core-cdl-sync-admin";
+        import type { IUserStateMachineContext } from "@msteams/core-cdl-sync-user";
+        import type { IUserOrCustomerStateMachineContext } from "@msteams/core-cdl-sync-user-or-customer";
+        import type { ICompanyOrCustomerStateMachineContext } from "@msteams/core-cdl-sync-company-or-customer";
+        import type { IWhateverStateMachineContext } from "@msteams/core-cdl-sync-whatever";
+        import type { IDifferentWhateverStateMachineContext } from "@msteams/core-cdl-sync-different-whatever";
+        export declare namespace Customer {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.Customer, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Company {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.Company, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Admin {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace User {
+            export interface Resolvers {
+                readonly id?: id;
+            }
+            export type id = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+        }
+        export declare namespace Node {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: unknown, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null>;
+        }
+        export declare namespace UserOrAdmin {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: Models.User | Models.Admin, context: unknown, info: ResolveInfo) => PromiseOrValue<"User" | "Admin" | null>;
+        }
+        export declare namespace UserOrCustomer {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: Models.User | Models.Customer, context: IUserOrCustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<"User" | "Customer" | null>;
+        }
+        export declare namespace CompanyOrCustomer {
+            export interface Resolvers {
+                readonly __resolveType?: __resolveType;
+            }
+            export type __resolveType = (parent: Models.Company | Models.Customer, context: ICompanyOrCustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<"Company" | "Customer" | null>;
+        }
+        export declare namespace Query {
+            export interface Resolvers {
+                readonly userById?: userById;
+                readonly userByMail?: userByMail;
+                readonly node?: node;
+            }
+            export type userById = (model: unknown, args: {
+                readonly id: string;
+            }, context: IWhateverStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
+            export type userByMail = (model: unknown, args: {
+                readonly mail?: string | null;
+            }, context: IDifferentWhateverStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
+            export type node = (model: unknown, args: {
+                readonly id: string;
+            }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Node | null | undefined>;
+        }
+        "
+      `);
+    });
+  });
+});
+
+function runGenerateTest(
+  doc: string,
+  options: {
+    outputPath?: string;
+    documentPath?: string;
+    defaultContextTypePath?: string;
+    contextName?: string;
+    legacyCompat?: boolean;
+    enumsImport?: string;
+    legacyNoModelsForObjects?: boolean;
+    legacyEnumsCompatibility?: boolean;
+    useStringUnionsInsteadOfEnums?: boolean;
+    enumNamesToMigrate?: string[];
+    enumNamesToKeep?: string[];
+    modelScope?: string;
+    contextSubTypeNameTemplate?: string;
+    contextSubTypePathTemplate?: string;
+  } = {},
+): {
+  enums?: string;
+  inputs?: string;
+  models: string;
+  resolvers: string;
+  legacyTypes?: string;
+  legacyResolvers?: string;
+  legacyNoModelsForObjects?: boolean;
+  legacyEnumsCompatibility?: boolean;
+  useStringUnionsInsteadOfEnums?: boolean;
+  enumNamesToMigrate?: string[];
+  enumNamesToKeep?: string[];
+  modelScope?: string;
+  contextMappingOutput: ContextMap | null;
+} {
+  const fullOptions: {
+    outputPath: string;
+    documentPath: string;
+    defaultContextTypePath?: string | null;
+    contextName?: string;
+    legacyCompat?: boolean;
+    legacyEnumsCompatibility?: boolean;
+    legacyNoModelsForObjects?: boolean;
+    useStringUnionsInsteadOfEnums?: boolean;
+    enumNamesToMigrate?: string[];
+    enumNamesToKeep?: string[];
+    contextSubTypeNameTemplate?: string;
+    contextSubTypePathTemplate?: string;
+  } = {
+    outputPath: "__generated__",
+    documentPath: "./typedef.graphql",
+    ...options,
+  };
+  const document = parse(doc);
+  const { files, contextMappingOutput } = generateTS(document, fullOptions);
+
+  function getFileByFileName(fileName: string) {
+    return files.find((file) => file.fileName === fileName);
+  }
+
+  const { models, resolvers, enums, inputs, legacyTypes, legacyResolvers } = {
+    models: getFileByFileName("models.interface.ts") as ts.SourceFile,
+    inputs: getFileByFileName("inputs.interface.ts"),
+    enums: getFileByFileName("enums.interface.ts"),
+    resolvers: getFileByFileName("resolvers.interface.ts") as ts.SourceFile,
+    legacyTypes: getFileByFileName("legacy-types.interface.ts"),
+    legacyResolvers: getFileByFileName("legacy-resolvers.interface.ts"),
+  };
+
+  const printer = ts.createPrinter();
+
+  return {
+    enums: enums && printer.printFile(enums),
+    inputs: inputs && printer.printFile(inputs),
+    models: printer.printFile(models),
+    resolvers: printer.printFile(resolvers),
+    legacyTypes: legacyTypes && printer.printFile(legacyTypes),
+    legacyResolvers: legacyResolvers && printer.printFile(legacyResolvers),
+    contextMappingOutput,
+  };
+}

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -18,11 +18,11 @@ describe(generateTS, () => {
             }
 
             type Message {
-              id: ID! @context(stateMachines: ["message"])
+              id: ID! @context(uses: ["message"])
             }
 
-            type User @context(stateMachines: ["user"]) {
-              id: ID! @context(stateMachines: ["id-user"])
+            type User @context(uses: ["user"]) {
+              id: ID! @context(uses: ["id-user"])
               name: String
               messagesWithAnswersNonRequired: [[Message]]
               messagesWithAnswersRequired: [[Message]]!
@@ -31,7 +31,7 @@ describe(generateTS, () => {
               messagesWithArrayRequired: [Message]!
               messagesRequired: [Message!]!
               messagesOnlyMessageRequired: [Message!]
-              post: Post @context(stateMachines: ["post"])
+              post: Post @context(uses: ["post"])
               postRequired: Post!
               avatar: Avatar
               avatarRequired: Avatar!
@@ -310,11 +310,11 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(stateMachines: ["node"]) {
+            interface Node @context(uses: ["node"]) {
               id: ID!
             }
 
-            interface Persona @context(stateMachines: ["persona"]) {
+            interface Persona @context(uses: ["persona"]) {
               phone: String!
             }
 
@@ -323,8 +323,7 @@ describe(generateTS, () => {
               name: String!
             }
 
-            type Admin implements Node & Persona
-              @context(stateMachines: ["admin"]) {
+            type Admin implements Node & Persona @context(uses: ["admin"]) {
               id: ID!
               rank: Int!
             }
@@ -458,12 +457,11 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(stateMachines: ["node"]) {
+            interface Node @context(uses: ["node"]) {
               id: ID!
             }
 
-            interface Customer implements Node
-              @context(stateMachines: ["customer"]) {
+            interface Customer implements Node @context(uses: ["customer"]) {
               id: ID!
               name: String!
             }
@@ -555,8 +553,7 @@ describe(generateTS, () => {
     test("applying @context to enum shouldn't affect anything", () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(graphql`
-          enum PresenceAvailability
-            @context(stateMachines: ["shouldnt-apply"]) {
+          enum PresenceAvailability @context(uses: ["shouldnt-apply"]) {
             Available
             Away
             Offline
@@ -631,11 +628,11 @@ describe(generateTS, () => {
               id: ID!
             }
 
-            type Admin @context(stateMachines: ["admin"]) {
+            type Admin @context(uses: ["admin"]) {
               id: ID!
             }
 
-            type User @context(stateMachines: ["user"]) {
+            type User @context(uses: ["user"]) {
               id: ID!
             }
 
@@ -644,18 +641,17 @@ describe(generateTS, () => {
             }
 
             union UserOrAdmin = User | Admin
-            union UserOrCustomer @context(stateMachines: ["user-or-customer"]) =
+            union UserOrCustomer @context(uses: ["user-or-customer"]) =
                 User
               | Customer
-            union CompanyOrCustomer
-              @context(stateMachines: ["company-or-customer"]) =
+            union CompanyOrCustomer @context(uses: ["company-or-customer"]) =
                 Company
               | Customer
 
             extend type Query {
-              userById(id: ID!): whatever @context(stateMachines: ["whatever"])
+              userById(id: ID!): whatever @context(uses: ["whatever"])
               userByMail(mail: String): whatever
-                @context(stateMachines: ["different-whatever"])
+                @context(uses: ["different-whatever"])
               node(id: ID!): Node
             }
           `,

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -47,8 +47,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
-            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
+            contextSubTypePathTemplate:
+              "@msteams/core-cdl-sync-${resourceName}",
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -334,8 +335,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
-            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
+            contextSubTypePathTemplate:
+              "@msteams/core-cdl-sync-${resourceName}",
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -476,8 +478,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
-            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
+            contextSubTypePathTemplate:
+              "@msteams/core-cdl-sync-${resourceName}",
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -656,8 +659,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${contextName}StateMachineContext",
-            contextSubTypePathTemplate: "@msteams/core-cdl-sync-${contextName}",
+            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
+            contextSubTypePathTemplate:
+              "@msteams/core-cdl-sync-${resourceName}",
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);

--- a/packages/ts-codegen/src/__tests__/index.test.ts
+++ b/packages/ts-codegen/src/__tests__/index.test.ts
@@ -1639,7 +1639,7 @@ describe(generateTS, () => {
     });
   });
 
-  it("generateTS without ContextName and ContextImport", () => {
+  it("generateTS without ContextName and defaultContextTypePath", () => {
     const { models, resolvers, enums, inputs } = runGenerateTest(graphql`
       interface Node {
         id: ID!
@@ -2299,8 +2299,8 @@ function runGenerateTest(
   options: {
     outputPath?: string;
     documentPath?: string;
-    contextImport?: string;
-    contextName?: string;
+    defaultContextTypePath?: string;
+    contextTypeName?: string;
     legacyCompat?: boolean;
     enumsImport?: string;
     legacyNoModelsForObjects?: boolean;
@@ -2327,8 +2327,8 @@ function runGenerateTest(
   const fullOptions: {
     outputPath: string;
     documentPath: string;
-    contextImport?: string | null;
-    contextName?: string;
+    defaultContextTypePath?: string | null;
+    contextTypeName?: string;
     legacyCompat?: boolean;
     legacyEnumsCompatibility?: boolean;
     legacyNoModelsForObjects?: boolean;

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -196,7 +196,7 @@ export class TsCodegenContext {
     camelCased = true,
   ) {
     return template.replace(
-      "${contextName}",
+      "${resourceName}",
       camelCased ? camelCase(contextName, { pascalCase: true }) : contextName,
     );
   }
@@ -775,7 +775,7 @@ export function extractContext(
         ) {
           if (
             node.arguments?.length !== 1 ||
-            node.arguments[0].name.value !== "stateMachines" ||
+            node.arguments[0].name.value !== "uses" ||
             node.arguments[0].value.kind !== "ListValue"
           ) {
             throw new Error("Invalid context use");

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -25,6 +25,7 @@ import ts, {
 import { DefinitionImport, DefinitionModel } from "../types";
 import { createImportDeclaration } from "./utilities";
 import {
+  camelCase,
   createListType,
   createNonNullableType,
   createNullableType,
@@ -51,6 +52,10 @@ export type TsCodegenContextOptions = {
   };
   legacyCompat: boolean;
   legacyNoModelsForObjects: boolean;
+  contextSubTypePathTemplate?: string;
+  contextSubTypeNameTemplate?: string;
+  defaultContextSubTypePath?: string;
+  defaultContextSubTypeName?: string;
   useStringUnionsInsteadOfEnums: boolean;
   enumNamesToMigrate: string[] | null;
   enumNamesToKeep: string[] | null;
@@ -95,8 +100,16 @@ const TsCodegenContextDefault: TsCodegenContextOptions = {
 
 type ModelNameAndImport = { modelName: string; imp: DefinitionImport };
 
+export type ContextMap = {
+  [key: string]: ContextMapTypeItem;
+};
+
+export type ContextMapTypeItem = { __context?: string[] } & {
+  [key: string]: string[];
+};
 export class TsCodegenContext {
   private allTypes: Array<Type>;
+  private typeContextMap: ContextMap;
   private typeNameToType: Map<string, Type>;
   private usedEntitiesInModels: Set<string>;
   private usedEntitiesInResolvers: Set<string>;
@@ -108,6 +121,12 @@ export class TsCodegenContext {
   >;
   private typeNameToModels: Map<string, DefinitionModel>;
   private legacyInterfaces: Set<string>;
+  context?: { name: string; from: string };
+  contextDefaultSubTypeTemplate?: {
+    nameTemplate: string;
+    pathTemplate: string;
+  };
+  contextDefaultSubTypeContext?: { name: string; from: string };
   hasUsedModelInInputs: boolean;
   hasUsedEnumsInModels: boolean;
   hasEnums: boolean;
@@ -115,6 +134,7 @@ export class TsCodegenContext {
 
   constructor(private options: TsCodegenContextOptions) {
     this.allTypes = [];
+    this.typeContextMap = {};
     this.typeNameToType = new Map();
     this.usedEntitiesInModels = new Set();
     this.usedEntitiesInResolvers = new Set();
@@ -128,6 +148,178 @@ export class TsCodegenContext {
     this.hasInputs = false;
     this.hasEnums = Boolean(options.enumsImport);
     this.hasUsedEnumsInModels = false;
+
+    if (
+      options.contextSubTypeNameTemplate &&
+      options.contextSubTypePathTemplate
+    ) {
+      this.contextDefaultSubTypeTemplate = {
+        nameTemplate: options.contextSubTypeNameTemplate,
+        pathTemplate: options.contextSubTypePathTemplate,
+      };
+    }
+
+    if (
+      options.defaultContextSubTypeName &&
+      options.defaultContextSubTypePath
+    ) {
+      this.contextDefaultSubTypeContext = {
+        name: options.defaultContextSubTypeName,
+        from: options.defaultContextSubTypePath,
+      };
+    }
+
+    if (options.context.from && options.context.name) {
+      this.context = {
+        name: options.context.name,
+        from: options.context.from,
+      };
+    }
+  }
+
+  public getContextTypes<T>(
+    contextRootType: T & {
+      __context?: string[];
+    },
+  ): string[] | null {
+    if (contextRootType) {
+      if (contextRootType.__context) {
+        return contextRootType.__context;
+      }
+    }
+    return null;
+  }
+
+  public replaceTemplateWithContextName(
+    template: string,
+    contextName: string,
+    camelCased = true,
+  ) {
+    return template.replace(
+      "${contextName}",
+      camelCased ? camelCase(contextName, { pascalCase: true }) : contextName,
+    );
+  }
+
+  public getContextTemplate() {
+    return this.contextDefaultSubTypeTemplate || null;
+  }
+
+  public getContextTypeNode(typeNames?: string[] | null) {
+    const contextDefaultSubTypeTemplate = this.contextDefaultSubTypeTemplate;
+
+    if (!typeNames || !typeNames.length || !contextDefaultSubTypeTemplate) {
+      return this.getContextType().toTypeReference();
+    } else if (
+      (typeNames.length === 1 && this.contextDefaultSubTypeContext) ||
+      typeNames.length > 1
+    ) {
+      const typeNameWithNamespace = typeNames.map((typeName) => {
+        return this.replaceTemplateWithContextName(
+          contextDefaultSubTypeTemplate.nameTemplate,
+          typeName,
+        );
+      });
+
+      return factory.createIntersectionTypeNode(
+        (this.contextDefaultSubTypeContext
+          ? [this.contextDefaultSubTypeContext.name, ...typeNameWithNamespace]
+          : typeNameWithNamespace
+        ).map((type: string) => {
+          return factory.createTypeReferenceNode(
+            factory.createIdentifier(type),
+            undefined,
+          );
+        }),
+      );
+    } else {
+      return new TypeLocation(
+        null,
+        this.replaceTemplateWithContextName(
+          contextDefaultSubTypeTemplate.nameTemplate,
+          typeNames[0],
+        ),
+      ).toTypeReference();
+    }
+  }
+
+  private isNonArrayNode(
+    node: ASTNode | ReadonlyArray<ASTNode>,
+  ): node is ASTNode {
+    return !Array.isArray(node);
+  }
+
+  public initContextMap(
+    ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+    values: string[],
+  ) {
+    if (ancestors.length < 2) {
+      throw new Error("Invalid document provided");
+    }
+
+    const node = ancestors[ancestors.length - 1];
+    const nonArrayNode = this.isNonArrayNode(node) ? node : null;
+
+    if (nonArrayNode) {
+      if (
+        nonArrayNode?.kind === "ObjectTypeDefinition" ||
+        nonArrayNode?.kind === "InterfaceTypeDefinition" ||
+        nonArrayNode?.kind === "UnionTypeDefinition"
+      ) {
+        if (this.typeContextMap[nonArrayNode.name.value]?.__context) {
+          throw new Error("Type already visited");
+        }
+
+        const typeName = nonArrayNode.name.value;
+        if (!this.typeContextMap[typeName]) {
+          this.typeContextMap[typeName] = {};
+        }
+
+        this.typeContextMap[typeName].__context = values;
+      } else if (nonArrayNode?.kind === "FieldDefinition") {
+        const node = ancestors[ancestors.length - 3];
+        const typeName =
+          this.isNonArrayNode(node) &&
+          (node.kind === "ObjectTypeDefinition" ||
+            node.kind === "ObjectTypeExtension")
+            ? node.name.value
+            : null;
+
+        if (typeName) {
+          if (!this.typeContextMap[typeName]) {
+            this.typeContextMap[typeName] = {};
+          }
+
+          this.typeContextMap[typeName][nonArrayNode.name.value] = values;
+        }
+      }
+    }
+  }
+
+  getSubTypeNamesFromTemplate(
+    subTypes: string[],
+    nameTemplate: string,
+    pathTemplate: string,
+  ) {
+    return subTypes.reduce<Record<string, string[]>>(
+      (acc: Record<string, string[]>, importName: string) => {
+        const importPath = this.replaceTemplateWithContextName(
+          pathTemplate,
+          importName,
+          false,
+        );
+        if (importPath) {
+          if (!acc[importPath]) {
+            acc[importPath] = [];
+          }
+          acc[importPath].push(
+            this.replaceTemplateWithContextName(nameTemplate, importName),
+          );
+        }
+        return acc;
+      },
+      {},
+    );
   }
 
   isLegacyCompatMode(): boolean {
@@ -140,6 +332,10 @@ export class TsCodegenContext {
 
   getEnumsImport(): string | null {
     return this.options.enumsImport;
+  }
+
+  getContextMap() {
+    return this.typeContextMap;
   }
 
   addType(type: Type): void {
@@ -185,6 +381,20 @@ export class TsCodegenContext {
         this.getModelType(node.name.value, markUsage).toTypeReference(),
         markUsage === "RESOLVERS" ? true : false,
       );
+    }
+  }
+
+  getTypeFromTypeNode(node: TypeNode): string {
+    if (typeof node === "string") {
+      return node;
+    }
+
+    if (node.kind === Kind.NON_NULL_TYPE) {
+      return this.getTypeFromTypeNode(node.type);
+    } else if (node.kind === Kind.LIST_TYPE) {
+      return this.getTypeFromTypeNode(node.type);
+    } else {
+      return node.name.value;
     }
   }
 
@@ -525,7 +735,9 @@ export function extractContext(
     ...TsCodegenContextDefault,
     ...options,
   };
+
   const context = new TsCodegenContext(fullOptions);
+  const { contextSubTypeNameTemplate, contextSubTypePathTemplate } = options;
 
   visit(document, {
     Directive: {
@@ -556,6 +768,28 @@ export function extractContext(
           }
           const typeName = (typeDef as InterfaceTypeDefinitionNode).name.value;
           context.addLegacyInterface(typeName);
+        } else if (
+          node.name.value === "context" &&
+          contextSubTypeNameTemplate &&
+          contextSubTypePathTemplate
+        ) {
+          if (
+            node.arguments?.length !== 1 ||
+            node.arguments[0].name.value !== "stateMachines" ||
+            node.arguments[0].value.kind !== "ListValue"
+          ) {
+            throw new Error("Invalid context use");
+          }
+          const directiveValues = node.arguments[0].value.values.map((item) => {
+            if (item.kind !== "StringValue") {
+              throw new Error("Invalid context use");
+            }
+            return item.value;
+          });
+
+          if (directiveValues.length) {
+            context.initContextMap(ancestors, directiveValues);
+          }
         }
       },
     },

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -1,5 +1,35 @@
-import { factory } from "typescript";
+import ts, { factory } from "typescript";
 import path from "path";
+
+export function getImportIdentifierForTypenames(
+  importNames: string[],
+  importPath: string,
+  contextImportNames: Set<string>,
+) {
+  return factory.createImportDeclaration(
+    undefined,
+    factory.createImportClause(
+      true,
+      undefined,
+      factory.createNamedImports(
+        importNames
+          .map((importName: string) => {
+            if (contextImportNames.has(importName)) {
+              return;
+            }
+            contextImportNames.add(importName);
+            return factory.createImportSpecifier(
+              false,
+              undefined,
+              factory.createIdentifier(importName),
+            );
+          })
+          .filter(Boolean) as ts.ImportSpecifier[],
+      ),
+    ),
+    factory.createStringLiteral(importPath),
+  );
+}
 
 export function createImportDeclaration(
   importNames: string[],

--- a/packages/ts-codegen/src/utilities.ts
+++ b/packages/ts-codegen/src/utilities.ts
@@ -23,13 +23,16 @@ type ResolverParameterDefinition<T> = { name: string; type: T };
 type ResolverParametersDefinitions = {
   parent: ResolverParameterDefinition<ts.TypeReferenceNode>;
   args?: ResolverParameterDefinition<readonly ts.TypeElement[]>;
-  context: ResolverParameterDefinition<ts.TypeReferenceNode>;
+  context: ResolverParameterDefinition<
+    ts.TypeReferenceNode | ts.IntersectionTypeNode
+  >;
   resolveInfo: ResolverParameterDefinition<ts.TypeReferenceNode>;
 };
 
 export function createUnionResolveType(
   context: TsCodegenContext,
   type: UnionType,
+  contextType: ts.TypeReferenceNode | ts.IntersectionTypeNode,
 ): ts.FunctionTypeNode {
   return factory.createFunctionTypeNode(
     undefined,
@@ -44,7 +47,7 @@ export function createUnionResolveType(
       },
       context: {
         name: "context",
-        type: context.getContextType().toTypeReference(),
+        type: contextType,
       },
       resolveInfo: {
         name: "info",
@@ -68,6 +71,7 @@ export function createUnionResolveType(
 
 export function createInterfaceResolveType(
   context: TsCodegenContext,
+  contextType: ts.TypeReferenceNode | ts.IntersectionTypeNode,
 ): ts.FunctionTypeNode {
   return factory.createFunctionTypeNode(
     undefined,
@@ -78,7 +82,7 @@ export function createInterfaceResolveType(
       },
       context: {
         name: "context",
-        type: context.getContextType().toTypeReference(),
+        type: contextType,
       },
       resolveInfo: {
         name: "info",


### PR DESCRIPTION
New parameters which are used to build imports of the context types are introduced

By default all context types are `unknown by default`. This is an option to apply a different type
```
--context-type-path [contextTypePath]
--context-type-name [contextTypeName]
```

used as -> `import { ${contextTypeName} from "${contextTypePath}"`

Newly there is an option to attach resources to fields using @context directive.
```
directive @context(
  uses: [String!]!
) on FIELD_DEFINITION | OBJECT | UNION | INTERFACE
```
A type used for extending every resource type.
```
--default-context-sub-type-path [defaultContextSubTypePath]
--default-context-sub-type-name [defaultContextSubTypeName]
```

used as -> `import { ${defaultContextSubTypeName} from "${defaultContextSubTypePath}"`

Template for resource types, which are extracted from resource names specified in the directive. For not we expect kebab-cased names in the context directive.
```
--context-sub-type-name-template [contextSubTypeNameTemplate]
--context-sub-type-path-template [contextSubTypePathTemplate]
```

Template must have `${resourceName}` specified, which will be then replaced with the resource name applied to fields

Example
contextSubTypeNameTemplate: `somePreffix${ResourceName}SomeSuffix` // type name 
contextSubTypePathTemplate: `import-${resourceName}-path` // type import path

used as -> `import { ${contextSubTypeNameTemplate} from "${contextSubTypePathTemplate}"`

### Resolver types
With defaultContextSubTypePath, defaultContextSubTypeName, contextSubTypeNameTemplate and contextSubTypePathTemplate specified a resolver type will then look like:

#### Parameters
```
  "--context-sub-type-name-template=I${resourceName}Context",
  "--context-sub-type-path-template=@package/core-sync-${resourceName}",
  "--default-context-sub-type-name=IDefaultContext",
  "--default-context-sub-type-path=@package/core-sync",
```
#### GraphQL definition
```
type Dummy @context(uses: ["dummy"]) {
  id: ID! @context(uses: ["id-dummy"])
  value: String!
  subDummy: SubDummy!
}
```

#### Generated Typescript
```
import type { IDefaultContext } from "@package/core-sync";
import type { IDummyContext } from "@package/core-sync-dummy";
import type { IIdDummyContext } from "@package/core-sync-id-dummy";

export declare namespace Dummy {
    export interface Resolvers {
        readonly id?: id;
        readonly value?: value;
        readonly subDummy?: subDummy;
    }
    export type id = (model: Models.Dummy, args: {}, context: IDefaultContext & IIdDummyContext, info: ResolveInfo) => PromiseOrValue<string>;
    export type value = (model: Models.Dummy, args: {}, context: IDefaultContext & IDummyContext, info: ResolveInfo) => PromiseOrValue<string>;
    export type subDummy = (model: Models.Dummy, args: {}, context: IDefaultContext & IDummyContext, info: ResolveInfo) => PromiseOrValue<Models.SubDummy>;
}
```