### PR TITLE
feat(apollo-forest-run): cache extract

### DIFF
--- a/change/@graphitation-apollo-forest-run-68967b17-737e-4a5d-830f-13897f4542f5.json
+++ b/change/@graphitation-apollo-forest-run-68967b17-737e-4a5d-830f-13897f4542f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(apollo-forest-run): cache extract",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-rempl-apollo-devtools-2b2f1543-4ad4-4625-b1ea-393e8ceb3553.json
+++ b/change/@graphitation-rempl-apollo-devtools-2b2f1543-4ad4-4625-b1ea-393e8ceb3553.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Apollo devtools support forestrun (#483)\"",
+  "packageName": "@graphitation/rempl-apollo-devtools",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -364,10 +364,10 @@ export class ForestRun extends ApolloCache<SerializedCache> {
 
   // Compatibility with InMemoryCache for Apollo dev tools
   get data() {
-    let cache = this;
+    const extract = this.extract.bind(this);
     return {
       get data() {
-        return cache.extract();
+        return extract();
       },
     };
   }

--- a/packages/apollo-forest-run/src/ForestRunCompat.ts
+++ b/packages/apollo-forest-run/src/ForestRunCompat.ts
@@ -4,7 +4,6 @@ import { restore } from "./cache/restore";
 import { resolveOperationDescriptor } from "./cache/descriptor";
 import { indexTree } from "./forest/indexTree";
 import { replaceTree } from "./forest/addTree";
-import type { StoreObject } from "@apollo/client";
 import { getEffectiveReadLayers } from "./cache/store";
 
 /**
@@ -19,7 +18,7 @@ export class ForestRunCompat extends ForestRun {
     };
   }
 
-  public extract(optimistic = false): StoreObject {
+  public extract(optimistic = false): any {
     const activeTransaction = peek(this.transactionStack);
     const effectiveOptimistic =
       activeTransaction?.forceOptimistic ?? optimistic;

--- a/packages/apollo-forest-run/src/__tests__/extract.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/extract.test.ts
@@ -1,0 +1,74 @@
+import { ForestRun } from "../ForestRun";
+import { gql } from "./helpers/descriptor";
+
+describe("ForestRun.extract()", () => {
+  test("should extract the cache correctly", () => {
+    const cache = new ForestRun();
+    const query = gql`
+      query Foo($i: Int = 0) {
+        foo(i: $i)
+      }
+    `;
+
+    cache.write({ query, result: { foo: 0 } });
+    cache.write({ query, result: { foo: 1 }, variables: { i: 1 } });
+
+    expect(cache.extract()).toMatchInlineSnapshot(`
+      {
+        "query Foo:1": {
+          "data": {
+            "foo": 0,
+          },
+          "optimisticData": null,
+          "variables": {},
+        },
+        "query Foo:2": {
+          "data": {
+            "foo": 1,
+          },
+          "optimisticData": null,
+          "variables": {
+            "i": 1,
+          },
+        },
+      }
+    `);
+  });
+
+  test("should extract the cache with optimistic data", () => {
+    const cache = new ForestRun();
+    const query = gql`
+      query Foo($i: Int = 0) {
+        foo(i: $i)
+      }
+    `;
+    cache.write({ query, result: { foo: 0 } });
+    cache.write({ query, result: { foo: 1 }, variables: { i: 1 } });
+    cache.recordOptimisticTransaction(() => {
+      cache.write({ query, result: { foo: 2 } });
+    }, "test");
+
+    expect(cache.extract(true)).toMatchInlineSnapshot(`
+      {
+        "query Foo:1": {
+          "data": {
+            "foo": 0,
+          },
+          "optimisticData": {
+            "foo": 2,
+          },
+          "variables": {},
+        },
+        "query Foo:2": {
+          "data": {
+            "foo": 1,
+          },
+          "optimisticData": null,
+          "variables": {
+            "i": 1,
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -151,3 +151,14 @@ export type CacheEnv = {
   nonEvictableQueries: Set<string>;
   maxOperationCount: number;
 };
+
+export type SerializedOperationKey = string;
+export type SerializedOperationInfo = {
+  data: Record<string, unknown>;
+  variables: Record<string, unknown>;
+  optimisticData: Record<string, unknown> | null;
+};
+export type SerializedCache = Record<
+  SerializedOperationKey,
+  SerializedOperationInfo
+>;

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -154,9 +154,9 @@ export type CacheEnv = {
 
 export type SerializedOperationKey = string;
 export type SerializedOperationInfo = {
-  data: Record<string, unknown>;
+  data: SourceObject | null;
+  optimisticData: SourceObject | null;
   variables: Record<string, unknown>;
-  optimisticData: Record<string, unknown> | null;
 };
 export type SerializedCache = Record<
   SerializedOperationKey,

--- a/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-operations-tracker-publisher.ts
+++ b/packages/rempl-apollo-devtools/src/publisher/publishers/apollo-operations-tracker-publisher.ts
@@ -84,7 +84,7 @@ export class ApolloOperationsTrackerPublisher {
               (ac) => ac.clientId === data.data.clientId,
             );
             window.navigator.clipboard.writeText(
-              JSON.stringify((apolloClient?.client.cache as any).data.data),
+              JSON.stringify(apolloClient?.client.cache.extract()),
             );
           } else {
             const copiedData = JSON.stringify(data.data.operations);

--- a/packages/rempl-apollo-devtools/src/types.ts
+++ b/packages/rempl-apollo-devtools/src/types.ts
@@ -13,12 +13,6 @@ export type WrapperCallbackParams = {
   activeClient: ClientObject | null;
 };
 
-export type ForestRunStoreObject = {
-  id: string;
-  data: Record<string, unknown>;
-  variables: Record<string, unknown>;
-};
-
 export type ClientObject = {
   clientId: string;
   client: ApolloClient<NormalizedCacheObject>;


### PR DESCRIPTION
Support `extract()` method from ApolloCache interface in ForestRun. Now custom changes we did for DevTools are not necessary, devtools can rely on common interface.