### PR TITLE
fix(apollo-forest-run): other approach for consistent root-level __typename

### DIFF
--- a/change/@graphitation-apollo-forest-run-89f388a7-a766-4e0d-850b-c6910a95227a.json
+++ b/change/@graphitation-apollo-forest-run-89f388a7-a766-4e0d-850b-c6910a95227a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): use other approach for consistent root-level __typename",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/compat/src/cache/inmemory/__tests__/cache.ts
+++ b/packages/apollo-forest-run/compat/src/cache/inmemory/__tests__/cache.ts
@@ -619,7 +619,7 @@ describe('Cache', () => {
       });
 
       expect(firstNameResult).toEqual({
-        __typename: "Person",
+        // __typename: "Person", // ForestRun: keeps __typename consistent with the query selection
         firstName: "Ben",
       });
 
@@ -652,7 +652,7 @@ describe('Cache', () => {
       });
 
       expect(lastNameResult).toEqual({
-        __typename: "Person",
+        // __typename: "Person", // ForestRun: keeps __typename consistent with the query selection
         lastName: "Newman",
       });
 
@@ -681,13 +681,13 @@ describe('Cache', () => {
       });
 
       expect(benjaminResult).toEqual({
-        __typename: "Person",
+        // __typename: "Person", // ForestRun: keeps __typename consistent with the query selection
         firstName: "Benjamin",
       });
 
       // Still the same as it was?
       expect(firstNameResult).toEqual({
-        __typename: "Person",
+        // __typename: "Person", // ForestRun: keeps __typename consistent with the query selection
         firstName: "Ben",
       });
 

--- a/packages/apollo-forest-run/compat/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/packages/apollo-forest-run/compat/src/cache/inmemory/__tests__/readFromStore.ts
@@ -106,6 +106,7 @@ describe('reading from the store', () => {
       });
 
       expect(queryResult).toEqual({
+        __typename: 'Query', // ForestRun: keeps __typename consistent with the query selection (__typename is added automatically for inline fragment selections)
         nestedObj: {
           innerArray: [{ id: 'abcdef', someField: 3 }],
         },
@@ -400,6 +401,7 @@ describe('reading from the store', () => {
 
     // The result of the query shouldn't contain __data_id fields
     expect(queryResult).toEqual({
+      __typename: 'Query', // ForestRun: keeps __typename consistent with the query selection (__typename is added automatically for inline fragment selections)
       stringField: 'This is a string!',
       numberField: 5,
       nullField: null,
@@ -1148,6 +1150,7 @@ describe('reading from the store', () => {
         }
       `,
     })).toEqual({
+      __typename: 'Query', // ForestRun: keeps __typename consistent with the query selection (__typename is added automatically for inline fragment selections)
       uuid: "8d573b9c-cfcf-4e3e-98dd-14d255af577e",
       null: null,
     });

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -842,6 +842,7 @@ test("treats incorrect list items as empty objects", () => {
 test("consistent root-level __typename in optimistic response 1", () => {
   const query = gql`
     {
+      __typename
       foo {
         id
         bar
@@ -873,6 +874,7 @@ test("consistent root-level __typename in optimistic response 1", () => {
         bar: { __typename: "Bar", id: "1", bar: "changed" },
       },
     });
+    cache.diff({ query, optimistic: true });
   }, "test");
   const optimisticData = cache.diff({ query, optimistic: true });
   cache.removeOptimistic("test");
@@ -913,6 +915,7 @@ test("consistent root-level __typename in optimistic response 2", () => {
   cache.write({
     query,
     result: {
+      __typename: "Query",
       foo: { __typename: "Bar", id: "1", bar: "bar" },
     },
   });
@@ -925,6 +928,7 @@ test("consistent root-level __typename in optimistic response 2", () => {
         bar: { __typename: "Bar", id: "1", bar: "changed" },
       },
     });
+    cache.diff({ query, optimistic: true });
   }, "test");
   const optimisticData = cache.diff({ query, optimistic: true });
   cache.removeOptimistic("test");


### PR DESCRIPTION
A follow up for https://github.com/microsoft/graphitation/pull/553 with a different approach, as the original one turned out to be incomplete in some edge cases.