### PR TITLE
fix(graphql-codegen-typescript-typemap-plugin): use output Scalars in TypeMap

### DIFF
--- a/change/@graphitation-graphql-codegen-typescript-typemap-plugin-4db16247-8e9c-48df-aa31-cd602e20f366.json
+++ b/change/@graphitation-graphql-codegen-typescript-typemap-plugin-4db16247-8e9c-48df-aa31-cd602e20f366.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: Use output Scalars in TypeMap",
+  "packageName": "@graphitation/graphql-codegen-typescript-typemap-plugin",
+  "email": "alina.o.zaieva@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-codegen-typescript-typemap-plugin/src/__tests__/index.test.ts
+++ b/packages/graphql-codegen-typescript-typemap-plugin/src/__tests__/index.test.ts
@@ -21,11 +21,11 @@ describe(plugin, () => {
     const result = plugin(schema, [], null);
     expect(result).toMatchInlineSnapshot(`
       "export type TypeMap = {
-        "Boolean": Scalars["Boolean"];
+        "Boolean": Scalars["Boolean"]["output"];
         "HTML": Html;
-        "ID": Scalars["ID"];
+        "ID": Scalars["ID"]["output"];
         "Query": Query;
-        "String": Scalars["String"];
+        "String": Scalars["String"]["output"];
         "TypeWITHUnderscore_AndSomeCapitalCharacters": TypeWithUnderscore_AndSomeCapitalCharacters;
         "lowerCaseTypeName": LowerCaseTypeName;
       };

--- a/packages/graphql-codegen-typescript-typemap-plugin/src/index.ts
+++ b/packages/graphql-codegen-typescript-typemap-plugin/src/index.ts
@@ -16,7 +16,7 @@ const graphqlCodegenTypeMapPlugin: PluginFunction = (
         (typeName) =>
           `  "${typeName}": ${
             isScalarType(typesMap[typeName])
-              ? `Scalars["${typeName}"]`
+              ? `Scalars["${typeName}"]["output"]`
               : typeName
                   .split("_")
                   .map((part) => pascalCase(part))


### PR DESCRIPTION
## Problem
`@graphql-codegen/typescript@4.0.0` plugin has introduced a breaking change in how `Scalars` type is generated - instead of a plain name-type map it now includes separate `input` and `output` types (more info is in changelog: <https://github.com/dotansimha/graphql-code-generator/blob/master/packages/plugins/typescript/typescript/CHANGELOG.md#400>).

The TypeMap plugin expects old format and generates `TypeMap` with same `input` and `output` field, which breaks consumers of the plugin.

## Solution
To recreate old behavior of the plugin, it is updated to generate `Scalars[<name>]["output"]` instead of `Scalars[<name>]`. This is a breaking change for this plugin since it will stop generating valid typescript when used with `@graphql-codegen/typescript` versions prior to 4.0.0.

This will still break for consumers that do have different `input` and `output` types for a scalar, so further investigation may be needed to find a better structure of `TypeMap`.