### PR TITLE
fix: prevent excessive re-renders in ForestRun

### DIFF
--- a/change/@graphitation-apollo-forest-run-b3e52c0c-9b15-451a-bf65-ecb0ce45aa97.json
+++ b/change/@graphitation-apollo-forest-run-b3e52c0c-9b15-451a-bf65-ecb0ce45aa97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent excessive re-renders",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -555,21 +555,13 @@ export class ForestRun extends ApolloCache<any> {
     }
 
     // Always notify when there is no "lastDiff" (first notification)
-    // intentionally not strict (null == undefined)
-    if (lastDiff && newDiff.result == lastDiff.result) {
-      return false;
-    }
     if (
       lastDiff &&
-      !newDiff.complete &&
-      !lastDiff.complete &&
-      !watch.returnPartialData &&
-      equal(lastDiff.result, newDiff.result)
+      (newDiff.result == lastDiff.result || // intentionally not strict (null == undefined)
+        equal(lastDiff.result, newDiff.result))
     ) {
-      // Already notified about partial data once
       return false;
     }
-
     // ApolloCompat: let transaction initiator decide
     if (
       onWatchUpdated &&


### PR DESCRIPTION
In some cases results after a transaction end up being equal to the last notified diff.

In this case we shouldn't notify watchers, but we do. This PR is just a quick-fix. My initial assumption was that the scenario where data is equal, but not strictly equal is not possible with FR, but so far it seems to be possible.

The proper fix requires further investigation and reproduction of the scenario where this is possible.