### PR TITLE
fix(forest-run): telemetry type for ascendants

### DIFF
--- a/change/@graphitation-apollo-forest-run-e9252a5d-ca0a-40ce-ad7a-e93c8b89f747.json
+++ b/change/@graphitation-apollo-forest-run-e9252a5d-ca0a-40ce-ad7a-e93c8b89f747.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix type for ascendants",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "pavelglac@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/telemetry/updateStats/types.ts
+++ b/packages/apollo-forest-run/src/telemetry/updateStats/types.ts
@@ -27,5 +27,5 @@ export type ChunkUpdateStats = {
     fieldsMutated: number;
     itemsMutated: number;
   } & CopyStats;
-  updateAscendantStats?: CopyStats;
+  updateAscendantStats: CopyStats;
 };


### PR DESCRIPTION
The type is always defined. For each chunk update we init the ascendant object: 
![image](https://github.com/user-attachments/assets/974dab01-f2ee-43b1-9594-29c86322c695)
