### PR TITLE
fix(apollo-forest-run): don't throw on incorrect incoming data

### DIFF
--- a/change/@graphitation-apollo-forest-run-8f579db3-9708-47e4-bcb1-918e7879330d.json
+++ b/change/@graphitation-apollo-forest-run-8f579db3-9708-47e4-bcb1-918e7879330d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): don't throw on incorrect written data",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -51,7 +51,10 @@ export function write(
   const { mergePolicies, objectKey, addTypename, keyMap } = env;
   const targetForest = getActiveForest(store, activeTransaction);
 
-  const writeData = options.result ?? {};
+  const writeData =
+    typeof options.result === "object" && options.result !== null
+      ? options.result
+      : {};
   const rootNodeKey = options.dataId ?? objectKey(writeData);
   assert(rootNodeKey !== false);
 

--- a/packages/apollo-forest-run/src/descriptor/operation.ts
+++ b/packages/apollo-forest-run/src/descriptor/operation.ts
@@ -122,5 +122,5 @@ function getKeyVars(doc: OperationDefinitionNode): VariableName[] | null {
         `got ${JSON.stringify(value)} in place of keyVars`,
     );
   }
-  return value;
+  return value as string[];
 }


### PR DESCRIPTION
Mirror Apollo behavior on incorrect incoming data. For backwards compatiblity