### PR TITLE
ts-codegen resolver context types will be defined explicitly in the input file

### DIFF
--- a/change/@graphitation-cli-eb21eb0e-6d37-4abf-8ea8-d5a247f340c5.json
+++ b/change/@graphitation-cli-eb21eb0e-6d37-4abf-8ea8-d5a247f340c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ts-codegen resolver context types will be defined explicitly in the input file",
+  "packageName": "@graphitation/cli",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-1fee3f38-7bd0-4a6d-87cc-67d36aa688d6.json
+++ b/change/@graphitation-ts-codegen-1fee3f38-7bd0-4a6d-87cc-67d36aa688d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ts-codegen resolver context types will be defined explicitly in the input file",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -72,7 +72,7 @@ export function supermassive(): Command {
     )
     .option(
       "--context-type-extensions-file [contextTypeExtensionsFile]",
-      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName: string, importPath: string }}}",
+      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}",
     )
     .option(
       "--generate-resolver-map",

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -15,53 +15,67 @@ describe(generateTS, () => {
           user: {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/user-state-machine",
+            typeName: 'UserStateMachineType["user"]',
           },
           whatever: {
             importPath: "@package/whatever-state-machine",
+            typeName: "whatever",
           },
           "different-whatever": {
             importNamespaceName: "DifferentWhateverStateMachineType",
             importPath: "@package/different-whatever-state-machine",
+            typeName:
+              'DifferentWhateverStateMachineType["managers"]["different-whatever"]',
           },
           post: {
             importNamespaceName: "PostStateMachineType",
             importPath: "@package/post-state-machine",
+            typeName: 'PostStateMachineType["post"]',
           },
           node: {
             importNamespaceName: "NodeStateMachineType",
             importPath: "@package/node-state-machine",
+            typeName: 'NodeStateMachineType["node"]',
           },
           persona: {
             importNamespaceName: "PersonaStateMachineType",
             importPath: "@package/persona-state-machine",
+            typeName: 'PersonaStateMachineType["managers"]["persona"]',
           },
           admin: {
             importNamespaceName: "AdminStateMachineType",
             importPath: "@package/admin-state-machine",
+            typeName: 'AdminStateMachineType["managers"]["admin"]',
           },
           message: {
             importNamespaceName: "MessageStateMachineType",
             importPath: "@package/message-state-machine",
+            typeName: 'MessageStateMachineType["message"]',
           },
           customer: {
             importNamespaceName: "CustomerStateMachineType",
             importPath: "@package/customer-state-machine",
+            typeName: 'CustomerStateMachineType["customer"]',
           },
           "shouldnt-apply": {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/shouldnt-apply-state-machine",
+            typeName: 'UserStateMachineType["managers"]["shouldnt-apply"]',
           },
           "user-or-customer": {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/user-or-customer-state-machine",
+            typeName: 'UserStateMachineType["user-or-customer"]',
           },
           "company-or-customer": {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/company-or-customer-state-machine",
+            typeName: 'UserStateMachineType["managers"]["company-or-customer"]',
           },
           "id-user": {
             importNamespaceName: "UserStateMachineType",
             importPath: "@package/id-user-state-machine",
+            typeName: 'UserStateMachineType["id-user"]',
           },
         },
       },
@@ -587,7 +601,7 @@ describe(generateTS, () => {
             }
             export type __resolveType = (parent: unknown, context: {
                 managers: {
-                    "persona": PersonaStateMachineType["persona"];
+                    "persona": PersonaStateMachineType["managers"]["persona"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<string | null>;
         }
@@ -604,12 +618,12 @@ describe(generateTS, () => {
             }
             export type id = (model: Models.Admin, args: {}, context: {
                 managers: {
-                    "admin": AdminStateMachineType["admin"];
+                    "admin": AdminStateMachineType["managers"]["admin"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<string>;
             export type rank = (model: Models.Admin, args: {}, context: {
                 managers: {
-                    "admin": AdminStateMachineType["admin"];
+                    "admin": AdminStateMachineType["managers"]["admin"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<number>;
         }
@@ -1070,7 +1084,7 @@ describe(generateTS, () => {
             }
             export type id = (model: Models.Admin, args: {}, context: {
                 managers: {
-                    "admin": AdminStateMachineType["admin"];
+                    "admin": AdminStateMachineType["managers"]["admin"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<string>;
         }
@@ -1112,7 +1126,7 @@ describe(generateTS, () => {
             }
             export type __resolveType = (parent: Models.Company | Models.Customer, context: {
                 managers: {
-                    "company-or-customer": UserStateMachineType["company-or-customer"];
+                    "company-or-customer": UserStateMachineType["managers"]["company-or-customer"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<"Company" | "Customer" | null>;
         }
@@ -1133,7 +1147,7 @@ describe(generateTS, () => {
                 readonly mail?: string | null;
             }, context: {
                 managers: {
-                    "different-whatever": DifferentWhateverStateMachineType["different-whatever"];
+                    "different-whatever": DifferentWhateverStateMachineType["managers"]["different-whatever"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<Models.whatever | null | undefined>;
             export type node = (model: unknown, args: {

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -13,6 +13,7 @@ export type SubTypeItem = {
   [subType: string]: {
     importNamespaceName?: string;
     importPath: string;
+    typeName: string;
   };
 };
 

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -258,6 +258,11 @@ export class TsCodegenContext {
       }
 
       const subTypeRawMetadata = namespace[subTypeName];
+      if (!subTypeRawMetadata.typeName) {
+        throw new Error(
+          `typeName is not defined for subType "${subTypeName}" in namespace "${namespaceName}"`,
+        );
+      }
       const subType = subTypeRawMetadata.typeName;
 
       acc[namespaceName].push({

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -258,9 +258,8 @@ export class TsCodegenContext {
       }
 
       const subTypeRawMetadata = namespace[subTypeName];
-      const subType = subTypeRawMetadata.importNamespaceName
-        ? `${subTypeRawMetadata.importNamespaceName}["${subTypeName}"]`
-        : subTypeName;
+      const subType = subTypeRawMetadata.typeName;
+
       acc[namespaceName].push({
         subType,
         name: subTypeName,


### PR DESCRIPTION
Will newely accept typeName field for more variability.
 ```   
 const contextTypeExtensions = {
      baseContextTypePath: "@package/default-context",
      baseContextTypeName: "DefaultContextType",
      contextTypes: {
        managers: {
          user: {
            importNamespaceName: "UserStateMachineType",
            importPath: "@package/user-state-machine",
            typeName: 'UserStateMachineType["user"]',
          },
          whatever: {
            importPath: "@package/whatever-state-machine",
            typeName: "whatever",
          },
          "different-whatever": {
            importNamespaceName: "DifferentWhateverStateMachineType",
            importPath: "@package/different-whatever-state-machine",
            typeName:
              'DifferentWhateverStateMachineType["managers"]["different-whatever"]',
          }
     }
 }         
```