### PR TITLE
feat: configurable auto-eviction

### DIFF
--- a/change/@graphitation-apollo-forest-run-e9ffb57c-ed0c-4c9f-8ea6-e14822696d37.json
+++ b/change/@graphitation-apollo-forest-run-e9ffb57c-ed0c-4c9f-8ea6-e14822696d37.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: configurable auto-eviction",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/eviction.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/eviction.test.ts
@@ -1,0 +1,145 @@
+import { ForestRun } from "../ForestRun";
+import { gql } from "./helpers/descriptor";
+
+it("evicts data automatically by default", () => {
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+  });
+  const query = gql`
+    query ($i: Int) {
+      foo(i: $i)
+    }
+  `;
+
+  cache.write({ query, variables: { i: 0 }, result: { foo: 0 } });
+  cache.write({ query, variables: { i: 1 }, result: { foo: 1 } });
+  cache.write({ query, variables: { i: 2 }, result: { foo: 2 } });
+
+  const result0 = cache.read({ query, variables: { i: 0 }, optimistic: true });
+  const result1 = cache.read({ query, variables: { i: 1 }, optimistic: true });
+  const result2 = cache.read({ query, variables: { i: 2 }, optimistic: true });
+
+  expect(result0).toEqual(null);
+  expect(result1).toEqual(null);
+  expect(result2).toEqual({ foo: 2 });
+});
+
+it("allows disabling automatic eviction", () => {
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+    autoEvict: false,
+  });
+  const query = gql`
+    query ($i: Int) {
+      foo(i: $i)
+    }
+  `;
+
+  cache.write({ query, variables: { i: 0 }, result: { foo: 0 } });
+  cache.write({ query, variables: { i: 1 }, result: { foo: 1 } });
+  cache.write({ query, variables: { i: 2 }, result: { foo: 2 } });
+
+  const result0 = cache.read({ query, variables: { i: 0 }, optimistic: true });
+  const result1 = cache.read({ query, variables: { i: 1 }, optimistic: true });
+  const result2 = cache.read({ query, variables: { i: 2 }, optimistic: true });
+
+  expect(result0).toEqual({ foo: 0 });
+  expect(result1).toEqual({ foo: 1 });
+  expect(result2).toEqual({ foo: 2 });
+});
+
+it("allows manual eviction", () => {
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+    autoEvict: false,
+  });
+  const query = gql`
+    query ($i: Int) {
+      foo(i: $i)
+    }
+  `;
+
+  cache.write({ query, variables: { i: 0 }, result: { foo: 0 } });
+  cache.write({ query, variables: { i: 1 }, result: { foo: 1 } });
+  cache.write({ query, variables: { i: 2 }, result: { foo: 2 } });
+
+  cache.gc();
+
+  const result0 = cache.read({ query, variables: { i: 0 }, optimistic: true });
+  const result1 = cache.read({ query, variables: { i: 1 }, optimistic: true });
+  const result2 = cache.read({ query, variables: { i: 2 }, optimistic: true });
+
+  expect(result0).toEqual(null);
+  expect(result1).toEqual(null);
+  expect(result2).toEqual({ foo: 2 });
+});
+
+it("doesn't evict watched old operations", () => {
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+    autoEvict: false,
+  });
+  const query = gql`
+    query ($i: Int) {
+      foo(i: $i)
+    }
+  `;
+
+  cache.watch({
+    query,
+    variables: { i: 1 },
+    optimistic: true,
+    callback: () => {},
+  });
+
+  cache.write({ query, variables: { i: 0 }, result: { foo: 0 } });
+  cache.write({ query, variables: { i: 1 }, result: { foo: 1 } });
+  cache.write({ query, variables: { i: 2 }, result: { foo: 2 } });
+
+  cache.gc();
+
+  const result0 = cache.read({ query, variables: { i: 0 }, optimistic: true });
+  const result1 = cache.read({ query, variables: { i: 1 }, optimistic: true });
+  const result2 = cache.read({ query, variables: { i: 2 }, optimistic: true });
+
+  expect(result0).toEqual(null);
+  expect(result1).toEqual({ foo: 1 });
+  expect(result2).toEqual({ foo: 2 });
+});
+
+it("allows to opt out operations from eviction", () => {
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+    autoEvict: false,
+    nonEvictableQueries: new Set(["b"]), // root-level field
+  });
+  const a = gql`
+    {
+      a
+    }
+  `;
+  const b = gql`
+    {
+      b
+    }
+  `;
+  const c = gql`
+    {
+      c
+    }
+  `;
+
+  cache.write({ query: a, result: { a: 0 } });
+  cache.write({ query: b, result: { b: 1 } });
+  cache.write({ query: c, result: { c: 2 } });
+
+  cache.gc();
+
+  const result0 = cache.read({ query: a, optimistic: true });
+  const result1 = cache.read({ query: b, optimistic: true });
+  const result2 = cache.read({ query: c, optimistic: true });
+
+  expect(result0).toEqual(null);
+  expect(result1).toEqual({ b: 1 });
+  expect(result2).toEqual({ c: 2 });
+});

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -23,7 +23,6 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
   const env: CacheEnv = {
     addTypename: config?.addTypename ?? true,
     apolloCompat_keepOrphanNodes: config?.apolloCompat_keepOrphanNodes ?? false,
-    maxOperationCount: config?.maxOperationCount ?? 1000,
     possibleTypes,
     typePolicies,
     dataIdFromObject: config?.dataIdFromObject,
@@ -35,6 +34,9 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     },
     mergePolicies: new Map(),
     readPolicies: new Map(),
+    autoEvict: config?.autoEvict ?? true,
+    nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
+    maxOperationCount: config?.maxOperationCount ?? 1000,
     now: () => ++tick, // Logical time
     genId: () => ++id,
     objectKey: (

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -63,6 +63,7 @@ export function touchOperation(
 
 export function maybeEvictOldData(env: CacheEnv, store: Store): OperationId[] {
   if (
+    !env.autoEvict ||
     !env.maxOperationCount ||
     store.dataForest.trees.size <= env.maxOperationCount * 2
   ) {

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -80,6 +80,7 @@ export type Transaction = {
 };
 
 export type CacheConfig = InMemoryCacheConfig & {
+  autoEvict?: boolean;
   maxOperationCount?: number;
   nonEvictableQueries?: Set<string>;
   apolloCompat_keepOrphanNodes?: boolean;
@@ -141,6 +142,7 @@ export type CacheEnv = {
 
   mergePolicies: Map<TypeName, Map<FieldName, FieldMergeFunction>>;
   readPolicies: Map<TypeName, Map<FieldName, FieldReadFunction>>;
-  nonEvictableQueries?: Set<string>;
-  maxOperationCount?: number;
+  autoEvict: boolean;
+  nonEvictableQueries: Set<string>;
+  maxOperationCount: number;
 };


### PR DESCRIPTION
Today ForestRun does automatic data eviction when the number of operation exceeds `maxOperationResult` option. This PR introduces an `autoEvict` option which allows disabling automated eviction and instead control when data eviction kicks in with `gc` method from Apollo cache interface.

Related options:

- `autoEvict`: default `true`
- `maxOperationCount`: default `1000`
