### PR TITLE
ForestRun: Explicit LRU eviction as a part of write transaction

### DIFF
--- a/change/@graphitation-apollo-forest-run-f9506eab-d2d4-4832-a8e0-2d9b33f81a18.json
+++ b/change/@graphitation-apollo-forest-run-f9506eab-d2d4-4832-a8e0-2d9b33f81a18.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Explicit LRU eviction as a part of write transaction",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -25,6 +25,7 @@ import {
   createOptimisticLayer,
   createStore,
   getEffectiveReadLayers,
+  maybeEvictOldData,
   removeOptimisticLayers,
   resetStore,
 } from "./cache/store";
@@ -481,6 +482,8 @@ export class ForestRun extends ApolloCache<any> {
         typeof optimistic === "string",
       );
     }
+    maybeEvictOldData(this.env, this.store);
+
     return result as T;
   }
 

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -19,6 +19,7 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     inheritTypePolicies(typePolicies, possibleTypes);
   }
   let id = 0;
+  let tick = 0;
   const env: CacheEnv = {
     addTypename: config?.addTypename ?? true,
     apolloCompat_keepOrphanNodes: config?.apolloCompat_keepOrphanNodes ?? false,
@@ -34,6 +35,7 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     },
     mergePolicies: new Map(),
     readPolicies: new Map(),
+    now: () => ++tick, // Logical time
     genId: () => ++id,
     objectKey: (
       object: object,

--- a/packages/apollo-forest-run/src/cache/read.ts
+++ b/packages/apollo-forest-run/src/cache/read.ts
@@ -29,7 +29,11 @@ import { indexTree } from "../forest/indexTree";
 import { createChunkMatcher, createChunkProvider } from "./draftHelpers";
 import { getDiffDescriptor, getOriginalDocument } from "./descriptor";
 import { Cache, MissingFieldError } from "@apollo/client";
-import { getActiveForest, getEffectiveReadLayers } from "./store";
+import {
+  getActiveForest,
+  getEffectiveReadLayers,
+  touchOperation,
+} from "./store";
 import { assert } from "../jsutils/assert";
 import { addTree, trackTreeNodes } from "../forest/addTree";
 
@@ -46,6 +50,7 @@ export function read<TData>(
   // Normally, this is a data forest, but when executed within transaction - could be one of the optimistic layers
   const forest = getActiveForest(store, activeTransaction);
   const operationDescriptor = getDiffDescriptor(env, store, options);
+  touchOperation(env, store, operationDescriptor);
 
   const resultsMap =
     options.optimistic && optimisticLayers.length

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -1,6 +1,6 @@
-import { Cache, InMemoryCacheConfig, TypePolicies } from "@apollo/client";
-import { IndexedForest, IndexedTree } from "../forest/types";
-import {
+import type { Cache, InMemoryCacheConfig, TypePolicies } from "@apollo/client";
+import type { IndexedForest, IndexedTree } from "../forest/types";
+import type {
   NodeKey,
   FieldName,
   OperationDescriptor,
@@ -9,16 +9,17 @@ import {
   ArgumentValues,
   Directives,
   TypeName,
+  OperationId,
 } from "../descriptor/types";
-import { DocumentNode } from "graphql/index";
-import {
+import type { DocumentNode } from "graphql";
+import type {
   Key,
   KeySpecifier,
   ObjectKey,
   SourceCompositeList,
   SourceObject,
 } from "../values/types";
-import {
+import type {
   FieldMergeFunction,
   FieldReadFunction,
 } from "@apollo/client/cache/inmemory/policies";
@@ -60,6 +61,9 @@ export type Store = {
   optimisticReadResults: Map<OperationDescriptor, TransformedResult>;
   partialReadResults: Set<OperationDescriptor>; // FIXME: this should be per layer for proper cleanup
   watches: Map<OperationDescriptor, Array<Cache.WatchOptions>>;
+  // Last access time of operation
+  //   Used for LRU eviction
+  atime: Map<OperationId, number>;
 };
 
 export type Transaction = {
@@ -91,6 +95,7 @@ export type CacheEnv = {
 
   possibleTypes?: PossibleTypes;
 
+  now(): number;
   genId: () => number;
 
   // TODO: use keyFields instead of objectKey function

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -19,7 +19,11 @@ import {
   ROOT_TYPES,
 } from "./descriptor";
 import { applyMergePolicies } from "./policies";
-import { getActiveForest, getEffectiveReadLayers } from "./store";
+import {
+  getActiveForest,
+  getEffectiveReadLayers,
+  touchOperation,
+} from "./store";
 import { diffTree, GraphDifference } from "../diff/diffTree";
 import {
   resolveAffectedOperations,
@@ -62,6 +66,7 @@ export function write(
     options.variables,
     rootNodeKey,
   );
+  touchOperation(env, store, operationDescriptor);
   const operationResult: OperationResult = { data: writeData };
 
   if (

--- a/packages/apollo-forest-run/src/forest/types.ts
+++ b/packages/apollo-forest-run/src/forest/types.ts
@@ -20,7 +20,6 @@ import {
   SourceObject,
   TypeMap,
 } from "../values/types";
-import { MapLike } from "../jsutils/lru";
 
 export type IndexedTree = {
   operation: OperationDescriptor;
@@ -46,7 +45,7 @@ export type IndexedTree = {
 };
 
 export type IndexedForest = {
-  trees: MapLike<OperationId, IndexedTree>;
+  trees: Map<OperationId, IndexedTree>;
   extraRootIds: Map<NodeKey, TypeName>;
   operationsByNodes: Map<NodeKey, Set<OperationId>>; // May contain false positives
   operationsWithErrors: Set<OperationDescriptor>; // May contain false positives


### PR DESCRIPTION
ForestRun evicts older trees automatically using LRU strategy. But the strategy before this PR was somewhat magical, using LRUMap for "trees" data. Basically any access to the via map `.get()` method caused the tree to be touched. This doesn't work well in certain cases. Plus, eviction happens in random moments and it is hard to control.

This PR exposes eviction as an explicit step in transaction as soon as forest size reaches a threshold for eviction. This way we have better control over it, and can adjust additional scenarios where we want to keep data in cache longer (e.g. with duct-tape integration)