### PR TITLE
fix(apollo-forest-run): fix bogus optimistic data extract

### DIFF
--- a/change/@graphitation-apollo-forest-run-a3bbed5c-144a-4ae0-a4a9-dde6c5648e17.json
+++ b/change/@graphitation-apollo-forest-run-a3bbed5c-144a-4ae0-a4a9-dde6c5648e17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): fix bogus optimistic data extract",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -403,7 +403,7 @@ export class ForestRun extends ApolloCache<SerializedCache> {
           variables: op.variables,
           optimisticData,
         };
-        this.extractedObjects.set(data, entry);
+        this.extractedObjects.set(key, entry);
       }
       return entry;
     };

--- a/packages/apollo-forest-run/src/__tests__/extract.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/extract.test.ts
@@ -71,4 +71,28 @@ describe("ForestRun.extract()", () => {
       }
     `);
   });
+
+  test("should extract the cache with optimistic data only", () => {
+    const cache = new ForestRun();
+    const query = gql`
+      query Foo($i: Int = 0) {
+        foo(i: $i)
+      }
+    `;
+    cache.recordOptimisticTransaction(() => {
+      cache.write({ query, result: { foo: 1 } });
+    }, "test");
+
+    expect(cache.extract(true)).toMatchInlineSnapshot(`
+      {
+        "query Foo:1": {
+          "data": null,
+          "optimisticData": {
+            "foo": 1,
+          },
+          "variables": {},
+        },
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes exception `Invalid value used as weak map key` when optimistic node has no corresponding entry in the actual data forest.