### PR TITLE
fix(ts-jest): source maps for debug

### DIFF
--- a/change/@graphitation-embedded-document-artefact-loader-0a728686-32d8-44df-9101-e88cfeffd469.json
+++ b/change/@graphitation-embedded-document-artefact-loader-0a728686-32d8-44df-9101-e88cfeffd469.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "reapply inline source maps",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/embedded-document-artefact-loader/src/ts-jest.ts
+++ b/packages/embedded-document-artefact-loader/src/ts-jest.ts
@@ -9,7 +9,10 @@ import type {
   TransformOptions,
 } from "@jest/transform";
 import type { TsJestTransformerOptions, TsJestTransformOptions } from "ts-jest";
-import { extractInlineSourceMap } from "./addInlineSourceMap";
+import {
+  addInlineSourceMap,
+  extractInlineSourceMap,
+} from "./addInlineSourceMap";
 import { applySourceMap } from "./source-map-utils";
 
 const transformerFactory: TransformerFactory<SyncTransformer<unknown>> = {
@@ -80,9 +83,15 @@ function extractAndApplySourceMap(
     if (tsResultMap === undefined) {
       throw new Error("Expected inline source-map");
     }
+    const mergedMap = applySourceMap(
+      sourcePath,
+      sourceMap.toJSON(),
+      tsResultMap,
+    ).toJSON();
     tsResult = {
-      code: tsResultCode,
-      map: applySourceMap(sourcePath, sourceMap.toJSON(), tsResultMap).toJSON(),
+      // Reapply merged inline source map to code to help debugger map to original source.
+      code: addInlineSourceMap(tsResultCode, JSON.stringify(mergedMap)),
+      map: mergedMap,
     };
   }
   return tsResult;


### PR DESCRIPTION
Currently, placing a line debugger in a file transformed by ts-jest causes issues with positioning, resulting in the debugger opening the transformed file instead of the original one. A similar behavior occurs with the debugger keyword, which also opens the transformed file.

To address this, we need to place inline source maps for code editors. While ts-jest generates these inline source maps, we have been extracting them and merging them with our source maps from the transformed files, but we have never applied them as inline source maps.