### PR TITLE
fix(apollo-forest-run): use replaceTree vs addTree on write

### DIFF
--- a/change/@graphitation-apollo-forest-run-7cc0912b-29df-4ac9-b632-88364bf55c93.json
+++ b/change/@graphitation-apollo-forest-run-7cc0912b-29df-4ac9-b632-88364bf55c93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): use replaceTree vs addTree to fix incorrect assumption",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -33,7 +33,7 @@ import { indexTree } from "../forest/indexTree";
 import { createParentLocator, markAsPartial, TraverseEnv } from "../values";
 import { NodeDifferenceMap } from "../forest/updateTree";
 import { getNodeChunks } from "./draftHelpers";
-import { addTree } from "../forest/addTree";
+import { replaceTree } from "../forest/addTree";
 import { invalidateReadResults } from "./invalidate";
 import { IndexedForest } from "../forest/types";
 
@@ -163,7 +163,10 @@ export function write(
 
   if (!existingResult && shouldCache(targetForest, operationDescriptor)) {
     affectedOperations.set(operationDescriptor, difference.nodeDifference);
-    addTree(targetForest, modifiedIncomingResult);
+    // Note: even with existingResult === undefined the tree for this operation may still exist in the cache
+    //   (when existingResult is resolved with a different key descriptor due to key variables)
+    // TODO: replace with addTree and add a proper check for keyVariables
+    replaceTree(targetForest, modifiedIncomingResult);
   }
 
   appendAffectedOperationsFromOtherLayers(


### PR DESCRIPTION
Fixes an incorrect assumption causing `Invariant violation` error in some niche "write" scenarios with ForestRun (when operation has keyVariables and key descriptor is removed after eviction, but non-key one remains in the cache).