### PR TITLE
fix(apollo-forest-run): do not rely on cached key for root-level objects

### DIFF
--- a/packages/apollo-forest-run/src/cache/keys.ts
+++ b/packages/apollo-forest-run/src/cache/keys.ts
@@ -35,7 +35,7 @@ export function objectKey(
   // ApolloCompat: this is necessary for compatibility with extract/restore methods
   //   (where object key is not inferable otherwise)
   const key = keyMap?.get(object);
-  if (key !== undefined) {
+  if (key !== undefined && key !== "ROOT_QUERY") {
     return key;
   }
   const typeName = object.__typename;


### PR DESCRIPTION
This is a fix for a really exotic scenario with manual cache writes. But the general idea is that we should not rely on cached object keys for query roots, as this is the only node id detected implicitly.

Note: this is a hotfix, proper solution requires changes to the write-side (i.e. never write those to key cache), which should be done in a follow-up.