### PR TITLE
fix(duct-tape): do not unsubscribe in loading state

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-9a499138-bae3-4fd0-a527-d52c6abfd72f.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-9a499138-bae3-4fd0-a527-d52c6abfd72f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "do not unsubscribe when we are still in loading state",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "pavelglac@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
@@ -14,7 +14,7 @@ import type { DocumentNode } from "graphql";
 import type { CompiledArtefactModule } from "@graphitation/apollo-react-relay-duct-tape-compiler";
 
 class ExecutionQueryHandler {
-  public status: [loading: boolean, error?: Error];
+  public status: [pending: boolean, error?: Error];
   private querySubscription?: ZenObservable.Subscription;
 
   constructor(private onComplete: () => void) {
@@ -35,16 +35,24 @@ class ExecutionQueryHandler {
     this.status = [true, undefined];
   }
 
-  private handleResult(error?: Error) {
+  private handleResult(error: Error | undefined, loading?: boolean) {
     this.status = [false, error];
-    this.dispose();
+
+    /**
+    /* For cache-and-network, we return the result from the cache
+    /* immediately, but we don't want to dispose of the observable
+    /* until the network request completes.
+    */
+    if (!loading) {
+      this.dispose();
+    }
     this.onComplete();
   }
 
   public subscribe(observable: ObservableQuery) {
     this.querySubscription = observable.subscribe(
-      ({ error: err }) => {
-        this.handleResult(err);
+      ({ error: err, loading }) => {
+        this.handleResult(err, loading);
       },
       (err) => {
         this.handleResult(err);
@@ -109,7 +117,7 @@ export function useCompiledLazyLoadQuery(
   const client = useOverridenOrDefaultApolloClient();
   const variables = useDeepCompareMemoize(options.variables);
   // First fetch all data needed for the entire tree...
-  const [loading, error] = useExecutionQuery(
+  const [pending, error] = useExecutionQuery(
     client,
     executionQueryDocument,
     variables,
@@ -121,7 +129,7 @@ export function useCompiledLazyLoadQuery(
     variables,
     fetchPolicy: "cache-only",
     // ...but only once finished loading.
-    skip: loading || !!error,
+    skip: pending || !!error,
   });
   return { data, error };
 }

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
@@ -17,7 +17,7 @@ class ExecutionQueryHandler {
   public status: [pending: boolean, error?: Error];
   private querySubscription?: ZenObservable.Subscription;
 
-  constructor(private onComplete: () => void) {
+  constructor(private onDataReceived: () => void) {
     this.status = [true, undefined];
   }
 
@@ -46,7 +46,7 @@ class ExecutionQueryHandler {
     if (!loading) {
       this.dispose();
     }
-    this.onComplete();
+    this.onDataReceived();
   }
 
   public subscribe(observable: ObservableQuery) {

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledLazyLoadQuery.ts
@@ -17,7 +17,7 @@ class ExecutionQueryHandler {
   public status: [pending: boolean, error?: Error];
   private querySubscription?: ZenObservable.Subscription;
 
-  constructor(private onDataReceived: () => void) {
+  constructor(private onDataReceive: () => void) {
     this.status = [true, undefined];
   }
 
@@ -46,7 +46,7 @@ class ExecutionQueryHandler {
     if (!loading) {
       this.dispose();
     }
-    this.onDataReceived();
+    this.onDataReceive();
   }
 
   public subscribe(observable: ObservableQuery) {


### PR DESCRIPTION
We are unsubscribing only if the state is not loading. In case of store-and-network we get the data immediately and then unsubscribe. With this change we returns the data and waits until the request finish.