### PR TITLE
feat(apollo-forest-run): support custom logger and rudimentary telemetry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "cSpell.words": ["Daichi", "fukuda", "Kadji"],
-  "jestrunner.configPath": "scripts/config/jest.config.js"
+  "jestrunner.configPath": "scripts/config/jest.config.js",
+  "files.eol": "\n",
+  "jest.jestCommandLine": "node node_modules/jest-cli/bin/jest.js --config scripts/config/jest.config.js",
+  "jest.runMode": "on-demand"
 }

--- a/change/@graphitation-apollo-forest-run-9332d398-83bc-460d-a82e-9cbb1f40378f.json
+++ b/change/@graphitation-apollo-forest-run-9332d398-83bc-460d-a82e-9cbb1f40378f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(apollo-forest-run): support custom logger and rudimentary telemetry",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -11,6 +11,7 @@ import {
 } from "../descriptor/types";
 import { getMergePolicyFn, getReadPolicyFn } from "./policies";
 import { SourceObject } from "../values/types";
+import { logger } from "../jsutils/logger";
 
 export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
   const possibleTypes = config?.possibleTypes;
@@ -37,6 +38,8 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     autoEvict: config?.autoEvict ?? true,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     maxOperationCount: config?.maxOperationCount ?? 1000,
+    logger: config && "logger" in config ? config.logger : logger,
+    notify: config?.notify,
     now: () => ++tick, // Logical time
     genId: () => ++id,
     objectKey: (

--- a/packages/apollo-forest-run/src/cache/keys.ts
+++ b/packages/apollo-forest-run/src/cache/keys.ts
@@ -21,7 +21,7 @@ export function identify(
     const value = object.__ref ?? objectKey(env, object as SourceObject);
     return typeof value !== "string" ? undefined : value;
   } catch (e) {
-    console.warn(e);
+    env.logger?.warn(e);
     return undefined;
   }
 }

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -132,6 +132,7 @@ export function createOptimisticLayer(
 
 export function removeOptimisticLayers<T>(
   cache: T,
+  env: CacheEnv,
   store: Store,
   layerTag: string,
 ): Set<OperationDescriptor> | undefined {
@@ -143,11 +144,10 @@ export function removeOptimisticLayers<T>(
   }
   const [affectedNodes, affectedOps] = resolveLayerImpact(store, layerTag);
 
-  //
-  // console.log(
-  //   `Removing optimistic layer ${layerTag}. Affected nodes: ${affectedNodes.length}; ` +
-  //     `affected operations: ${affectedOps.length}`,
-  // );
+  env.logger?.debug(
+    `Removing optimistic layer ${layerTag}. Affected nodes: ${affectedNodes.length}; ` +
+      `affected operations: ${affectedOps.length}`,
+  );
 
   const affectedOperationSet = new Set<OperationDescriptor>();
 

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -23,6 +23,8 @@ import type {
   FieldMergeFunction,
   FieldReadFunction,
 } from "@apollo/client/cache/inmemory/policies";
+import type { TelemetryEvent } from "../telemetry/types";
+import { Logger } from "../jsutils/logger";
 
 export type DataTree = IndexedTree & {
   grown?: boolean;
@@ -82,6 +84,8 @@ export type CacheConfig = InMemoryCacheConfig & {
   maxOperationCount?: number;
   nonEvictableQueries?: Set<string>;
   apolloCompat_keepOrphanNodes?: boolean;
+  logger?: Logger;
+  notify?: (event: TelemetryEvent) => void;
 };
 
 export type CacheEnv = {
@@ -124,6 +128,9 @@ export type CacheEnv = {
     directives?: Directives,
     source?: OperationDescriptor | undefined,
   ) => Key | KeySpecifier | undefined;
+
+  notify?: (event: TelemetryEvent) => void;
+  logger?: Logger;
 
   // ApolloCompat:
   //   Apollo can track dirty entries in results of read operations even if some "key" fields are missing in selection

--- a/packages/apollo-forest-run/src/forest/types.ts
+++ b/packages/apollo-forest-run/src/forest/types.ts
@@ -20,6 +20,8 @@ import {
   SourceObject,
   TypeMap,
 } from "../values/types";
+import { TelemetryEvent } from "../telemetry/types";
+import { Logger } from "../jsutils/logger";
 
 export type IndexedTree = {
   operation: OperationDescriptor;
@@ -77,6 +79,9 @@ export type ForestEnv = {
     fields?: PossibleSelection,
     operation?: OperationDescriptor,
   ) => ObjectKey | false | undefined;
+
+  logger?: Logger;
+  notify?: (event: TelemetryEvent) => void;
 
   // ApolloCompat:
   //   Apollo can track dirty entries in results of read operations even if some "key" fields are missing in selection

--- a/packages/apollo-forest-run/src/forest/updateTree.ts
+++ b/packages/apollo-forest-run/src/forest/updateTree.ts
@@ -88,6 +88,7 @@ export function updateTree(
     assert(difference);
 
     const result = updateObject(
+      env,
       base.dataMap,
       chunk,
       difference,

--- a/packages/apollo-forest-run/src/jsutils/logger.ts
+++ b/packages/apollo-forest-run/src/jsutils/logger.ts
@@ -1,0 +1,8 @@
+export type Logger = {
+  debug: typeof console.debug;
+  log: typeof console.log;
+  warn: typeof console.warn;
+  error: typeof console.error;
+};
+
+export const logger: Logger = console;

--- a/packages/apollo-forest-run/src/telemetry/types.ts
+++ b/packages/apollo-forest-run/src/telemetry/types.ts
@@ -1,0 +1,49 @@
+// IMPORTANT!
+// 1. Events MUST NOT include any user data or any other information that can be used to identify a user.
+//    This is necessary to comply with GDPR and other privacy regulations.
+//    Events could be sent to the server and may be stored in logs or other storage.
+// 2. Events MUST be serializable with JSON.stringify.
+type OperationDebugName = string;
+type FirstMissingFieldMessage = string;
+
+// Event occurs when incoming write causes missing fields in watched operations.
+// This happens due to a mismatching selection in the incoming operation and the affected operation.
+//
+// There are several situations when this can happen:
+// - Incoming operation adds a new list item, but affected operation has some field in the selection
+//     which is not present in the incoming operation, so it is impossible to complete the new array item.
+//
+// - Incoming operation switches field value of abstract type from one specific type to anoter (i.e. "__typename" changes),
+//     but selection for another type of the affected operation contains fields in selection
+//     which are not present in the incoming operation, so it is impossible to complete the object.
+//
+// - Incoming operation changes relationship between objects (i.e. changes value of some field
+//   from object with id "A" to object with id "B"), but affected operation has fields in selection
+//     which are not present in the incoming operation,
+//
+export type UnexpectedRefetch = {
+  kind: "UNEXPECTED_REFETCH";
+  causedBy: OperationDebugName[];
+  affected: Array<[OperationDebugName, FirstMissingFieldMessage]>;
+};
+
+// Event occurs when read policy throws an error
+export type ReadPolicyError = {
+  kind: "READ_POLICY_ERROR";
+  op: OperationDebugName;
+  type: string;
+  field: string;
+};
+
+// Event occurs when merge policy throws an error
+export type MergePolicyError = {
+  kind: "MERGE_POLICY_ERROR";
+  op: OperationDebugName;
+  type: string;
+  field: string;
+};
+
+export type TelemetryEvent =
+  | UnexpectedRefetch
+  | ReadPolicyError
+  | MergePolicyError;


### PR DESCRIPTION
# Logging and telemetry-related changes for ForestRun

## Custom logger

Replace all `console.log` statements with custom logger. Logger instance can be injected via cache config. The default is equivalent to:

```ts
const cache = new ForestRun({
  logger: console
});
```

Passing `logger: undefined` will disable logging (alternatively custom `log`, `debug`, `error`, `warn` methods could be used for fine-grain control over logging).

## Events for telemetry

Add ability to send structured data to telemetry, when corresponding notification handler is set:

```ts
const cache = new ForestRun({
  notify: (event) => {
    // event contains structured data to be sent to telemetry
  }
});
```

All event types are placed under `telemetry/types.ts`