### PR TITLE
fix(apollo-forest-run): keep root-level __typename in sync when reading

### DIFF
--- a/change/@graphitation-apollo-forest-run-5995c44c-85cd-4b7a-ae10-9ccb7505b4f9.json
+++ b/change/@graphitation-apollo-forest-run-5995c44c-85cd-4b7a-ae10-9ccb7505b4f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): keep root-level __typename in sync when reading",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/cache/read.ts
+++ b/packages/apollo-forest-run/src/cache/read.ts
@@ -206,10 +206,16 @@ function applyTransformations(
     createChunkProvider(dataLayers),
     createChunkMatcher(dataLayers),
   );
+  // Special case: root-level __typename field may become out of sync due to difference in manual writes/optimistic results and network results
+  //   so forcing them to be in sync:
+  const data = optimisticDraft.data as SourceObject;
+  if (inputTree.result.data.__typename) {
+    data.__typename = inputTree.result.data.__typename;
+  }
   const optimisticTree = indexTree(
     env,
     operation,
-    { data: optimisticDraft.data as SourceObject },
+    { data },
     optimisticDraft.missingFields,
     inputTree,
   );


### PR DESCRIPTION
## Overview

Fixes a bug in ForestRun where root-level `__typename` field comes out of sync for optimistic and non-optimistic result and accidentally breaks `@nonreactive`/`useFragment` scenario.

## Context

Apollo InMemoryCache strips away root-level `__typename` on read. Example:
```ts
cache.write({
  query: gql`{ foo }`,
  result: { __typename: "Query", foo: "foo" }; // <-- Note the `__typename` field
});
const readResult = cache.read({ query, optimistic: true });
```

`readResult` above is `{ foo: "foo" }` (i.e. without the `__typename` field).

(this logic plays a role later when Apollo compares "before/after" results of the same query for equality)

## Bug Description

ForestRun on the other hand always preserves the initial result for a query "as-is" (so in ForestRun `readResult` from the example contains `__typename`). But for optimistic responses it mimics Apollo behavior and strips away root-level `__typename`. This is where inconsistency creeps in - optimistic result in ForestRun is different from the regular read in this scenario.

This later breaks Apollo equality check, and as a result breaks `@nonreactive` and `useFragment` scenario (that is instead of only updating the fragment, it also notifies root-level `useQuery` as it assumes the data had changed for the whole query).