### PR TITLE
Make root fields mandatory

### DIFF
--- a/change/@graphitation-cli-ab95b636-c6c9-42ed-bc92-b5b765abf810.json
+++ b/change/@graphitation-cli-ab95b636-c6c9-42ed-bc92-b5b765abf810.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(ts-codegen): option to make root operation types mandatory",
+  "packageName": "@graphitation/cli",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-cd777679-7d9e-4240-a4a0-2ee7e3ae666a.json
+++ b/change/@graphitation-ts-codegen-cd777679-7d9e-4240-a4a0-2ee7e3ae666a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(ts-codegen): option to make root operation types mandatory",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/__tests__/__snapshots__/typeDefsToImplicitResolvers.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/typeDefsToImplicitResolvers.test.ts.snap
@@ -529,3 +529,515 @@ export default interface ResolversMap {
 `;
 
 exports[`supermassive should generate interfaces with --generate-resolver-map 4`] = `"{}"`;
+
+exports[`supermassive should generate interfaces with --mandatory-root-operation-types --generate-resolver-map 1`] = `
+"/* eslint-disable */ 
+// This file was automatically generated (by @graphitation/supermassive) and should not be edited.
+export enum NodeType {
+    Person = "Person",
+    Starship = "Starship",
+    Transport = "Transport",
+    Species = "Species",
+    Vehicle = "Vehicle",
+    Planet = "Planet",
+    Film = "Film"
+}
+"
+`;
+
+exports[`supermassive should generate interfaces with --mandatory-root-operation-types --generate-resolver-map 2`] = `
+"/* eslint-disable */ 
+// This file was automatically generated (by @graphitation/supermassive) and should not be edited.
+export * from "./enums.interface";
+// Base type for all models. Enables automatic resolution of abstract GraphQL types (interfaces, unions)
+export interface BaseModel {
+    readonly __typename?: string;
+}
+export type SearchResult = Person | Starship | Transport | Species | Vehicle | Planet | Film;
+export interface Node extends BaseModel {
+    readonly __typename?: string;
+}
+export interface Film extends BaseModel, Node {
+    readonly __typename?: "Film";
+    readonly title: string;
+    readonly starships?: ReadonlyArray<Starship | null> | null;
+    readonly edited?: string | null;
+    readonly vehicles?: ReadonlyArray<Vehicle | null> | null;
+    readonly planets?: ReadonlyArray<Planet | null> | null;
+    readonly producer?: string | null;
+    readonly created?: string | null;
+    readonly episode_id?: number | null;
+    readonly director?: string | null;
+    readonly release_date?: string | null;
+    readonly opening_crawl?: string | null;
+    readonly characters?: ReadonlyArray<Person | null> | null;
+    readonly species?: ReadonlyArray<Species | null> | null;
+    readonly id?: number | null;
+}
+export interface Vehicle extends BaseModel, Node {
+    readonly __typename?: "Vehicle";
+    readonly id?: number | null;
+    readonly name?: string | null;
+    readonly vehicle_class?: string | null;
+    readonly pilots?: ReadonlyArray<Person | null> | null;
+    readonly edited?: string | null;
+    readonly consumables?: string | null;
+    readonly created?: string | null;
+    readonly model?: string | null;
+    readonly manufacturer?: string | null;
+    readonly image?: string | null;
+    readonly cargo_capacity?: number | null;
+    readonly passengers?: number | null;
+    readonly max_atmosphering_speed?: number | null;
+    readonly crew?: number | null;
+    readonly length?: number | null;
+    readonly cost_in_credits?: number | null;
+}
+export interface Person extends BaseModel, Node {
+    readonly __typename?: "Person";
+    readonly id?: number | null;
+    readonly edited?: string | null;
+    readonly name?: string | null;
+    readonly created?: string | null;
+    readonly gender?: string | null;
+    readonly skin_color?: string | null;
+    readonly hair_color?: string | null;
+    readonly height?: number | null;
+    readonly eye_color?: string | null;
+    readonly mass?: number | null;
+    readonly homeworld?: Planet | null;
+    readonly birth_year?: string | null;
+    readonly image?: string | null;
+    readonly vehicles?: ReadonlyArray<Vehicle | null> | null;
+    readonly starships?: ReadonlyArray<Starship | null> | null;
+    readonly films?: ReadonlyArray<Film | null> | null;
+}
+export interface Starship extends BaseModel, Node {
+    readonly __typename?: "Starship";
+    readonly id?: number | null;
+    readonly films?: ReadonlyArray<Film | null> | null;
+    readonly pilots?: ReadonlyArray<Person | null> | null;
+    readonly MGLT?: number | null;
+    readonly starship_class?: string | null;
+    readonly hyperdrive_rating?: number | null;
+    readonly edited?: string | null;
+    readonly consumables?: string | null;
+    readonly name?: string | null;
+    readonly created?: string | null;
+    readonly cargo_capacity?: number | null;
+    readonly passengers?: number | null;
+    readonly max_atmosphering_speed?: number | null;
+    readonly crew?: string | null;
+    readonly length?: number | null;
+    readonly model?: string | null;
+    readonly cost_in_credits?: number | null;
+    readonly manufacturer?: string | null;
+    readonly image?: string | null;
+}
+export interface Planet extends BaseModel, Node {
+    readonly __typename?: "Planet";
+    readonly id?: number | null;
+    readonly edited?: string | null;
+    readonly climate?: string | null;
+    readonly surface_water?: string | null;
+    readonly name?: string | null;
+    readonly diameter?: number | null;
+    readonly rotation_period?: number | null;
+    readonly created?: string | null;
+    readonly terrain?: string | null;
+    readonly gravity?: string | null;
+    readonly orbital_period?: number | null;
+    readonly population?: number | null;
+    readonly residents?: ReadonlyArray<Person | null> | null;
+    readonly films?: ReadonlyArray<Film | null> | null;
+}
+export interface Species extends BaseModel, Node {
+    readonly __typename?: "Species";
+    readonly edited?: string | null;
+    readonly classification?: string | null;
+    readonly name?: string | null;
+    readonly designation?: string | null;
+    readonly created?: string | null;
+    readonly eye_colors?: string | null;
+    readonly people?: ReadonlyArray<Person | null> | null;
+    readonly skin_colors?: string | null;
+    readonly language?: string | null;
+    readonly hair_colors?: string | null;
+    readonly homeworld?: Planet | null;
+    readonly average_lifespan?: number | null;
+    readonly average_height?: number | null;
+    readonly id?: number | null;
+}
+export interface Transport extends BaseModel, Node {
+    readonly __typename?: "Transport";
+    readonly edited?: string | null;
+    readonly consumables?: string | null;
+    readonly name?: string | null;
+    readonly created?: string | null;
+    readonly cargo_capacity?: number | null;
+    readonly passengers?: number | null;
+    readonly max_atmosphering_speed?: number | null;
+    readonly crew?: string | null;
+    readonly length?: number | null;
+    readonly model?: string | null;
+    readonly cost_in_credits?: number | null;
+    readonly manufacturer?: string | null;
+    readonly image?: string | null;
+    readonly id?: number | null;
+}
+"
+`;
+
+exports[`supermassive should generate interfaces with --mandatory-root-operation-types --generate-resolver-map 3`] = `
+"/* eslint-disable */ 
+// This file was automatically generated (by @graphitation/supermassive) and should not be edited.
+import type { PromiseOrValue } from "@graphitation/supermassive";
+import type { ResolveInfo } from "@graphitation/supermassive";
+import * as Models from "./models.interface";
+export declare namespace SearchResult {
+    export interface Resolvers {
+        readonly __resolveType?: __resolveType;
+    }
+    export type __resolveType = (parent: Models.Person | Models.Starship | Models.Transport | Models.Species | Models.Vehicle | Models.Planet | Models.Film, context: unknown, info: ResolveInfo) => PromiseOrValue<"Person" | "Starship" | "Transport" | "Species" | "Vehicle" | "Planet" | "Film" | null>;
+}
+export declare namespace Query {
+    export interface Resolvers {
+        readonly node: node;
+        readonly search: search;
+        readonly person: person;
+        readonly planet: planet;
+        readonly film: film;
+        readonly transport: transport;
+        readonly starship: starship;
+        readonly vehicle: vehicle;
+        readonly searchPeopleByName: searchPeopleByName;
+        readonly searchStarshipsByName: searchStarshipsByName;
+        readonly searchTransportsByName: searchTransportsByName;
+        readonly searchSpeciesByName: searchSpeciesByName;
+        readonly searchVehiclesByName: searchVehiclesByName;
+        readonly searchPlanetsByName: searchPlanetsByName;
+        readonly searchFilmsByTitle: searchFilmsByTitle;
+        readonly allFilms: allFilms;
+        readonly allStarships: allStarships;
+        readonly allPeople: allPeople;
+        readonly allPlanets: allPlanets;
+        readonly allSpecies: allSpecies;
+        readonly allTransports: allTransports;
+    }
+    export type node = (model: unknown, args: {
+        readonly nodeType: Models.NodeType;
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Node | null | undefined>;
+    export type search = (model: unknown, args: {
+        readonly search?: string | null;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.SearchResult | null | undefined> | null | undefined>;
+    export type person = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Person | null | undefined>;
+    export type planet = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Planet | null | undefined>;
+    export type film = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Film | null | undefined>;
+    export type transport = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Transport | null | undefined>;
+    export type starship = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Starship | null | undefined>;
+    export type vehicle = (model: unknown, args: {
+        readonly id: number;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Vehicle | null | undefined>;
+    export type searchPeopleByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type searchStarshipsByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Starship | null | undefined> | null | undefined>;
+    export type searchTransportsByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Transport | null | undefined> | null | undefined>;
+    export type searchSpeciesByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Species | null | undefined> | null | undefined>;
+    export type searchVehiclesByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Vehicle | null | undefined> | null | undefined>;
+    export type searchPlanetsByName = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Planet | null | undefined> | null | undefined>;
+    export type searchFilmsByTitle = (model: unknown, args: {
+        readonly search: string;
+    }, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Film | null | undefined> | null | undefined>;
+    export type allFilms = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Film | null | undefined> | null | undefined>;
+    export type allStarships = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Starship | null | undefined> | null | undefined>;
+    export type allPeople = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type allPlanets = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Planet | null | undefined> | null | undefined>;
+    export type allSpecies = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Species | null | undefined> | null | undefined>;
+    export type allTransports = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Transport | null | undefined> | null | undefined>;
+}
+export declare namespace Node {
+    export interface Resolvers {
+        readonly __resolveType?: __resolveType;
+    }
+    export type __resolveType = (parent: unknown, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null>;
+}
+export declare namespace Film {
+    export interface Resolvers {
+        readonly title?: title;
+        readonly starships?: starships;
+        readonly edited?: edited;
+        readonly vehicles?: vehicles;
+        readonly planets?: planets;
+        readonly producer?: producer;
+        readonly created?: created;
+        readonly episode_id?: episode_id;
+        readonly director?: director;
+        readonly release_date?: release_date;
+        readonly opening_crawl?: opening_crawl;
+        readonly characters?: characters;
+        readonly species?: species;
+        readonly id?: id;
+    }
+    export type title = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+    export type starships = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Starship | null | undefined> | null | undefined>;
+    export type edited = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type vehicles = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Vehicle | null | undefined> | null | undefined>;
+    export type planets = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Planet | null | undefined> | null | undefined>;
+    export type producer = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type episode_id = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type director = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type release_date = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type opening_crawl = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type characters = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type species = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Species | null | undefined> | null | undefined>;
+    export type id = (model: Models.Film, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+}
+export declare namespace Vehicle {
+    export interface Resolvers {
+        readonly id?: id;
+        readonly name?: name;
+        readonly vehicle_class?: vehicle_class;
+        readonly pilots?: pilots;
+        readonly edited?: edited;
+        readonly consumables?: consumables;
+        readonly created?: created;
+        readonly model?: model;
+        readonly manufacturer?: manufacturer;
+        readonly image?: image;
+        readonly cargo_capacity?: cargo_capacity;
+        readonly passengers?: passengers;
+        readonly max_atmosphering_speed?: max_atmosphering_speed;
+        readonly crew?: crew;
+        readonly length?: length;
+        readonly cost_in_credits?: cost_in_credits;
+    }
+    export type id = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type name = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type vehicle_class = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type pilots = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type edited = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type consumables = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type model = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type manufacturer = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type image = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type cargo_capacity = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type passengers = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type max_atmosphering_speed = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type crew = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type length = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type cost_in_credits = (model: Models.Vehicle, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+}
+export declare namespace Person {
+    export interface Resolvers {
+        readonly id?: id;
+        readonly edited?: edited;
+        readonly name?: name;
+        readonly created?: created;
+        readonly gender?: gender;
+        readonly skin_color?: skin_color;
+        readonly hair_color?: hair_color;
+        readonly height?: height;
+        readonly eye_color?: eye_color;
+        readonly mass?: mass;
+        readonly homeworld?: homeworld;
+        readonly birth_year?: birth_year;
+        readonly image?: image;
+        readonly vehicles?: vehicles;
+        readonly starships?: starships;
+        readonly films?: films;
+    }
+    export type id = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type edited = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type name = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type gender = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type skin_color = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type hair_color = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type height = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type eye_color = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type mass = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type homeworld = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Planet | null | undefined>;
+    export type birth_year = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type image = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type vehicles = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Vehicle | null | undefined> | null | undefined>;
+    export type starships = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Starship | null | undefined> | null | undefined>;
+    export type films = (model: Models.Person, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Film | null | undefined> | null | undefined>;
+}
+export declare namespace Starship {
+    export interface Resolvers {
+        readonly id?: id;
+        readonly films?: films;
+        readonly pilots?: pilots;
+        readonly MGLT?: MGLT;
+        readonly starship_class?: starship_class;
+        readonly hyperdrive_rating?: hyperdrive_rating;
+        readonly edited?: edited;
+        readonly consumables?: consumables;
+        readonly name?: name;
+        readonly created?: created;
+        readonly cargo_capacity?: cargo_capacity;
+        readonly passengers?: passengers;
+        readonly max_atmosphering_speed?: max_atmosphering_speed;
+        readonly crew?: crew;
+        readonly length?: length;
+        readonly model?: model;
+        readonly cost_in_credits?: cost_in_credits;
+        readonly manufacturer?: manufacturer;
+        readonly image?: image;
+    }
+    export type id = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type films = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Film | null | undefined> | null | undefined>;
+    export type pilots = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type MGLT = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type starship_class = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type hyperdrive_rating = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type edited = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type consumables = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type name = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type cargo_capacity = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type passengers = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type max_atmosphering_speed = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type crew = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type length = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type model = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type cost_in_credits = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type manufacturer = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type image = (model: Models.Starship, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+}
+export declare namespace Planet {
+    export interface Resolvers {
+        readonly id?: id;
+        readonly edited?: edited;
+        readonly climate?: climate;
+        readonly surface_water?: surface_water;
+        readonly name?: name;
+        readonly diameter?: diameter;
+        readonly rotation_period?: rotation_period;
+        readonly created?: created;
+        readonly terrain?: terrain;
+        readonly gravity?: gravity;
+        readonly orbital_period?: orbital_period;
+        readonly population?: population;
+        readonly residents?: residents;
+        readonly films?: films;
+    }
+    export type id = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type edited = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type climate = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type surface_water = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type name = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type diameter = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type rotation_period = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type created = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type terrain = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type gravity = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type orbital_period = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type population = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type residents = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type films = (model: Models.Planet, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Film | null | undefined> | null | undefined>;
+}
+export declare namespace Species {
+    export interface Resolvers {
+        readonly edited?: edited;
+        readonly classification?: classification;
+        readonly name?: name;
+        readonly designation?: designation;
+        readonly created?: created;
+        readonly eye_colors?: eye_colors;
+        readonly people?: people;
+        readonly skin_colors?: skin_colors;
+        readonly language?: language;
+        readonly hair_colors?: hair_colors;
+        readonly homeworld?: homeworld;
+        readonly average_lifespan?: average_lifespan;
+        readonly average_height?: average_height;
+        readonly id?: id;
+    }
+    export type edited = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type classification = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type name = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type designation = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type eye_colors = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type people = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Person | null | undefined> | null | undefined>;
+    export type skin_colors = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type language = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type hair_colors = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type homeworld = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Planet | null | undefined>;
+    export type average_lifespan = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type average_height = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type id = (model: Models.Species, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+}
+export declare namespace Transport {
+    export interface Resolvers {
+        readonly edited?: edited;
+        readonly consumables?: consumables;
+        readonly name?: name;
+        readonly created?: created;
+        readonly cargo_capacity?: cargo_capacity;
+        readonly passengers?: passengers;
+        readonly max_atmosphering_speed?: max_atmosphering_speed;
+        readonly crew?: crew;
+        readonly length?: length;
+        readonly model?: model;
+        readonly cost_in_credits?: cost_in_credits;
+        readonly manufacturer?: manufacturer;
+        readonly image?: image;
+        readonly id?: id;
+    }
+    export type edited = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type consumables = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type name = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type created = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type cargo_capacity = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type passengers = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type max_atmosphering_speed = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type crew = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type length = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type model = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type cost_in_credits = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+    export type manufacturer = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type image = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+    export type id = (model: Models.Transport, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<number | null | undefined>;
+}
+export default interface ResolversMap {
+    readonly SearchResult?: SearchResult.Resolvers;
+    readonly Query: Query.Resolvers;
+    readonly Node?: Node.Resolvers;
+    readonly Film?: Film.Resolvers;
+    readonly Vehicle?: Vehicle.Resolvers;
+    readonly Person?: Person.Resolvers;
+    readonly Starship?: Starship.Resolvers;
+    readonly Planet?: Planet.Resolvers;
+    readonly Species?: Species.Resolvers;
+    readonly Transport?: Transport.Resolvers;
+}
+"
+`;
+
+exports[`supermassive should generate interfaces with --mandatory-root-operation-types --generate-resolver-map 4`] = `"{}"`;

--- a/packages/cli/src/__tests__/typeDefsToImplicitResolvers.test.ts
+++ b/packages/cli/src/__tests__/typeDefsToImplicitResolvers.test.ts
@@ -52,4 +52,25 @@ describe(supermassive, () => {
       ).toMatchSnapshot();
     }
   });
+
+  it("should generate interfaces with --mandatory-root-operation-types --generate-resolver-map", async () => {
+    const program = supermassive();
+    await program.parseAsync([
+      "node",
+      "supermassive",
+      "generate-interfaces",
+      path.join(__dirname, "./fixtures/schema.graphql"),
+      "--output-dir=../__generated__",
+      "--mandatory-root-operation-types",
+      "--generate-resolver-map",
+    ]);
+    const files = await fs.readdir(path.join(__dirname, "./__generated__"));
+    for (const file of files) {
+      expect(
+        await fs.readFile(path.join(__dirname, "./__generated__", file), {
+          encoding: "utf-8",
+        }),
+      ).toMatchSnapshot();
+    }
+  });
 });

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -20,6 +20,7 @@ type GenerateInterfacesOptions = {
   enumMigrationExceptionsJsonFile?: string;
   generateOnlyEnums?: boolean;
   generateResolverMap?: boolean;
+  mandatoryRootOperationTypes?: boolean;
   contextSubTypeNameTemplate?: string;
   contextSubTypePathTemplate?: string;
   defaultContextSubTypePath?: string;
@@ -91,6 +92,10 @@ export function supermassive(): Command {
       "--generate-resolver-map",
       "Generate a schema map for resolvers. Default export with resolvers for each type",
     )
+    .option(
+      "--mandatory-root-operation-types",
+      "Makes root operation types and its properties mandatory in all generated resolver interfaces",
+    )
     .description("generate interfaces and models")
     .action(
       async (inputs: Array<string>, options: GenerateInterfacesOptions) => {
@@ -116,6 +121,7 @@ function getFiles(inputs: Array<string>) {
     .flat()
     .filter(Boolean);
 }
+
 function getContextPath(
   outputDir: string,
   contextTypePath: string | undefined,
@@ -215,6 +221,7 @@ async function generateInterfaces(
       useStringUnionsInsteadOfEnums: !!options.useStringUnionsInsteadOfEnums,
       generateOnlyEnums: !!options.generateOnlyEnums,
       generateResolverMap: !!options.generateResolverMap,
+      mandatoryRootOperationTypes: !!options.mandatoryRootOperationTypes,
       enumNamesToMigrate,
       enumNamesToKeep,
       modelScope: options.scope || null,

--- a/packages/ts-codegen/src/__tests__/index.test.ts
+++ b/packages/ts-codegen/src/__tests__/index.test.ts
@@ -2191,6 +2191,45 @@ describe(generateTS, () => {
       "
     `);
   });
+  test("generateTS with generateResolverMap and mandatoryRootOperationTypes options", () => {
+    const { resolvers } = runGenerateTest(
+      graphql`
+        type User {
+          id: ID!
+          name: String
+        }
+
+        extend type Query {
+          users: [User!]!
+        }
+      `,
+      { mandatoryRootOperationTypes: true, generateResolverMap: true },
+    );
+    expect(resolvers).toMatchInlineSnapshot(`
+      "import type { PromiseOrValue } from "@graphitation/supermassive";
+      import type { ResolveInfo } from "@graphitation/supermassive";
+      import * as Models from "./models.interface";
+      export declare namespace User {
+          export interface Resolvers {
+              readonly id?: id;
+              readonly name?: name;
+          }
+          export type id = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string>;
+          export type name = (model: Models.User, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+      }
+      export declare namespace Query {
+          export interface Resolvers {
+              readonly users: users;
+          }
+          export type users = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.User>>;
+      }
+      export default interface ResolversMap {
+          readonly User?: User.Resolvers;
+          readonly Query: Query.Resolvers;
+      }
+      "
+    `);
+  });
 });
 
 function runGenerateTest(

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -38,6 +38,34 @@ export interface GenerateTSOptions {
    *   }
    * */
   generateResolverMap?: boolean;
+  /**
+   * Makes root operation types and its properties mandatory in all generated resolver interfaces,
+   * including ResolverMap.
+   *
+   * @example
+   * // mandatoryRootOperationTypes: enabled
+   * export declare namespace Query {
+   *    export interface Resolvers {
+   *       readonly allTodos: allTodos;
+   *    }
+   * }
+   * export default interface ResolversMap {
+   *    readonly Query: Query.Resolvers;
+   *    readonly User?: User.Resolvers;
+   * }
+   *
+   * // mandatoryRootOperationTypes: disabled
+   * export declare namespace Query {
+   *    export interface Resolvers {
+   *       readonly allTodos?: allTodos;
+   *    }
+   * }
+   * export default interface ResolversMap {
+   *    readonly Query?: Query.Resolvers;
+   *    readonly User?: User.Resolvers;
+   * }
+   */
+  mandatoryRootOperationTypes?: boolean;
 }
 
 export function generateTS(
@@ -60,6 +88,7 @@ export function generateTS(
     defaultContextSubTypePath,
     defaultContextSubTypeName,
     generateResolverMap,
+    mandatoryRootOperationTypes,
   }: GenerateTSOptions,
 ): {
   files: ts.SourceFile[];
@@ -96,7 +125,12 @@ export function generateTS(
 
     if (!generateOnlyEnums) {
       result.push(generateModels(context));
-      result.push(generateResolvers(context, generateResolverMap));
+      result.push(
+        generateResolvers(context, {
+          generateResolverMap,
+          mandatoryRootOperationTypes,
+        }),
+      );
       if (context.hasInputs) {
         result.push(generateInputs(context));
       }


### PR DESCRIPTION
Makes properties in `Resolvers` interface for query/mutation/subscription mandatory.
Also ensures that `Query`/`Mutation`/`Subscription` property in `ResolverMap` is mandatory.