### PR TITLE
fix(apollo-forest-run): correctly write fragments on abstract types

### DIFF
--- a/change/@graphitation-apollo-forest-run-0b0b8357-664b-4c02-a8b9-1c3ecd2a2032.json
+++ b/change/@graphitation-apollo-forest-run-0b0b8357-664b-4c02-a8b9-1c3ecd2a2032.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): correctly write fragments on abstract types",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vladimir.razuvaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -48,7 +48,7 @@ export function write(
   activeTransaction: Transaction,
   options: Cache.WriteOptions,
 ): WriteResult {
-  const { mergePolicies, objectKey, keyMap } = env;
+  const { mergePolicies, objectKey, addTypename, keyMap } = env;
   const targetForest = getActiveForest(store, activeTransaction);
 
   const writeData =
@@ -101,7 +101,7 @@ export function write(
       operationDescriptor,
       writeData,
     );
-    if (env.addTypename && typeName && !writeData["__typename"]) {
+    if (addTypename && typeName && !writeData["__typename"]) {
       writeData["__typename"] = typeName;
     }
     targetForest.extraRootIds.set(


### PR DESCRIPTION
Fixes a bug in ForestRun where fragments on abstract types were not being written correctly. That was caused by ForestRun relying on fragment type condition instead of the actual `__typename` from the store for abstract types.