### PR TITLE
fix(apollo-react-relay-duct-tape): fix `store-and-network` policy on refetchable fragments

### DIFF
--- a/change/@graphitation-apollo-react-relay-duct-tape-a82ac372-c1f5-4f2b-bd45-8d443375c2c1.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-a82ac372-c1f5-4f2b-bd45-8d443375c2c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix store-and-network when used with refetchable fragments",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
@@ -97,8 +97,9 @@ export function useCompiledRefetchableFragment(
       });
       let subscription: ZenObservable.Subscription | undefined =
         observable.subscribe(
-          ({ data, error }) => {
+          ({ data, error, loading }) => {
             // Be sure not to keep a retain cycle, so cleanup the reference first thing.
+            // if (!loading) {
             subscription?.unsubscribe();
             subscription = undefined;
             disposable.current = undefined;
@@ -133,6 +134,7 @@ export function useCompiledRefetchableFragment(
                 }
               }
             });
+            // }
           },
           (error) => {
             // Be sure not to keep a retain cycle

--- a/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
+++ b/packages/apollo-react-relay-duct-tape/src/storeObservation/compiledHooks/useCompiledRefetchableFragment.ts
@@ -98,43 +98,43 @@ export function useCompiledRefetchableFragment(
       let subscription: ZenObservable.Subscription | undefined =
         observable.subscribe(
           ({ data, error, loading }) => {
-            // Be sure not to keep a retain cycle, so cleanup the reference first thing.
-            // if (!loading) {
-            subscription?.unsubscribe();
-            subscription = undefined;
-            disposable.current = undefined;
+            if (!loading) {
+              // Be sure not to keep a retain cycle, so cleanup the reference first thing.
+              subscription?.unsubscribe();
+              subscription = undefined;
+              disposable.current = undefined;
 
-            unstable_batchedUpdates(() => {
-              if (options?.UNSTABLE_onCompletedWithData) {
-                options.UNSTABLE_onCompletedWithData(error || null, data);
-              } else {
-                options?.onCompleted?.(error || null);
-              }
-              if (!error) {
-                const { id: _, ...variablesToPropagate } = variables;
-                const nextVariables = {
-                  ...fragmentReference.__fragments,
-                  ...variablesToPropagate,
-                };
-                // No need to trigger an update to propagate new variables if they don't actually change.
-                if (
-                  !isEqual(
-                    fragmentReferenceWithOwnVariables.__fragments,
-                    nextVariables,
-                  )
-                ) {
-                  const nextFragmentReference: FragmentReference = {
-                    __fragments: nextVariables,
-                  };
-                  // Don't add an empty key if this is a fragment on the Query type.
-                  if (fragmentReference.id !== undefined) {
-                    nextFragmentReference.id = fragmentReference.id;
-                  }
-                  setFragmentReferenceWithOwnVariables(nextFragmentReference);
+              unstable_batchedUpdates(() => {
+                if (options?.UNSTABLE_onCompletedWithData) {
+                  options.UNSTABLE_onCompletedWithData(error || null, data);
+                } else {
+                  options?.onCompleted?.(error || null);
                 }
-              }
-            });
-            // }
+                if (!error) {
+                  const { id: _, ...variablesToPropagate } = variables;
+                  const nextVariables = {
+                    ...fragmentReference.__fragments,
+                    ...variablesToPropagate,
+                  };
+                  // No need to trigger an update to propagate new variables if they don't actually change.
+                  if (
+                    !isEqual(
+                      fragmentReferenceWithOwnVariables.__fragments,
+                      nextVariables,
+                    )
+                  ) {
+                    const nextFragmentReference: FragmentReference = {
+                      __fragments: nextVariables,
+                    };
+                    // Don't add an empty key if this is a fragment on the Query type.
+                    if (fragmentReference.id !== undefined) {
+                      nextFragmentReference.id = fragmentReference.id;
+                    }
+                    setFragmentReferenceWithOwnVariables(nextFragmentReference);
+                  }
+                }
+              });
+            }
           },
           (error) => {
             // Be sure not to keep a retain cycle


### PR DESCRIPTION
We experience a bug in People app where upon using `store-and-network` policy in `useRefetchable/PaginationFragment`'s refetch function, we sometimes don't get the result returned from resolvers. This is very similar issue to #528 and the fix is similar as well, we make sure to not unsubscribe from watched query until it is out of loading state.

Added unit tests which failed before the fix and now works correctly