### PR TITLE
ForestRun: Expose data cleanup through Apollo gc() method

### DIFF
--- a/change/@graphitation-apollo-forest-run-07cc18c7-3acd-465a-bb5f-c0c1131a7052.json
+++ b/change/@graphitation-apollo-forest-run-07cc18c7-3acd-465a-bb5f-c0c1131a7052.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose explicit data cleanup through Apollo gc() method",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -24,6 +24,7 @@ import { modify } from "./cache/modify";
 import {
   createOptimisticLayer,
   createStore,
+  evictOldData,
   getEffectiveReadLayers,
   maybeEvictOldData,
   removeOptimisticLayers,
@@ -362,6 +363,13 @@ export class ForestRun extends ApolloCache<any> {
 
   public restore(_: Record<string, any>): this {
     throw new Error("ForestRunCache.restore() is not supported");
+  }
+
+  public gc(): string[] {
+    if (this.env.maxOperationCount) {
+      return evictOldData(this.env, this.store).map(String);
+    }
+    return [];
   }
 
   public getStats() {

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -61,13 +61,18 @@ export function touchOperation(
 }
 
 export function maybeEvictOldData(env: CacheEnv, store: Store): OperationId[] {
-  const { dataForest, atime } = store;
   if (
     !env.maxOperationCount ||
-    dataForest.trees.size <= env.maxOperationCount * 2
+    store.dataForest.trees.size <= env.maxOperationCount * 2
   ) {
     return [];
   }
+  return evictOldData(env, store);
+}
+
+export function evictOldData(env: CacheEnv, store: Store): OperationId[] {
+  assert(env.maxOperationCount);
+  const { dataForest, atime } = store;
   let nonEvictable = 0;
   const toEvict: number[] = [];
   for (const tree of dataForest.trees.values()) {


### PR DESCRIPTION
ForestRun cleans up old unused trees automatically as soon as cache size reaches a certain threshold. But sometimes it makes sense to not wait and call cleanup explicitly. Apollo already has `gc()` method in its abstract ApolloCache class. In this PR we expose `ForestRun` cleanup via this method.