### PR TITLE
fix(apollo-forest-run): treat incorrect list items the same way as InMemoryCache

### DIFF
--- a/change/@graphitation-apollo-forest-run-7575015d-b204-4199-bd95-dd0b8d432556.json
+++ b/change/@graphitation-apollo-forest-run-7575015d-b204-4199-bd95-dd0b8d432556.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): treat incorrect list items the same way as InMemoryCache",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -818,3 +818,23 @@ test("writes with missing fields should be kept up-to-date", () => {
     bar: "barUpdated",
   });
 });
+
+test("treats incorrect list items as empty objects", () => {
+  // Note: this is for backwards compatibility with Apollo Client 3.6+ 🤷‍♂️
+  const query = gql`
+    {
+      foo {
+        bar
+      }
+    }
+  `;
+
+  const cache = new ForestRun();
+  const result = { foo: [{ bar: "test" }, "bad"] };
+
+  cache.write({ query, result, dataId: "ROOT_QUERY" });
+
+  const data = cache.diff({ query, optimistic: true });
+  expect(data.result).toEqual({ foo: [{ bar: "test" }, {}] });
+  expect(data.complete).toBe(false);
+});

--- a/packages/apollo-forest-run/src/forest/indexTree.ts
+++ b/packages/apollo-forest-run/src/forest/indexTree.ts
@@ -216,17 +216,7 @@ function indexSourceObject(
     : env.objectKey(source, selection, context.operation);
 
   const key = typeof objectKeyResult === "string" ? objectKeyResult : false;
-  let missingFields = knownMissingFields?.get(source);
-
-  if (typeName === void 0 && selection.fields.has("__typename")) {
-    const field = selection.fields.get("__typename");
-    if (!missingFields) {
-      missingFields = new Set();
-      knownMissingFields?.set(source, missingFields);
-    }
-    assert(field?.length);
-    missingFields.add(field[0]);
-  }
+  const missingFields = knownMissingFields?.get(source);
 
   const chunk = createObjectChunk(
     op,
@@ -356,6 +346,9 @@ function indexSourceList(
         list[index] = fixedValue;
       }
       item = indexSourceObject(context, fixedValue, selection, itemParent);
+      item.missingFields = new Set([...item.selection.fields.values()].flat());
+      markAsPartial(context, itemParent);
+      context.incompleteChunks.add(item);
     }
     itemParent.value = item;
     chunk.itemChunks[index] = itemParent;


### PR DESCRIPTION
Minor fix for ForestRun to ensure backwards-compatibility with Apollo InMemoryCache when manual write contains incorrect list item.