### PR TITLE
fix(apollo-forest-run): do not visit the same chunk twice when reading

### DIFF
--- a/change/@graphitation-apollo-forest-run-236a4676-ef3a-46e7-8d83-e276c80d94de.json
+++ b/change/@graphitation-apollo-forest-run-236a4676-ef3a-46e7-8d83-e276c80d94de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(execute): do not visit the same chunk twice when reading",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/helpers/mock.ts
+++ b/packages/apollo-forest-run/src/__tests__/helpers/mock.ts
@@ -15,7 +15,7 @@ export function generateMockObject(doc: DocumentNode): SourceObject {
   const result = visit(doc, {
     Field: {
       leave: (node) => [
-        node.name.value,
+        node.alias?.value ?? node.name.value,
         itemsCount(node) === -1
           ? fieldValue(node)
           : [...new Array(itemsCount(node))].map(() => fieldValue(node)),


### PR DESCRIPTION
This PR fixes a quirk of ForestRun that was known before, but proved to be really detrimental for perf in some edge cases in the real world app.

In short, embedded objects (i.e. objects without ids) could be wastefully re-visited many times while reading object value in presence of missing fields (which is common with duct-tape and some other scenarios).

Here we simply track which objects were visited during read and don't re-visit them again.