### PR TITLE
[ts-codegen] Implement context types with namespaces defined in the input file

### DIFF
--- a/change/@graphitation-cli-9d74464b-d6d4-47f3-af75-eb0380d27a3d.json
+++ b/change/@graphitation-cli-9d74464b-d6d4-47f3-af75-eb0380d27a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Resolver context subtypes added",
+  "packageName": "@graphitation/cli",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-35e832ce-c9de-4ac0-9b68-b90e373b4573.json
+++ b/change/@graphitation-ts-codegen-35e832ce-c9de-4ac0-9b68-b90e373b4573.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Resolver context subtypes added",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -7,6 +7,7 @@ import { extractImplicitTypesToTypescript } from "@graphitation/supermassive-ext
 import { parse } from "graphql";
 import { generateTS } from "@graphitation/ts-codegen";
 import * as glob from "fast-glob";
+import type { SubTypeNamespace } from "@graphitation/ts-codegen";
 
 type GenerateInterfacesOptions = {
   outputDir?: string;
@@ -153,7 +154,7 @@ async function generateInterfaces(
     }
     const content = await fs.readFile(fullPath, { encoding: "utf-8" });
     const document = parse(content);
-    let contextSubTypeMetadata: Record<string, any> | undefined;
+    let contextSubTypeMetadata: SubTypeNamespace | undefined;
 
     const outputPath = path.join(
       path.dirname(fullPath),

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -53,14 +53,6 @@ export function supermassive(): Command {
       "from where to import context",
     )
     .option("-cn, --context-type-name [contextTypeName]", "Context type name")
-    .option(
-      "-dcp, --default-context-sub-type-path [baseContextSubTypePath]",
-      "From where the default context type will be exported",
-    )
-    .option(
-      "-cpt, --context-sub-type-path-template [contextSubTypePathTemplate]",
-      "context resource path template. You need to specify ${resourceName} in the parameter eg. `@package/preffix-${resourceName}-suffix`",
-    )
     .option("-ei, --enums-import [enumsImport]", "from where to import enums")
     .option("-l, --legacy", "generate legacy types")
     .option("--legacy-models", "do not use models for object types")
@@ -80,7 +72,7 @@ export function supermassive(): Command {
     )
     .option(
       "--context-sub-type-metadata-file [contextTypeExtensionsFile]",
-      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextSubTypePath?: string, baseContextSubTypeName?: string, contextSubTypes: { [namespace: string]: { [type: string]: { importNamespaceName: string, importPath: string }}}",
+      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName: string, importPath: string }}}",
     )
     .option(
       "--generate-resolver-map",
@@ -186,6 +178,12 @@ async function generateInterfaces(
           },
         ),
       );
+
+      if (!content?.contextTypes) {
+        throw new Error(
+          "contextTypeExtensionsFile doesn't contain contextTypes",
+        );
+      }
 
       contextTypeExtensions = content;
     }

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -3,9 +3,80 @@ import { parse } from "graphql";
 import { blankGraphQLTag as graphql } from "../utilities";
 import { generateTS } from "..";
 import { ContextMap } from "../context";
+import { SubTypeNamespace } from "../codegen";
 
 describe(generateTS, () => {
   describe("Tests basic syntax GraphQL syntax", () => {
+    const contextSubTypeMetadata = {
+      managers: {
+        user: {
+          name: "user",
+          importTypeName: 'UserStateMachineType["user"]',
+          importPath: "@package/user-state-machine",
+        },
+        whatever: {
+          name: "whatever",
+          importTypeName: 'WhateverStateMachineType["whatever"]',
+          importPath: "@package/whatever-state-machine",
+        },
+        "different-whatever": {
+          name: "different-whatever",
+          importTypeName:
+            'DifferentWhateverStateMachineType["different-whatever"]',
+          importPath: "@package/different-whatever-state-machine",
+        },
+        post: {
+          name: "post",
+          importTypeName: 'PostStateMachineType["post"]',
+          importPath: "@package/post-state-machine",
+        },
+        node: {
+          name: "node",
+          importTypeName: 'NodeStateMachineType["node"]',
+          importPath: "@package/node-state-machine",
+        },
+        persona: {
+          name: "persona",
+          importTypeName: 'PersonaStateMachineType["persona"]',
+          importPath: "@package/persona-state-machine",
+        },
+        admin: {
+          name: "admin",
+          importTypeName: 'AdminStateMachineType["admin"]',
+          importPath: "@package/admin-state-machine",
+        },
+        message: {
+          name: "message",
+          importTypeName: 'MessageStateMachineType["message"]',
+          importPath: "@package/message-state-machine",
+        },
+        customer: {
+          name: "customer",
+          importTypeName: 'CustomerStateMachineType["customer"]',
+          importPath: "@package/customer-state-machine",
+        },
+        "shouldnt-apply": {
+          name: "shouldnt-apply",
+          importTypeName: 'UserStateMachineType["shouldnt-apply"]',
+          importPath: "@package/shouldnt-apply-state-machine",
+        },
+        "user-or-customer": {
+          name: "user-or-customer",
+          importTypeName: 'UserStateMachineType["user-or-customer"]',
+          importPath: "@package/user-or-customer-state-machine",
+        },
+        "company-or-customer": {
+          name: "company-or-customer",
+          importTypeName: 'UserStateMachineType["company-or-customer"]',
+          importPath: "@package/company-or-customer-state-machine",
+        },
+        "id-user": {
+          name: "id-user",
+          importTypeName: 'UserStateMachineType["id-user"]',
+          importPath: "@package/id-user-state-machine",
+        },
+      },
+    };
     test("all possible nullable and non-nullable combinations", () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
@@ -18,11 +89,11 @@ describe(generateTS, () => {
             }
 
             type Message {
-              id: ID! @context(uses: ["message"])
+              id: ID! @context(uses: { managers: ["message"] })
             }
 
-            type User @context(uses: ["user"]) {
-              id: ID! @context(uses: ["id-user"])
+            type User @context(uses: { managers: ["user"] }) {
+              id: ID! @context(uses: { managers: ["id-user", "user"] })
               name: String
               messagesWithAnswersNonRequired: [[Message]]
               messagesWithAnswersRequired: [[Message]]!
@@ -31,7 +102,7 @@ describe(generateTS, () => {
               messagesWithArrayRequired: [Message]!
               messagesRequired: [Message!]!
               messagesOnlyMessageRequired: [Message!]
-              post: Post @context(uses: ["post"])
+              post: Post @context(uses: { managers: ["post"] })
               postRequired: Post!
               avatar: Avatar
               avatarRequired: Avatar!
@@ -47,29 +118,88 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
-            contextSubTypePathTemplate:
-              "@msteams/core-cdl-sync-${resourceName}",
+            contextSubTypeMetadata: contextSubTypeMetadata,
+            defaultContextSubTypePath: "@package/default-context",
+            defaultContextSubTypeName: "DefaultContextType",
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
       expect(contextMappingOutput).toMatchInlineSnapshot(`
         {
           "Message": {
-            "id": [
-              "message",
-            ],
+            "id": {
+              "managers": [
+                "message",
+              ],
+            },
           },
           "User": {
-            "__context": [
-              "user",
-            ],
-            "id": [
-              "id-user",
-            ],
-            "post": [
-              "post",
-            ],
+            "avatar": {
+              "managers": [
+                "user",
+              ],
+            },
+            "avatarRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "id": {
+              "managers": [
+                "id-user",
+                "user",
+              ],
+            },
+            "messagesNonRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesOnlyMessageRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesWithAnswersAllRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesWithAnswersNonRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesWithAnswersRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "messagesWithArrayRequired": {
+              "managers": [
+                "user",
+              ],
+            },
+            "name": {
+              "managers": [
+                "user",
+              ],
+            },
+            "post": {
+              "managers": [
+                "post",
+              ],
+            },
+            "postRequired": {
+              "managers": [
+                "user",
+              ],
+            },
           },
         }
       `);
@@ -111,10 +241,10 @@ describe(generateTS, () => {
         import type { PromiseOrValue } from "@graphitation/supermassive";
         import type { ResolveInfo } from "@graphitation/supermassive";
         import * as Models from "./models.interface";
-        import type { IMessageStateMachineContext } from "@msteams/core-cdl-sync-message";
-        import type { IUserStateMachineContext } from "@msteams/core-cdl-sync-user";
-        import type { IIdUserStateMachineContext } from "@msteams/core-cdl-sync-id-user";
-        import type { IPostStateMachineContext } from "@msteams/core-cdl-sync-post";
+        import type { DefaultContextType } from "@package/default-context";
+        import type { MessageStateMachineType } from "@package/message-state-machine";
+        import type { UserStateMachineType } from "@package/user-state-machine";
+        import type { PostStateMachineType } from "@package/post-state-machine";
         export declare namespace Post {
             export interface Resolvers {
                 readonly id?: id;
@@ -125,7 +255,11 @@ describe(generateTS, () => {
             export interface Resolvers {
                 readonly id?: id;
             }
-            export type id = (model: Models.Message, args: {}, context: IMessageStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+            export type id = (model: Models.Message, args: {}, context: DefaultContextType & {
+                managers: {
+                    "message": MessageStateMachineType["message"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string>;
         }
         export declare namespace User {
             export interface Resolvers {
@@ -143,19 +277,72 @@ describe(generateTS, () => {
                 readonly avatar?: avatar;
                 readonly avatarRequired?: avatarRequired;
             }
-            export type id = (model: Models.User, args: {}, context: IIdUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
-            export type name = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
-            export type messagesWithAnswersNonRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined> | null | undefined>;
-            export type messagesWithAnswersRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined>>;
-            export type messagesWithAnswersAllRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message>>>;
-            export type messagesNonRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined> | null | undefined>;
-            export type messagesWithArrayRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined>>;
-            export type messagesRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message>>;
-            export type messagesOnlyMessageRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message> | null | undefined>;
-            export type post = (model: Models.User, args: {}, context: IPostStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
-            export type postRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.Post>;
-            export type avatar = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar | null | undefined>;
-            export type avatarRequired = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar>;
+            export type id = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "id-user": UserStateMachineType["id-user"];
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string>;
+            export type name = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string | null | undefined>;
+            export type messagesWithAnswersNonRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined> | null | undefined>;
+            export type messagesWithAnswersRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message | null | undefined> | null | undefined>>;
+            export type messagesWithAnswersAllRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<ReadonlyArray<Models.Message>>>;
+            export type messagesNonRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined> | null | undefined>;
+            export type messagesWithArrayRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message | null | undefined>>;
+            export type messagesRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message>>;
+            export type messagesOnlyMessageRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<ReadonlyArray<Models.Message> | null | undefined>;
+            export type post = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "post": PostStateMachineType["post"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
+            export type postRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.Post>;
+            export type avatar = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar | null | undefined>;
+            export type avatarRequired = (model: Models.User, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar>;
         }
         export declare namespace Query {
             export interface Resolvers {
@@ -311,11 +498,11 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(uses: ["node"]) {
+            interface Node @context(uses: { managers: ["node"] }) {
               id: ID!
             }
 
-            interface Persona @context(uses: ["persona"]) {
+            interface Persona @context(uses: { managers: ["persona"] }) {
               phone: String!
             }
 
@@ -324,7 +511,8 @@ describe(generateTS, () => {
               name: String!
             }
 
-            type Admin implements Node & Persona @context(uses: ["admin"]) {
+            type Admin implements Node & Persona
+              @context(uses: { managers: ["admin"] }) {
               id: ID!
               rank: Int!
             }
@@ -335,26 +523,31 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
-            contextSubTypePathTemplate:
-              "@msteams/core-cdl-sync-${resourceName}",
+            contextSubTypeMetadata,
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
       expect(contextMappingOutput).toMatchInlineSnapshot(`
         {
           "Admin": {
-            "__context": [
-              "admin",
-            ],
+            "id": {
+              "managers": [
+                "admin",
+              ],
+            },
+            "rank": {
+              "managers": [
+                "admin",
+              ],
+            },
           },
           "Node": {
-            "__context": [
+            "managers": [
               "node",
             ],
           },
           "Persona": {
-            "__context": [
+            "managers": [
               "persona",
             ],
           },
@@ -386,20 +579,28 @@ describe(generateTS, () => {
         "import type { PromiseOrValue } from "@graphitation/supermassive";
         import type { ResolveInfo } from "@graphitation/supermassive";
         import * as Models from "./models.interface";
-        import type { INodeStateMachineContext } from "@msteams/core-cdl-sync-node";
-        import type { IPersonaStateMachineContext } from "@msteams/core-cdl-sync-persona";
-        import type { IAdminStateMachineContext } from "@msteams/core-cdl-sync-admin";
+        import type { NodeStateMachineType } from "@package/node-state-machine";
+        import type { PersonaStateMachineType } from "@package/persona-state-machine";
+        import type { AdminStateMachineType } from "@package/admin-state-machine";
         export declare namespace Node {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: unknown, context: INodeStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+            export type __resolveType = (parent: unknown, context: {
+                managers: {
+                    "node": NodeStateMachineType["node"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string | null>;
         }
         export declare namespace Persona {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: unknown, context: IPersonaStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+            export type __resolveType = (parent: unknown, context: {
+                managers: {
+                    "persona": PersonaStateMachineType["persona"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string | null>;
         }
         export declare namespace User {
             export interface Resolvers {
@@ -412,8 +613,16 @@ describe(generateTS, () => {
                 readonly id?: id;
                 readonly rank?: rank;
             }
-            export type id = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
-            export type rank = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<number>;
+            export type id = (model: Models.Admin, args: {}, context: {
+                managers: {
+                    "admin": AdminStateMachineType["admin"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string>;
+            export type rank = (model: Models.Admin, args: {}, context: {
+                managers: {
+                    "admin": AdminStateMachineType["admin"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<number>;
         }
         export declare namespace Query {
             export interface Resolvers {
@@ -459,11 +668,12 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(uses: ["node"]) {
+            interface Node @context(uses: { managers: ["node"] }) {
               id: ID!
             }
 
-            interface Customer implements Node @context(uses: ["customer"]) {
+            interface Customer implements Node
+              @context(uses: { managers: ["customer"] }) {
               id: ID!
               name: String!
             }
@@ -478,21 +688,19 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
-            contextSubTypePathTemplate:
-              "@msteams/core-cdl-sync-${resourceName}",
+            contextSubTypeMetadata,
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
       expect(contextMappingOutput).toMatchInlineSnapshot(`
         {
           "Customer": {
-            "__context": [
+            "managers": [
               "customer",
             ],
           },
           "Node": {
-            "__context": [
+            "managers": [
               "node",
             ],
           },
@@ -521,19 +729,27 @@ describe(generateTS, () => {
         "import type { PromiseOrValue } from "@graphitation/supermassive";
         import type { ResolveInfo } from "@graphitation/supermassive";
         import * as Models from "./models.interface";
-        import type { INodeStateMachineContext } from "@msteams/core-cdl-sync-node";
-        import type { ICustomerStateMachineContext } from "@msteams/core-cdl-sync-customer";
+        import type { NodeStateMachineType } from "@package/node-state-machine";
+        import type { CustomerStateMachineType } from "@package/customer-state-machine";
         export declare namespace Node {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: unknown, context: INodeStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+            export type __resolveType = (parent: unknown, context: {
+                managers: {
+                    "node": NodeStateMachineType["node"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string | null>;
         }
         export declare namespace Customer {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: unknown, context: ICustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<string | null>;
+            export type __resolveType = (parent: unknown, context: {
+                managers: {
+                    "customer": CustomerStateMachineType["customer"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string | null>;
         }
         export declare namespace User {
             export interface Resolvers {
@@ -555,22 +771,26 @@ describe(generateTS, () => {
 
     test("applying @context to enum shouldn't affect anything", () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
-        runGenerateTest(graphql`
-          enum PresenceAvailability @context(uses: ["shouldnt-apply"]) {
-            Available
-            Away
-            Offline
-          }
+        runGenerateTest(
+          graphql`
+            enum PresenceAvailability
+              @context(uses: { managers: ["shouldnt-apply"] }) {
+              Available
+              Away
+              Offline
+            }
 
-          type User {
-            id: ID!
-            availability: PresenceAvailability!
-          }
+            type User {
+              id: ID!
+              availability: PresenceAvailability!
+            }
 
-          extend type Query {
-            userById(id: ID!): User
-          }
-        `);
+            extend type Query {
+              userById(id: ID!): User
+            }
+          `,
+          { contextSubTypeMetadata },
+        );
       expect(enums).toMatchInlineSnapshot(`
         "export enum PresenceAvailability {
             Available = "Available",
@@ -631,11 +851,11 @@ describe(generateTS, () => {
               id: ID!
             }
 
-            type Admin @context(uses: ["admin"]) {
+            type Admin @context(uses: { managers: ["admin"] }) {
               id: ID!
             }
 
-            type User @context(uses: ["user"]) {
+            type User @context(uses: { managers: ["user"] }) {
               id: ID!
             }
 
@@ -644,54 +864,63 @@ describe(generateTS, () => {
             }
 
             union UserOrAdmin = User | Admin
-            union UserOrCustomer @context(uses: ["user-or-customer"]) =
+            union UserOrCustomer
+              @context(uses: { managers: ["user-or-customer"] }) =
                 User
               | Customer
-            union CompanyOrCustomer @context(uses: ["company-or-customer"]) =
+            union CompanyOrCustomer
+              @context(uses: { managers: ["company-or-customer"] }) =
                 Company
               | Customer
 
             extend type Query {
-              userById(id: ID!): whatever @context(uses: ["whatever"])
+              userById(id: ID!): whatever
+                @context(uses: { managers: ["whatever"] })
               userByMail(mail: String): whatever
-                @context(uses: ["different-whatever"])
+                @context(uses: { managers: ["different-whatever"] })
               node(id: ID!): Node
             }
           `,
           {
-            contextSubTypeNameTemplate: "I${resourceName}StateMachineContext",
-            contextSubTypePathTemplate:
-              "@msteams/core-cdl-sync-${resourceName}",
+            contextSubTypeMetadata,
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
       expect(contextMappingOutput).toMatchInlineSnapshot(`
         {
           "Admin": {
-            "__context": [
-              "admin",
-            ],
+            "id": {
+              "managers": [
+                "admin",
+              ],
+            },
           },
           "CompanyOrCustomer": {
-            "__context": [
+            "managers": [
               "company-or-customer",
             ],
           },
           "Query": {
-            "userById": [
-              "whatever",
-            ],
-            "userByMail": [
-              "different-whatever",
-            ],
+            "userById": {
+              "managers": [
+                "whatever",
+              ],
+            },
+            "userByMail": {
+              "managers": [
+                "different-whatever",
+              ],
+            },
           },
           "User": {
-            "__context": [
-              "user",
-            ],
+            "id": {
+              "managers": [
+                "user",
+              ],
+            },
           },
           "UserOrCustomer": {
-            "__context": [
+            "managers": [
               "user-or-customer",
             ],
           },
@@ -731,12 +960,10 @@ describe(generateTS, () => {
         "import type { PromiseOrValue } from "@graphitation/supermassive";
         import type { ResolveInfo } from "@graphitation/supermassive";
         import * as Models from "./models.interface";
-        import type { IAdminStateMachineContext } from "@msteams/core-cdl-sync-admin";
-        import type { IUserStateMachineContext } from "@msteams/core-cdl-sync-user";
-        import type { IUserOrCustomerStateMachineContext } from "@msteams/core-cdl-sync-user-or-customer";
-        import type { ICompanyOrCustomerStateMachineContext } from "@msteams/core-cdl-sync-company-or-customer";
-        import type { IWhateverStateMachineContext } from "@msteams/core-cdl-sync-whatever";
-        import type { IDifferentWhateverStateMachineContext } from "@msteams/core-cdl-sync-different-whatever";
+        import type { AdminStateMachineType } from "@package/admin-state-machine";
+        import type { UserStateMachineType } from "@package/user-state-machine";
+        import type { WhateverStateMachineType } from "@package/whatever-state-machine";
+        import type { DifferentWhateverStateMachineType } from "@package/different-whatever-state-machine";
         export declare namespace Customer {
             export interface Resolvers {
                 readonly id?: id;
@@ -753,13 +980,21 @@ describe(generateTS, () => {
             export interface Resolvers {
                 readonly id?: id;
             }
-            export type id = (model: Models.Admin, args: {}, context: IAdminStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+            export type id = (model: Models.Admin, args: {}, context: {
+                managers: {
+                    "admin": AdminStateMachineType["admin"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string>;
         }
         export declare namespace User {
             export interface Resolvers {
                 readonly id?: id;
             }
-            export type id = (model: Models.User, args: {}, context: IUserStateMachineContext, info: ResolveInfo) => PromiseOrValue<string>;
+            export type id = (model: Models.User, args: {}, context: {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<string>;
         }
         export declare namespace Node {
             export interface Resolvers {
@@ -777,13 +1012,21 @@ describe(generateTS, () => {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: Models.User | Models.Customer, context: IUserOrCustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<"User" | "Customer" | null>;
+            export type __resolveType = (parent: Models.User | Models.Customer, context: {
+                managers: {
+                    "user-or-customer": UserStateMachineType["user-or-customer"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<"User" | "Customer" | null>;
         }
         export declare namespace CompanyOrCustomer {
             export interface Resolvers {
                 readonly __resolveType?: __resolveType;
             }
-            export type __resolveType = (parent: Models.Company | Models.Customer, context: ICompanyOrCustomerStateMachineContext, info: ResolveInfo) => PromiseOrValue<"Company" | "Customer" | null>;
+            export type __resolveType = (parent: Models.Company | Models.Customer, context: {
+                managers: {
+                    "company-or-customer": UserStateMachineType["company-or-customer"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<"Company" | "Customer" | null>;
         }
         export declare namespace Query {
             export interface Resolvers {
@@ -793,10 +1036,18 @@ describe(generateTS, () => {
             }
             export type userById = (model: unknown, args: {
                 readonly id: string;
-            }, context: IWhateverStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
+            }, context: {
+                managers: {
+                    "whatever": WhateverStateMachineType["whatever"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
             export type userByMail = (model: unknown, args: {
                 readonly mail?: string | null;
-            }, context: IDifferentWhateverStateMachineContext, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
+            }, context: {
+                managers: {
+                    "different-whatever": DifferentWhateverStateMachineType["different-whatever"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
             export type node = (model: unknown, args: {
                 readonly id: string;
             }, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Node | null | undefined>;
@@ -812,7 +1063,8 @@ function runGenerateTest(
   options: {
     outputPath?: string;
     documentPath?: string;
-    defaultContextTypePath?: string;
+    defaultContextSubTypeName?: string;
+    defaultContextSubTypePath?: string;
     contextName?: string;
     legacyCompat?: boolean;
     enumsImport?: string;
@@ -821,8 +1073,7 @@ function runGenerateTest(
     enumNamesToMigrate?: string[];
     enumNamesToKeep?: string[];
     modelScope?: string;
-    contextSubTypeNameTemplate?: string;
-    contextSubTypePathTemplate?: string;
+    contextSubTypeMetadata?: SubTypeNamespace;
   } = {},
 ): {
   enums?: string;
@@ -841,15 +1092,14 @@ function runGenerateTest(
   const fullOptions: {
     outputPath: string;
     documentPath: string;
-    defaultContextTypePath?: string | null;
+    defaultContextSubTypeName?: string;
+    defaultContextSubTypePath?: string;
     contextName?: string;
     legacyCompat?: boolean;
     legacyNoModelsForObjects?: boolean;
     useStringUnionsInsteadOfEnums?: boolean;
     enumNamesToMigrate?: string[];
     enumNamesToKeep?: string[];
-    contextSubTypeNameTemplate?: string;
-    contextSubTypePathTemplate?: string;
   } = {
     outputPath: "__generated__",
     documentPath: "./typedef.graphql",

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -8,16 +8,15 @@ import { OutputMetadata } from "../context/utilities";
 describe(generateTS, () => {
   describe("Tests basic syntax GraphQL syntax", () => {
     const contextTypeExtensions = {
-      baseContextSubTypePath: "@package/default-context",
-      baseContextSubTypeName: "DefaultContextType",
-      contextSubTypes: {
+      baseContextTypePath: "@package/default-context",
+      baseContextTypeName: "DefaultContextType",
+      contextTypes: {
         managers: {
           user: {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/user-state-machine",
           },
           whatever: {
-            importNamespaceName: "WhateverStateMachineType",
             importPath: "@package/whatever-state-machine",
           },
           "different-whatever": {
@@ -512,7 +511,7 @@ describe(generateTS, () => {
           `,
           {
             contextTypeExtensions: {
-              contextSubTypes: contextTypeExtensions.contextSubTypes,
+              contextTypes: contextTypeExtensions.contextTypes,
             },
           },
         );
@@ -679,7 +678,7 @@ describe(generateTS, () => {
           `,
           {
             contextTypeExtensions: {
-              contextSubTypes: contextTypeExtensions.contextSubTypes,
+              contextTypes: contextTypeExtensions.contextTypes,
             },
           },
         );
@@ -875,7 +874,7 @@ describe(generateTS, () => {
           `,
           {
             contextTypeExtensions: {
-              contextSubTypes: contextTypeExtensions.contextSubTypes,
+              contextTypes: contextTypeExtensions.contextTypes,
             },
           },
         );
@@ -956,7 +955,7 @@ describe(generateTS, () => {
         import * as Models from "./models.interface";
         import type { AdminStateMachineType } from "@package/admin-state-machine";
         import type { UserStateMachineType } from "@package/user-state-machine";
-        import type { WhateverStateMachineType } from "@package/whatever-state-machine";
+        import type { whatever } from "@package/whatever-state-machine";
         import type { DifferentWhateverStateMachineType } from "@package/different-whatever-state-machine";
         export declare namespace Customer {
             export interface Resolvers {
@@ -1032,7 +1031,7 @@ describe(generateTS, () => {
                 readonly id: string;
             }, context: {
                 managers: {
-                    "whatever": WhateverStateMachineType["whatever"];
+                    "whatever": whatever;
                 };
             }, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
             export type userByMail = (model: unknown, args: {
@@ -1084,8 +1083,8 @@ function runGenerateTest(
   const fullOptions: {
     outputPath: string;
     documentPath: string;
-    baseContextSubTypeName?: string;
-    baseContextSubTypePath?: string;
+    baseContextTypeName?: string;
+    baseContextTypePath?: string;
     contextName?: string;
     legacyCompat?: boolean;
     legacyNoModelsForObjects?: boolean;
@@ -1096,10 +1095,8 @@ function runGenerateTest(
     outputPath: "__generated__",
     documentPath: "./typedef.graphql",
     ...options,
-    baseContextSubTypeName:
-      options?.contextTypeExtensions?.baseContextSubTypeName,
-    baseContextSubTypePath:
-      options?.contextTypeExtensions?.baseContextSubTypePath,
+    baseContextTypeName: options?.contextTypeExtensions?.baseContextTypeName,
+    baseContextTypePath: options?.contextTypeExtensions?.baseContextTypePath,
   };
   const document = parse(doc);
   const { files, contextMappingOutput } = generateTS(document, fullOptions);

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -7,73 +7,63 @@ import { OutputMetadata } from "../context/utilities";
 
 describe(generateTS, () => {
   describe("Tests basic syntax GraphQL syntax", () => {
-    const contextSubTypeMetadata = {
-      managers: {
-        user: {
-          name: "user",
-          importTypeName: 'UserStateMachineType["user"]',
-          importPath: "@package/user-state-machine",
-        },
-        whatever: {
-          name: "whatever",
-          importTypeName: 'WhateverStateMachineType["whatever"]',
-          importPath: "@package/whatever-state-machine",
-        },
-        "different-whatever": {
-          name: "different-whatever",
-          importTypeName:
-            'DifferentWhateverStateMachineType["different-whatever"]',
-          importPath: "@package/different-whatever-state-machine",
-        },
-        post: {
-          name: "post",
-          importTypeName: 'PostStateMachineType["post"]',
-          importPath: "@package/post-state-machine",
-        },
-        node: {
-          name: "node",
-          importTypeName: 'NodeStateMachineType["node"]',
-          importPath: "@package/node-state-machine",
-        },
-        persona: {
-          name: "persona",
-          importTypeName: 'PersonaStateMachineType["persona"]',
-          importPath: "@package/persona-state-machine",
-        },
-        admin: {
-          name: "admin",
-          importTypeName: 'AdminStateMachineType["admin"]',
-          importPath: "@package/admin-state-machine",
-        },
-        message: {
-          name: "message",
-          importTypeName: 'MessageStateMachineType["message"]',
-          importPath: "@package/message-state-machine",
-        },
-        customer: {
-          name: "customer",
-          importTypeName: 'CustomerStateMachineType["customer"]',
-          importPath: "@package/customer-state-machine",
-        },
-        "shouldnt-apply": {
-          name: "shouldnt-apply",
-          importTypeName: 'UserStateMachineType["shouldnt-apply"]',
-          importPath: "@package/shouldnt-apply-state-machine",
-        },
-        "user-or-customer": {
-          name: "user-or-customer",
-          importTypeName: 'UserStateMachineType["user-or-customer"]',
-          importPath: "@package/user-or-customer-state-machine",
-        },
-        "company-or-customer": {
-          name: "company-or-customer",
-          importTypeName: 'UserStateMachineType["company-or-customer"]',
-          importPath: "@package/company-or-customer-state-machine",
-        },
-        "id-user": {
-          name: "id-user",
-          importTypeName: 'UserStateMachineType["id-user"]',
-          importPath: "@package/id-user-state-machine",
+    const contextTypeExtensions = {
+      baseContextSubTypePath: "@package/default-context",
+      baseContextSubTypeName: "DefaultContextType",
+      contextSubTypes: {
+        managers: {
+          user: {
+            importNamespaceName: "UserStateMachineType",
+            importPath: "@package/user-state-machine",
+          },
+          whatever: {
+            importNamespaceName: "WhateverStateMachineType",
+            importPath: "@package/whatever-state-machine",
+          },
+          "different-whatever": {
+            importNamespaceName: "DifferentWhateverStateMachineType",
+            importPath: "@package/different-whatever-state-machine",
+          },
+          post: {
+            importNamespaceName: "PostStateMachineType",
+            importPath: "@package/post-state-machine",
+          },
+          node: {
+            importNamespaceName: "NodeStateMachineType",
+            importPath: "@package/node-state-machine",
+          },
+          persona: {
+            importNamespaceName: "PersonaStateMachineType",
+            importPath: "@package/persona-state-machine",
+          },
+          admin: {
+            importNamespaceName: "AdminStateMachineType",
+            importPath: "@package/admin-state-machine",
+          },
+          message: {
+            importNamespaceName: "MessageStateMachineType",
+            importPath: "@package/message-state-machine",
+          },
+          customer: {
+            importNamespaceName: "CustomerStateMachineType",
+            importPath: "@package/customer-state-machine",
+          },
+          "shouldnt-apply": {
+            importNamespaceName: "UserStateMachineType",
+            importPath: "@package/shouldnt-apply-state-machine",
+          },
+          "user-or-customer": {
+            importNamespaceName: "UserStateMachineType",
+            importPath: "@package/user-or-customer-state-machine",
+          },
+          "company-or-customer": {
+            importNamespaceName: "UserStateMachineType",
+            importPath: "@package/company-or-customer-state-machine",
+          },
+          "id-user": {
+            importNamespaceName: "UserStateMachineType",
+            importPath: "@package/id-user-state-machine",
+          },
         },
       },
     };
@@ -118,9 +108,7 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeMetadata: contextSubTypeMetadata,
-            defaultContextSubTypePath: "@package/default-context",
-            defaultContextSubTypeName: "DefaultContextType",
+            contextTypeExtensions: contextTypeExtensions,
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -523,7 +511,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeMetadata,
+            contextTypeExtensions: {
+              contextSubTypes: contextTypeExtensions.contextSubTypes,
+            },
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -688,7 +678,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeMetadata,
+            contextTypeExtensions: {
+              contextSubTypes: contextTypeExtensions.contextSubTypes,
+            },
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -789,7 +781,7 @@ describe(generateTS, () => {
               userById(id: ID!): User
             }
           `,
-          { contextSubTypeMetadata },
+          { contextTypeExtensions },
         );
       expect(enums).toMatchInlineSnapshot(`
         "export enum PresenceAvailability {
@@ -882,7 +874,9 @@ describe(generateTS, () => {
             }
           `,
           {
-            contextSubTypeMetadata,
+            contextTypeExtensions: {
+              contextSubTypes: contextTypeExtensions.contextSubTypes,
+            },
           },
         );
       expect(enums).toMatchInlineSnapshot(`undefined`);
@@ -1063,8 +1057,6 @@ function runGenerateTest(
   options: {
     outputPath?: string;
     documentPath?: string;
-    defaultContextSubTypeName?: string;
-    defaultContextSubTypePath?: string;
     contextName?: string;
     legacyCompat?: boolean;
     enumsImport?: string;
@@ -1073,7 +1065,7 @@ function runGenerateTest(
     enumNamesToMigrate?: string[];
     enumNamesToKeep?: string[];
     modelScope?: string;
-    contextSubTypeMetadata?: SubTypeNamespace;
+    contextTypeExtensions?: SubTypeNamespace;
   } = {},
 ): {
   enums?: string;
@@ -1092,8 +1084,8 @@ function runGenerateTest(
   const fullOptions: {
     outputPath: string;
     documentPath: string;
-    defaultContextSubTypeName?: string;
-    defaultContextSubTypePath?: string;
+    baseContextSubTypeName?: string;
+    baseContextSubTypePath?: string;
     contextName?: string;
     legacyCompat?: boolean;
     legacyNoModelsForObjects?: boolean;
@@ -1104,6 +1096,10 @@ function runGenerateTest(
     outputPath: "__generated__",
     documentPath: "./typedef.graphql",
     ...options,
+    baseContextSubTypeName:
+      options?.contextTypeExtensions?.baseContextSubTypeName,
+    baseContextSubTypePath:
+      options?.contextTypeExtensions?.baseContextSubTypePath,
   };
   const document = parse(doc);
   const { files, contextMappingOutput } = generateTS(document, fullOptions);

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -2,8 +2,8 @@ import ts from "typescript";
 import { parse } from "graphql";
 import { blankGraphQLTag as graphql } from "../utilities";
 import { generateTS } from "..";
-import { ContextMap } from "../context";
 import { SubTypeNamespace } from "../codegen";
+import { OutputMetadata } from "../context/utilities";
 
 describe(generateTS, () => {
   describe("Tests basic syntax GraphQL syntax", () => {
@@ -1087,7 +1087,7 @@ function runGenerateTest(
   enumNamesToMigrate?: string[];
   enumNamesToKeep?: string[];
   modelScope?: string;
-  contextMappingOutput: ContextMap | null;
+  contextMappingOutput: OutputMetadata | null;
 } {
   const fullOptions: {
     outputPath: string;

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -6,6 +6,7 @@ import { generateModels } from "./models";
 import { generateLegacyTypes } from "./legacyTypes";
 import { generateLegacyResolvers } from "./legacyResolvers";
 import { generateEnums } from "./enums";
+import { OutputMetadata } from "./context/utilities";
 
 export type SubTypeItem = {
   [name: string]: {
@@ -96,7 +97,7 @@ export function generateTS(
   }: GenerateTSOptions,
 ): {
   files: ts.SourceFile[];
-  contextMappingOutput: any | null;
+  contextMappingOutput: OutputMetadata | null;
 } {
   try {
     const context = extractContext(

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -17,9 +17,9 @@ export type SubTypeItem = {
 };
 
 export type SubTypeNamespace = {
-  baseContextSubTypeName?: string;
-  baseContextSubTypePath?: string;
-  contextSubTypes: { [namespace: string]: SubTypeItem };
+  baseContextTypeName?: string;
+  baseContextTypePath?: string;
+  contextTypes: { [namespace: string]: SubTypeItem };
 };
 
 export interface GenerateTSOptions {
@@ -113,11 +113,11 @@ export function generateTS(
         enumNamesToMigrate,
         enumNamesToKeep,
         contextTypeExtensions,
-        baseContextSubTypePath: getContextPath(
+        baseContextTypePath: getContextPath(
           outputPath,
-          contextTypeExtensions?.baseContextSubTypePath,
+          contextTypeExtensions?.baseContextTypePath,
         ),
-        baseContextSubTypeName: contextTypeExtensions?.baseContextSubTypeName,
+        baseContextTypeName: contextTypeExtensions?.baseContextTypeName,
       },
       document,
       outputPath,

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -1,12 +1,23 @@
 import ts from "typescript";
 import { DocumentNode } from "graphql";
-import { ContextMap, extractContext } from "./context/index";
+import { extractContext } from "./context/index";
 import { generateResolvers } from "./resolvers";
 import { generateModels } from "./models";
 import { generateLegacyTypes } from "./legacyTypes";
 import { generateLegacyResolvers } from "./legacyResolvers";
 import { generateEnums } from "./enums";
 
+export type SubTypeItem = {
+  [name: string]: {
+    name: string;
+    importTypeName: string;
+    importPath: string;
+  };
+};
+
+export type SubTypeNamespace = {
+  [namespace: string]: SubTypeItem;
+};
 export interface GenerateTSOptions {
   outputPath: string;
   documentPath: string;
@@ -20,8 +31,7 @@ export interface GenerateTSOptions {
   generateOnlyEnums?: boolean;
   enumNamesToMigrate?: string[];
   enumNamesToKeep?: string[];
-  contextSubTypeNameTemplate?: string;
-  contextSubTypePathTemplate?: string;
+  contextSubTypeMetadata?: SubTypeNamespace;
   defaultContextSubTypePath?: string;
   defaultContextSubTypeName?: string;
   /**
@@ -78,8 +88,7 @@ export function generateTS(
     generateOnlyEnums,
     enumNamesToMigrate,
     enumNamesToKeep,
-    contextSubTypeNameTemplate,
-    contextSubTypePathTemplate,
+    contextSubTypeMetadata,
     defaultContextSubTypePath,
     defaultContextSubTypeName,
     generateResolverMap = false,
@@ -87,7 +96,7 @@ export function generateTS(
   }: GenerateTSOptions,
 ): {
   files: ts.SourceFile[];
-  contextMappingOutput: ContextMap | null;
+  contextMappingOutput: any | null;
 } {
   try {
     const context = extractContext(
@@ -103,8 +112,7 @@ export function generateTS(
         modelScope,
         enumNamesToMigrate,
         enumNamesToKeep,
-        contextSubTypeNameTemplate,
-        contextSubTypePathTemplate,
+        contextSubTypeMetadata,
         defaultContextSubTypePath,
         defaultContextSubTypeName,
       },
@@ -138,7 +146,7 @@ export function generateTS(
     }
     return {
       files: result,
-      contextMappingOutput: context.getContextMap(),
+      contextMappingOutput: context.getMetadataObject(),
     };
   } catch (e) {
     console.error(e);

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -7,18 +7,21 @@ import { generateLegacyTypes } from "./legacyTypes";
 import { generateLegacyResolvers } from "./legacyResolvers";
 import { generateEnums } from "./enums";
 import { OutputMetadata } from "./context/utilities";
+import { getContextPath } from "./utilities";
 
 export type SubTypeItem = {
-  [name: string]: {
-    name: string;
-    importTypeName: string;
+  [subType: string]: {
+    importNamespaceName?: string;
     importPath: string;
   };
 };
 
 export type SubTypeNamespace = {
-  [namespace: string]: SubTypeItem;
+  baseContextSubTypeName?: string;
+  baseContextSubTypePath?: string;
+  contextSubTypes: { [namespace: string]: SubTypeItem };
 };
+
 export interface GenerateTSOptions {
   outputPath: string;
   documentPath: string;
@@ -32,9 +35,7 @@ export interface GenerateTSOptions {
   generateOnlyEnums?: boolean;
   enumNamesToMigrate?: string[];
   enumNamesToKeep?: string[];
-  contextSubTypeMetadata?: SubTypeNamespace;
-  defaultContextSubTypePath?: string;
-  defaultContextSubTypeName?: string;
+  contextTypeExtensions?: SubTypeNamespace;
   /**
    * Enable the generation of the resolver map as the default export in the resolvers file.
    *
@@ -89,9 +90,7 @@ export function generateTS(
     generateOnlyEnums,
     enumNamesToMigrate,
     enumNamesToKeep,
-    contextSubTypeMetadata,
-    defaultContextSubTypePath,
-    defaultContextSubTypeName,
+    contextTypeExtensions,
     generateResolverMap = false,
     mandatoryResolverTypes = false,
   }: GenerateTSOptions,
@@ -113,9 +112,12 @@ export function generateTS(
         modelScope,
         enumNamesToMigrate,
         enumNamesToKeep,
-        contextSubTypeMetadata,
-        defaultContextSubTypePath,
-        defaultContextSubTypeName,
+        contextTypeExtensions,
+        baseContextSubTypePath: getContextPath(
+          outputPath,
+          contextTypeExtensions?.baseContextSubTypePath,
+        ),
+        baseContextSubTypeName: contextTypeExtensions?.baseContextSubTypeName,
       },
       document,
       outputPath,

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -114,7 +114,7 @@ export type ContextMapTypeItem = { __context?: string[] } & {
 
 export class TsCodegenContext {
   private allTypes: Array<Type>;
-  private resolverTypeMap: any;
+  private resolverTypeMap: Record<string, string[] | null>;
   private typeContextMap: ContextMap;
   private typeNameToType: Map<string, Type>;
   private usedEntitiesInModels: Set<string>;

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -1,35 +1,5 @@
-import ts, { factory } from "typescript";
+import { factory } from "typescript";
 import path from "path";
-
-export function getImportIdentifierForTypenames(
-  importNames: string[],
-  importPath: string,
-  contextImportNames: Set<string>,
-) {
-  return factory.createImportDeclaration(
-    undefined,
-    factory.createImportClause(
-      true,
-      undefined,
-      factory.createNamedImports(
-        importNames
-          .map((importName: string) => {
-            if (contextImportNames.has(importName)) {
-              return;
-            }
-            contextImportNames.add(importName);
-            return factory.createImportSpecifier(
-              false,
-              undefined,
-              factory.createIdentifier(importName),
-            );
-          })
-          .filter(Boolean) as ts.ImportSpecifier[],
-      ),
-    ),
-    factory.createStringLiteral(importPath),
-  );
-}
 
 export function createImportDeclaration(
   importNames: string[],
@@ -82,6 +52,104 @@ export function getRelativePath(
   const modelFullPath = path.resolve(path.dirname(documentPath), from);
 
   return cleanRelativePath(path.relative(outputPath, modelFullPath));
+}
+
+type MetadataItem = { [namespace: string]: string[] };
+
+type RootResolersMetadata = {
+  [resolver: string]: MetadataItem;
+};
+
+type TypeMetadata = {
+  [typeName: string]: { [field: string]: MetadataItem };
+};
+
+type OutputMetadata = RootResolersMetadata | TypeMetadata;
+
+export function buildContextMetadataOutput(
+  contextMap: any,
+  resolverTypeMap: any,
+) {
+  const metadata: OutputMetadata = {};
+
+  for (const [key, values] of Object.entries(
+    resolverTypeMap as Record<string, string>,
+  )) {
+    if (!contextMap[key]) {
+      continue;
+    }
+
+    if (values === null) {
+      if (contextMap[key]?.__context) {
+        for (const contextValue of contextMap[key].__context) {
+          const [namespace, subTypeName] = contextValue.split(":");
+
+          if (!metadata[key]) {
+            metadata[key] = {};
+          }
+
+          if (!metadata[key][namespace]) {
+            metadata[key][namespace] = [];
+          }
+
+          if (!Array.isArray(metadata[key][namespace])) {
+            throw Error("Invalid context metadata");
+          }
+
+          if (!metadata[key][namespace].includes(subTypeName)) {
+            metadata[key][namespace].push(subTypeName);
+          }
+        }
+        continue;
+      }
+      continue;
+    }
+
+    for (const value of values) {
+      if (contextMap[key][value]) {
+        for (const typeValue of contextMap[key][value]) {
+          buildContextMetadataOutputItem(metadata, typeValue, key, value);
+        }
+        continue;
+      } else if (contextMap[key].__context) {
+        for (const contextValue of contextMap[key].__context) {
+          buildContextMetadataOutputItem(metadata, contextValue, key, value);
+        }
+        continue;
+      }
+    }
+  }
+
+  return metadata;
+}
+
+function buildContextMetadataOutputItem(
+  metadata: OutputMetadata,
+  contextKey: string,
+  key: string,
+  value: string,
+) {
+  const [namespace, subTypeName] = contextKey.split(":");
+
+  if (!metadata[key]) {
+    metadata[key] = {};
+  }
+
+  if (!metadata[key][value]) {
+    metadata[key][value] = {};
+  }
+
+  if (Array.isArray(metadata[key][value])) {
+    throw Error("Invalid context metadata");
+  }
+
+  if (!metadata[key][value][namespace]) {
+    metadata[key][value][namespace] = [];
+  }
+
+  if (!metadata[key][value][namespace].includes(subTypeName)) {
+    metadata[key][value][namespace].push(subTypeName);
+  }
 }
 
 export function isRootOperationType(typeName: string) {

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -1,5 +1,6 @@
 import { factory } from "typescript";
 import path from "path";
+import { ContextMap } from ".";
 
 export function createImportDeclaration(
   importNames: string[],
@@ -64,17 +65,15 @@ type TypeMetadata = {
   [typeName: string]: { [field: string]: MetadataItem };
 };
 
-type OutputMetadata = RootResolersMetadata | TypeMetadata;
+export type OutputMetadata = RootResolersMetadata | TypeMetadata;
 
 export function buildContextMetadataOutput(
-  contextMap: any,
-  resolverTypeMap: any,
+  contextMap: ContextMap,
+  resolverTypeMap: Record<string, string[] | null>,
 ) {
   const metadata: OutputMetadata = {};
 
-  for (const [key, values] of Object.entries(
-    resolverTypeMap as Record<string, string>,
-  )) {
+  for (const [key, values] of Object.entries(resolverTypeMap)) {
     if (!contextMap[key]) {
       continue;
     }

--- a/packages/ts-codegen/src/index.ts
+++ b/packages/ts-codegen/src/index.ts
@@ -1,1 +1,2 @@
 export { generateTS } from "./codegen";
+export type { SubTypeNamespace } from "./codegen";

--- a/packages/ts-codegen/src/resolvers.ts
+++ b/packages/ts-codegen/src/resolvers.ts
@@ -18,7 +18,7 @@ import {
   isRootOperationType,
 } from "./context/utilities";
 
-export function getImportIdentifierForTypenames(
+function getContextImportIdentifiers(
   imports: Record<string, string[]>,
   contextImportNames: Set<string>,
 ) {
@@ -121,8 +121,8 @@ function generateImports(context: TsCodegenContext) {
     );
   }
 
-  const getSubTypesMetadata = context.getSubTypesMetadata();
-  if (Object.keys(context.getContextMap()).length && getSubTypesMetadata) {
+  const contextTypeExtensions = context.getContextTypeExtensions();
+  if (Object.keys(context.getContextMap()).length && contextTypeExtensions) {
     if (
       context.contextDefaultSubTypeContext?.from &&
       context.contextDefaultSubTypeContext?.name
@@ -149,7 +149,7 @@ function generateImports(context: TsCodegenContext) {
 
         const imports = context.getSubTypeNamesImportMap(rootValue);
         importStatements.push(
-          ...getImportIdentifierForTypenames(imports, contextImportNames),
+          ...getContextImportIdentifiers(imports, contextImportNames),
         );
       }
       for (const [key, value] of Object.entries(root)) {
@@ -167,7 +167,7 @@ function generateImports(context: TsCodegenContext) {
         const imports = context.getSubTypeNamesImportMap(value);
 
         importStatements.push(
-          ...getImportIdentifierForTypenames(imports, contextImportNames),
+          ...getContextImportIdentifiers(imports, contextImportNames),
         );
       }
     }

--- a/packages/ts-codegen/src/utilities.ts
+++ b/packages/ts-codegen/src/utilities.ts
@@ -1,4 +1,5 @@
 import ts, { factory } from "typescript";
+import path from "path";
 import { TsCodegenContext, UnionType } from "./context";
 
 const MODEL_SUFFIX = "Model";
@@ -495,4 +496,24 @@ export function camelCase(
   }
 
   return postProcess(input, toUpperCase);
+}
+
+export function getContextPath(
+  outputDir: string,
+  contextTypePath: string | undefined,
+) {
+  if (!contextTypePath) {
+    return;
+  }
+
+  if (!contextTypePath.startsWith(".")) {
+    return contextTypePath;
+  }
+
+  const contextDir = path.join(process.cwd(), contextTypePath);
+
+  return path
+    .relative(outputDir, contextDir)
+    .split(path.sep)
+    .join(path.posix.sep);
 }


### PR DESCRIPTION
We want to enable people to define the resolver context subtypes  with namespaces.

Expected input: 
--context-sub-type-metadata-file
```
{
      baseContextTypePath: "@package/default-context",
      baseContextTypeName: "DefaultContextType",
      contextTypes: {
        managers: {
          user: {
            importNamespaceName: "UserStateMachineType",
            importPath: "@package/user-state-machine",
          },
          whatever: {
            importPath: "@package/whatever-state-machine",
          },
}
```