### PR TITLE
(feat): do not emit empty models

### DIFF
--- a/change/@graphitation-ts-codegen-e8bb23c6-ffa0-420e-ab9d-2c2e593ca434.json
+++ b/change/@graphitation-ts-codegen-e8bb23c6-ffa0-420e-ab9d-2c2e593ca434.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(ts-codegen): do not emit empty models.interface.ts",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -120,7 +120,9 @@ export function generateTS(
     }
 
     if (!generateOnlyEnums) {
-      result.push(generateModels(context));
+      if (context.hasModels) {
+        result.push(generateModels(context));
+      }
       if (context.hasResolvers) {
         result.push(
           generateResolvers(context, {

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -83,3 +83,7 @@ export function getRelativePath(
 
   return cleanRelativePath(path.relative(outputPath, modelFullPath));
 }
+
+export function isRootOperationType(typeName: string) {
+  return ["Query", "Mutation", "Subscription"].includes(typeName);
+}

--- a/packages/ts-codegen/src/models.ts
+++ b/packages/ts-codegen/src/models.ts
@@ -1,4 +1,5 @@
 import ts, { factory } from "typescript";
+import { isRootOperationType } from "./context/utilities";
 import {
   ScalarType,
   TsCodegenContext,
@@ -81,10 +82,7 @@ function createObjectTypeModel(
   context: TsCodegenContext,
   type: ObjectType,
 ): ts.InterfaceDeclaration | null {
-  if (
-    ["Query", "Mutation", "Subscription"].includes(type.name) ||
-    type.isExtension
-  ) {
+  if (isRootOperationType(type.name) || type.isExtension) {
     return null;
   }
 

--- a/packages/ts-codegen/src/resolvers.ts
+++ b/packages/ts-codegen/src/resolvers.ts
@@ -16,6 +16,7 @@ import {
 import {
   createImportDeclaration,
   getImportIdentifierForTypenames,
+  isRootOperationType,
 } from "./context/utilities";
 
 const getResolverTypes = (context: TsCodegenContext): ResolverType[] => {
@@ -41,18 +42,19 @@ export function generateResolvers(
   const { generateResolverMap, mandatoryResolverTypes } = options;
   const statements: ts.Statement[] = [];
   statements.push(...context.getBasicImports());
-  statements.push(
-    factory.createImportDeclaration(
-      undefined,
-      factory.createImportClause(
-        false,
+  if (context.hasModels) {
+    statements.push(
+      factory.createImportDeclaration(
         undefined,
-        factory.createNamespaceImport(factory.createIdentifier("Models")),
+        factory.createImportClause(
+          false,
+          undefined,
+          factory.createNamespaceImport(factory.createIdentifier("Models")),
+        ),
+        factory.createStringLiteral("./models.interface"),
       ),
-      factory.createStringLiteral("./models.interface"),
-    ),
-  );
-
+    );
+  }
   const contextTemplate = context.getContextTemplate();
 
   if (Object.keys(context.getContextMap()).length && contextTemplate) {
@@ -230,10 +232,6 @@ function createObjectTypeResolvers(
     factory.createModuleBlock(members),
     ts.NodeFlags.Namespace,
   );
-}
-
-function isRootOperationType(type: string): boolean {
-  return ["Query", "Mutation", "Subscription"].includes(type);
 }
 
 function createResolverField(


### PR DESCRIPTION
Prevents `ts-codegen` from emitting empty `model.interface.ts` files and adding unused imports to `resolvers.interface.ts` which could cause ts errors