### PR TITLE
fix(apollo-forest-run): later chunks should have precedence

### DIFF
--- a/change/@graphitation-apollo-forest-run-b8f5d9f6-f553-48f0-805d-d134603c1c01.json
+++ b/change/@graphitation-apollo-forest-run-b8f5d9f6-f553-48f0-805d-d134603c1c01.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): later chunks should have precedence",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/forest/__tests__/updateTree.test.ts
+++ b/packages/apollo-forest-run/src/forest/__tests__/updateTree.test.ts
@@ -1207,7 +1207,7 @@ describe("update list of union type", () => {
         plainObjectUnionList: [
           plainObjectBar({
             bar: "1",
-            entityUnion: entityFoo({ id: "1", foo: "foo1" }),
+            entityUnion: entityFoo({ id: "3", foo: "foo1" }),
           }),
           plainObjectFoo({
             foo: "2",
@@ -1616,16 +1616,16 @@ describe("with missing fields", () => {
 describe("with different selections", () => {
   test("updates entities", () => {
     const base = completeObject({
-      entity: entityFoo({ foo: "foo" }),
+      entity: entityFoo({ id: "2", foo: "foo" }),
     });
     const model = completeObject({
-      entity: entityFoo({ foo: "changed" }),
+      entity: entityFoo({ id: "2", foo: "changed" }),
     });
     const { difference } = diff(base, model);
 
     const otherTree: TestValue = [
       completeObject({
-        entity: entityFoo({ fooAliased: "foo" }),
+        entity: entityFoo({ id: "2", fooAliased: "foo" }),
       }),
       gql`
         fragment OtherObject on CompleteObject {
@@ -1640,7 +1640,7 @@ describe("with different selections", () => {
     ];
     const { data } = update(otherTree, difference);
 
-    expect(data.entity).toEqual(entityFoo({ fooAliased: "changed" }));
+    expect(data.entity).toEqual(entityFoo({ id: "2", fooAliased: "changed" }));
     expect(data).not.toBe(base);
     expect(data).not.toBe(model);
   });

--- a/packages/apollo-forest-run/src/values/__tests__/resolve.test.ts
+++ b/packages/apollo-forest-run/src/values/__tests__/resolve.test.ts
@@ -767,7 +767,8 @@ describe(aggregateFieldValue, () => {
     ]);
     const result = aggregateFieldValue(aggregateObject, "foo");
 
-    expect(result).toBe(42);
+    // ApolloCompat: last chunk takes precedence
+    expect(result).toBe(43);
   });
 
   it("aggregates object field values when parent is an aggregate", () => {
@@ -784,7 +785,7 @@ describe(aggregateFieldValue, () => {
 
     // The field 'bar' should have been aggregated
     const barValue = aggregateFieldValue(fooValue as ObjectValue, "bar");
-    expect(barValue).toBe("baz1"); // First value takes precedence
+    expect(barValue).toBe("baz2"); // ApolloCompat: last chunk takes precedence
   });
 
   it("handles missing fields in some chunks when aggregating", () => {
@@ -869,16 +870,17 @@ describe(aggregateFieldValue, () => {
     expect(result).toBe(leafDeletedValue);
   });
 
-  it("returns the first non-missing field value when aggregating", () => {
+  it("returns the last non-missing field value when aggregating", () => {
     const aggregateObject = createTestAggregateObject([
       [`query { foo }`, {}],
       [`query { foo }`, { foo: 43 }],
       [`query { foo }`, { foo: 44 }],
+      [`query { foo }`, {}],
     ]);
 
     const result = aggregateFieldValue(aggregateObject, "foo");
 
-    expect(result).toBe(43);
+    expect(result).toBe(44); // ApolloCompat: last non-empty chunk takes precedence
   });
 
   it("aggregates fields with arguments", () => {
@@ -921,7 +923,7 @@ describe(aggregateFieldValue, () => {
 
     const result = aggregateFieldValue(aggregateObject, "foo");
 
-    expect(result).toBe(42); // First value takes precedence
+    expect(result).toBe(43); // ApolloCompat: last chunk takes precedence
   });
 
   it("aggregates nested fields recursively", () => {
@@ -986,7 +988,7 @@ describe(aggregateFieldValue, () => {
 
     const result = aggregateFieldValue(aggregateObject, fieldEntry);
 
-    expect(result).toBe(42); // First value takes precedence
+    expect(result).toBe(43); // ApolloCompat: last chunk takes precedence
   });
 
   it("handles null values in some chunks when aggregating", () => {


### PR DESCRIPTION
This PR addresses a difference in behavior between ForestRun and InMemoryCache in a peculiar scenario when written result contains conflicting data. 

In the following example InMemoryCache will pick value `foo2` over `foo1` when writing to cache:

```js
  const badResult = {
    foo1: { __typename: "Foo", id: "foo", value: "foo1" },
    foo2: { __typename: "Foo", id: "foo", value: "foo2" },
  };
```

Before this PR, ForestRun would pick `foo1` over `foo2`. With this PR it behaves the same way as InMemoryCache.