### PR TITLE
Bump all packages with new build target - ES2018

### DIFF
--- a/change/@graphitation-apollo-mock-client-5bd98313-0cb0-4d3a-ab1c-f35295707e7f.json
+++ b/change/@graphitation-apollo-mock-client-5bd98313-0cb0-4d3a-ab1c-f35295707e7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/apollo-mock-client",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-react-relay-duct-tape-8dfbf320-25ee-485c-b207-f0e3c3f1ef04.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-8dfbf320-25ee-485c-b207-f0e3c3f1ef04.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-react-relay-duct-tape-compiler-22f1ddbf-d0f8-4038-a404-290c580f4dc0.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-compiler-22f1ddbf-d0f8-4038-a404-290c580f4dc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape-compiler",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-cli-69344dde-2cdf-4e48-9f29-961f3a5f609d.json
+++ b/change/@graphitation-cli-69344dde-2cdf-4e48-9f29-961f3a5f609d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/cli",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-embedded-document-artefact-loader-f1a86fc9-e9d5-499b-bbb5-f69b55a3e748.json
+++ b/change/@graphitation-embedded-document-artefact-loader-f1a86fc9-e9d5-499b-bbb5-f69b55a3e748.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/embedded-document-artefact-loader",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-resolvers-models-530e0dde-e6ec-4220-af68-21870f9f7b0a.json
+++ b/change/@graphitation-graphql-codegen-resolvers-models-530e0dde-e6ec-4220-af68-21870f9f7b0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-codegen-resolvers-models",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-supermassive-schema-extraction-plugin-f065b011-f163-4f73-9536-d3c578cfee7f.json
+++ b/change/@graphitation-graphql-codegen-supermassive-schema-extraction-plugin-f065b011-f163-4f73-9536-d3c578cfee7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-codegen-supermassive-schema-extraction-plugin",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-c293811d-27d4-4b26-82d4-cd95b0136a01.json
+++ b/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-c293811d-27d4-4b26-82d4-cd95b0136a01.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-codegen-supermassive-typed-document-node-plugin",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-typescript-operations-bc944249-9395-4136-8c4a-0565f3995811.json
+++ b/change/@graphitation-graphql-codegen-typescript-operations-bc944249-9395-4136-8c4a-0565f3995811.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-codegen-typescript-operations",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-typescript-typemap-plugin-87a1ca71-9690-4c8b-8423-93496c7fc47d.json
+++ b/change/@graphitation-graphql-codegen-typescript-typemap-plugin-87a1ca71-9690-4c8b-8423-93496c7fc47d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-codegen-typescript-typemap-plugin",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-eslint-rules-39aa8004-a754-4588-9e89-ac1b399b1575.json
+++ b/change/@graphitation-graphql-eslint-rules-39aa8004-a754-4588-9e89-ac1b399b1575.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-js-operation-payload-generator-78aef08f-7334-4a62-a952-1a852a9bf8b2.json
+++ b/change/@graphitation-graphql-js-operation-payload-generator-78aef08f-7334-4a62-a952-1a852a9bf8b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-js-operation-payload-generator",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-js-tag-f21ac1ef-6bad-4776-ac04-43ee223f7e93.json
+++ b/change/@graphitation-graphql-js-tag-f21ac1ef-6bad-4776-ac04-43ee223f7e93.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/graphql-js-tag",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-rempl-apollo-devtools-c0b0cb98-6a22-4008-a9c4-d0f9ca6c5956.json
+++ b/change/@graphitation-rempl-apollo-devtools-c0b0cb98-6a22-4008-a9c4-d0f9ca6c5956.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/rempl-apollo-devtools",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-supermassive-cf61cd51-ab1a-4154-a1a1-a584b3218fd7.json
+++ b/change/@graphitation-supermassive-cf61cd51-ab1a-4154-a1a1-a584b3218fd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/supermassive",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-supermassive-extractors-fb1ee13b-90ff-4ebf-a17c-e61f2f7ca3fc.json
+++ b/change/@graphitation-supermassive-extractors-fb1ee13b-90ff-4ebf-a17c-e61f2f7ca3fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/supermassive-extractors",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-15fc1402-48b8-4620-8b22-0c16fd6aa413.json
+++ b/change/@graphitation-ts-codegen-15fc1402-48b8-4620-8b22-0c16fd6aa413.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-transform-graphql-js-tag-16c48d9c-9397-4706-a04d-161cf09d9927.json
+++ b/change/@graphitation-ts-transform-graphql-js-tag-16c48d9c-9397-4706-a04d-161cf09d9927.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/ts-transform-graphql-js-tag",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-webpack-loader-2e33f3f1-359f-4f6e-96f1-fe7e1edbe9dd.json
+++ b/change/@graphitation-webpack-loader-2e33f3f1-359f-4f6e-96f1-fe7e1edbe9dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed build target from ES6 to ES2018",
+  "packageName": "@graphitation/webpack-loader",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This is a follow up for https://github.com/microsoft/graphitation/pull/536

In that PR build target in the repo was changed from `ES6` to `ES2018`. Here we bump all packages and publish new minors with new build target (except for `apollo-forest-run` which is already published with new build target)