### PR TITLE
Codegen supports resolver context conditionality and creating groups in input file

### DIFF
--- a/change/@graphitation-cli-daecf3a3-3287-4687-835d-9c44acbce968.json
+++ b/change/@graphitation-cli-daecf3a3-3287-4687-835d-9c44acbce968.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Codegen support resolver context conditionality and creating groups in input file",
+  "packageName": "@graphitation/cli",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-6545cc24-06ec-443b-94ca-42f154d74e98.json
+++ b/change/@graphitation-ts-codegen-6545cc24-06ec-443b-94ca-42f154d74e98.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Codegen support resolver context conditionality and creating groups in input file",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -72,7 +72,7 @@ export function supermassive(): Command {
     )
     .option(
       "--context-type-extensions-file [contextTypeExtensionsFile]",
-      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, groups?: { [groupName]: { [namespace: string]]: string[] }}, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}",
+      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, groups?: { [groupName]: { [namespace: string]]: string[] }}, contextTypes: { required? :{ [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}}",
     )
     .option(
       "--generate-resolver-map",

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -72,7 +72,7 @@ export function supermassive(): Command {
     )
     .option(
       "--context-type-extensions-file [contextTypeExtensionsFile]",
-      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}",
+      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, groups?: { [groupName]: { [namespace: string]]: string[] }}, contextTypes: { [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}",
     )
     .option(
       "--generate-resolver-map",

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -132,9 +132,7 @@ describe(generateTS, () => {
             }
 
             extend type Query {
-              requiredUsers: [User!]!
-                @UserTestGroup
-                @context(optional: { managers: ["node"] })
+              requiredUsers: [User!]! @UserTestGroup
               optionalUsers: [User] @UserTestGroup
               optionalUser: User
                 @context(
@@ -189,7 +187,8 @@ describe(generateTS, () => {
             },
             "requiredUsers": {
               "managers": [
-                "node",
+                "user",
+                "whatever",
               ],
             },
           },
@@ -419,7 +418,8 @@ describe(generateTS, () => {
             }
             export type requiredUsers = (model: unknown, args: {}, context: DefaultContextType & {
                 managers: {
-                    "node"?: NodeStateMachineType["node"];
+                    "user": UserStateMachineType["user"];
+                    "whatever": whatever;
                 };
             }, info: ResolveInfo) => PromiseOrValue<IterableOrAsyncIterable<Models.User>>;
             export type optionalUsers = (model: unknown, args: {}, context: DefaultContextType & {

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -10,6 +10,15 @@ describe(generateTS, () => {
     const contextTypeExtensions = {
       baseContextTypePath: "@package/default-context",
       baseContextTypeName: "DefaultContextType",
+      groups: {
+        UserTestGroup: {
+          managers: ["user", "whatever"],
+        },
+        PostTestGroup: {
+          managers: ["post", "whatever"],
+          workflows: ["post-workflow"],
+        },
+      },
       contextTypes: {
         managers: {
           user: {
@@ -78,6 +87,13 @@ describe(generateTS, () => {
             typeName: 'UserStateMachineType["id-user"]',
           },
         },
+        workflows: {
+          "post-workflow": {
+            importNamespaceName: "PostStateMachineType",
+            importPath: "@package/post-state-machine",
+            typeName: 'PostStateMachineType["post-workflow"]',
+          },
+        },
       },
     };
     test("all possible nullable and non-nullable combinations", () => {
@@ -92,11 +108,11 @@ describe(generateTS, () => {
             }
 
             type Message {
-              id: ID! @context(uses: { managers: ["message"] })
+              id: ID! @context(required: { managers: ["message"] })
             }
 
-            type User @context(uses: { managers: ["user"] }) {
-              id: ID! @context(uses: { managers: ["id-user", "user"] })
+            type User @context(required: { managers: ["user"] }) {
+              id: ID! @context(required: { managers: ["id-user", "user"] })
               name: String
               messagesWithAnswersNonRequired: [[Message]]
               messagesWithAnswersRequired: [[Message]]!
@@ -105,19 +121,29 @@ describe(generateTS, () => {
               messagesWithArrayRequired: [Message]!
               messagesRequired: [Message!]!
               messagesOnlyMessageRequired: [Message!]
-              post: Post @context(uses: { managers: ["post"] })
+              post: Post @context(required: { managers: ["post"] })
               postRequired: Post!
               avatar: Avatar
-              avatarRequired: Avatar!
+                @context(
+                  required: { managers: ["user"] }
+                  optional: { managers: ["node"] }
+                )
+              avatarRequired: Avatar! @context(optional: { managers: ["node"] })
             }
 
             extend type Query {
               requiredUsers: [User!]!
-              optionalUsers: [User]
+                @UserTestGroup
+                @context(optional: { managers: ["node"] })
+              optionalUsers: [User] @UserTestGroup
               optionalUser: User
-              requiredUser: User!
+                @context(
+                  required: { managers: ["user"] }
+                  optional: { managers: ["node"] }
+                )
+              requiredUser: User! @context(optional: { managers: ["node"] })
               requiredPost: Post!
-              optionalPost: Post
+              optionalPost: Post @PostTestGroup
             }
           `,
           {
@@ -134,15 +160,49 @@ describe(generateTS, () => {
               ],
             },
           },
+          "Query": {
+            "optionalPost": {
+              "managers": [
+                "post",
+                "whatever",
+              ],
+              "workflows": [
+                "post-workflow",
+              ],
+            },
+            "optionalUser": {
+              "managers": [
+                "user",
+                "node",
+              ],
+            },
+            "optionalUsers": {
+              "managers": [
+                "user",
+                "whatever",
+              ],
+            },
+            "requiredUser": {
+              "managers": [
+                "node",
+              ],
+            },
+            "requiredUsers": {
+              "managers": [
+                "node",
+              ],
+            },
+          },
           "User": {
             "avatar": {
               "managers": [
                 "user",
+                "node",
               ],
             },
             "avatarRequired": {
               "managers": [
-                "user",
+                "node",
               ],
             },
             "id": {
@@ -246,6 +306,8 @@ describe(generateTS, () => {
         import type { MessageStateMachineType } from "@package/message-state-machine";
         import type { UserStateMachineType } from "@package/user-state-machine";
         import type { PostStateMachineType } from "@package/post-state-machine";
+        import type { NodeStateMachineType } from "@package/node-state-machine";
+        import type { whatever } from "@package/whatever-state-machine";
         export declare namespace Post {
             export interface Resolvers {
                 readonly id?: id;
@@ -337,11 +399,12 @@ describe(generateTS, () => {
             export type avatar = (model: Models.User, args: {}, context: DefaultContextType & {
                 managers: {
                     "user": UserStateMachineType["user"];
+                    "node"?: NodeStateMachineType["node"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar | null | undefined>;
             export type avatarRequired = (model: Models.User, args: {}, context: DefaultContextType & {
                 managers: {
-                    "user": UserStateMachineType["user"];
+                    "node"?: NodeStateMachineType["node"];
                 };
             }, info: ResolveInfo) => PromiseOrValue<NSMsteamsPackagesTestModels.Avatar>;
         }
@@ -354,12 +417,38 @@ describe(generateTS, () => {
                 readonly requiredPost?: requiredPost;
                 readonly optionalPost?: optionalPost;
             }
-            export type requiredUsers = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<IterableOrAsyncIterable<Models.User>>;
-            export type optionalUsers = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<IterableOrAsyncIterable<Models.User | null | undefined> | null | undefined>;
-            export type optionalUser = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User | null | undefined>;
-            export type requiredUser = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.User>;
+            export type requiredUsers = (model: unknown, args: {}, context: DefaultContextType & {
+                managers: {
+                    "node"?: NodeStateMachineType["node"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<IterableOrAsyncIterable<Models.User>>;
+            export type optionalUsers = (model: unknown, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                    "whatever": whatever;
+                };
+            }, info: ResolveInfo) => PromiseOrValue<IterableOrAsyncIterable<Models.User | null | undefined> | null | undefined>;
+            export type optionalUser = (model: unknown, args: {}, context: DefaultContextType & {
+                managers: {
+                    "user": UserStateMachineType["user"];
+                    "node"?: NodeStateMachineType["node"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.User | null | undefined>;
+            export type requiredUser = (model: unknown, args: {}, context: DefaultContextType & {
+                managers: {
+                    "node"?: NodeStateMachineType["node"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.User>;
             export type requiredPost = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Post>;
-            export type optionalPost = (model: unknown, args: {}, context: unknown, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
+            export type optionalPost = (model: unknown, args: {}, context: DefaultContextType & {
+                managers: {
+                    "post": PostStateMachineType["post"];
+                    "whatever": whatever;
+                };
+                workflows: {
+                    "post-workflow": PostStateMachineType["post-workflow"];
+                };
+            }, info: ResolveInfo) => PromiseOrValue<Models.Post | null | undefined>;
         }
         "
       `);
@@ -499,11 +588,11 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(uses: { managers: ["node"] }) {
+            interface Node @context(required: { managers: ["node"] }) {
               id: ID!
             }
 
-            interface Persona @context(uses: { managers: ["persona"] }) {
+            interface Persona @context(required: { managers: ["persona"] }) {
               phone: String!
             }
 
@@ -513,7 +602,7 @@ describe(generateTS, () => {
             }
 
             type Admin implements Node & Persona
-              @context(uses: { managers: ["admin"] }) {
+              @context(required: { managers: ["admin"] }) {
               id: ID!
               rank: Int!
             }
@@ -642,11 +731,11 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(uses: { managers: ["node"] }) {
+            interface Node @context(required: { managers: ["node"] }) {
               id: ID!
             }
 
-            interface Persona @context(uses: { managers: ["persona"] }) {
+            interface Persona @context(required: { managers: ["persona"] }) {
               phone: String!
             }
 
@@ -656,7 +745,7 @@ describe(generateTS, () => {
             }
 
             type Admin implements Node & Persona
-              @context(uses: { managers: ["admin"] }) {
+              @context(required: { managers: ["admin"] }) {
               id: ID!
               rank: Int!
             }
@@ -766,12 +855,12 @@ describe(generateTS, () => {
       const { resolvers, models, enums, inputs, contextMappingOutput } =
         runGenerateTest(
           graphql`
-            interface Node @context(uses: { managers: ["node"] }) {
+            interface Node @context(required: { managers: ["node"] }) {
               id: ID!
             }
 
             interface Customer implements Node
-              @context(uses: { managers: ["customer"] }) {
+              @context(required: { managers: ["customer"] }) {
               id: ID!
               name: String!
             }
@@ -874,7 +963,7 @@ describe(generateTS, () => {
         runGenerateTest(
           graphql`
             enum PresenceAvailability
-              @context(uses: { managers: ["shouldnt-apply"] }) {
+              @context(required: { managers: ["shouldnt-apply"] }) {
               Available
               Away
               Offline
@@ -951,11 +1040,11 @@ describe(generateTS, () => {
               id: ID!
             }
 
-            type Admin @context(uses: { managers: ["admin"] }) {
+            type Admin @context(required: { managers: ["admin"] }) {
               id: ID!
             }
 
-            type User @context(uses: { managers: ["user"] }) {
+            type User @context(required: { managers: ["user"] }) {
               id: ID!
             }
 
@@ -965,19 +1054,19 @@ describe(generateTS, () => {
 
             union UserOrAdmin = User | Admin
             union UserOrCustomer
-              @context(uses: { managers: ["user-or-customer"] }) =
+              @context(required: { managers: ["user-or-customer"] }) =
                 User
               | Customer
             union CompanyOrCustomer
-              @context(uses: { managers: ["company-or-customer"] }) =
+              @context(required: { managers: ["company-or-customer"] }) =
                 Company
               | Customer
 
             extend type Query {
               userById(id: ID!): whatever
-                @context(uses: { managers: ["whatever"] })
+                @context(required: { managers: ["whatever"] })
               userByMail(mail: String): whatever
-                @context(uses: { managers: ["different-whatever"] })
+                @context(required: { managers: ["different-whatever"] })
               node(id: ID!): Node
             }
           `,

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -17,9 +17,14 @@ export type SubTypeItem = {
   };
 };
 
+export type GroupItem = {
+  [namespace: string]: string[];
+};
+
 export type SubTypeNamespace = {
   baseContextTypeName?: string;
   baseContextTypePath?: string;
+  groups?: { [group: string]: GroupItem };
   contextTypes: { [namespace: string]: SubTypeItem };
 };
 

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -108,8 +108,12 @@ export type ContextMap = {
   [key: string]: ContextMapTypeItem;
 };
 
-export type ContextMapTypeItem = { __context?: string[] } & {
-  [key: string]: string[];
+export type ContextTypeItem = { id: string; optional?: boolean };
+
+export type ContextMapTypeItem = {
+  __context?: ContextTypeItem[];
+} & {
+  [key: string]: ContextTypeItem[];
 };
 
 export class TsCodegenContext {
@@ -169,9 +173,9 @@ export class TsCodegenContext {
 
   public getContextTypes<T>(
     contextRootType: T & {
-      __context?: string[];
+      __context?: ContextTypeItem[];
     },
-  ): string[] | null {
+  ): ContextTypeItem[] | null {
     if (contextRootType) {
       if (contextRootType.__context) {
         return contextRootType.__context;
@@ -180,12 +184,19 @@ export class TsCodegenContext {
     return null;
   }
 
-  public getContextTypeNode(typeNames?: string[] | null) {
+  public getContextTypeNode(typeNames?: ContextTypeItem[] | null) {
     const contextTypeExtensions = this.getContextTypeExtensions();
 
-    if (!typeNames || !typeNames.length || !contextTypeExtensions) {
+    if (!typeNames || !contextTypeExtensions) {
       return this.getContextType().toTypeReference();
     } else {
+      if (typeNames.length === 0 && this.contextDefaultSubTypeContext?.name) {
+        return factory.createTypeReferenceNode(
+          factory.createIdentifier(this.contextDefaultSubTypeContext.name),
+          undefined,
+        );
+      }
+
       const typeNameWithNamespace =
         this.buildContextSubTypeNamespaceObject(typeNames);
 
@@ -204,11 +215,13 @@ export class TsCodegenContext {
                   factory.createIdentifier(namespace),
                   undefined,
                   factory.createTypeLiteralNode(
-                    subTypes.map(({ subType, name }) => {
+                    subTypes.map(({ subType, name, optional }) => {
                       return factory.createPropertySignature(
                         undefined,
                         factory.createIdentifier(`"${name}"`),
-                        undefined,
+                        optional
+                          ? factory.createToken(ts.SyntaxKind.QuestionToken)
+                          : undefined,
                         factory.createTypeReferenceNode(
                           factory.createIdentifier(subType),
                           undefined,
@@ -228,17 +241,19 @@ export class TsCodegenContext {
     return this.options.contextTypeExtensions;
   }
 
-  private buildContextSubTypeNamespaceObject(typeNames: string[]) {
+  private buildContextSubTypeNamespaceObject(
+    contextTypeItems: ContextTypeItem[],
+  ) {
     const contextTypeExtensions = this.getContextTypeExtensions();
 
     if (!contextTypeExtensions || !contextTypeExtensions.contextTypes) {
       throw new Error("Context type extensions are not defined in the options");
     }
 
-    return typeNames.reduce<
-      Record<string, { subType: string; name: string }[]>
-    >((acc, typeName) => {
-      const [namespaceName, subTypeName] = typeName.split(":");
+    return contextTypeItems.reduce<
+      Record<string, { subType: string; name: string; optional: boolean }[]>
+    >((acc, contextTypeItem) => {
+      const [namespaceName, subTypeName] = contextTypeItem.id.split(":");
       if (!acc[namespaceName]) {
         acc[namespaceName] = [];
       }
@@ -268,6 +283,7 @@ export class TsCodegenContext {
       acc[namespaceName].push({
         subType,
         name: subTypeName,
+        optional: contextTypeItem.optional || false,
       });
 
       return acc;
@@ -282,7 +298,7 @@ export class TsCodegenContext {
 
   public initContextMap(
     ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
-    values: string[],
+    values: { required?: string[]; optional?: string[] },
   ) {
     if (ancestors.length < 2) {
       throw new Error("Invalid document provided");
@@ -298,7 +314,7 @@ export class TsCodegenContext {
         nonArrayNode?.kind === "UnionTypeDefinition"
       ) {
         if (this.typeContextMap[nonArrayNode.name.value]?.__context) {
-          throw new Error("Type already visited");
+          throw new Error(`Type "${nonArrayNode.name.value}" already visited`);
         }
 
         const typeName = nonArrayNode.name.value;
@@ -306,7 +322,14 @@ export class TsCodegenContext {
           this.typeContextMap[typeName] = {};
         }
 
-        this.typeContextMap[typeName].__context = values;
+        this.typeContextMap[typeName].__context = [
+          ...(values.required
+            ? values.required.map((value) => ({ id: value, optional: false }))
+            : []),
+          ...(values.optional
+            ? values.optional.map((value) => ({ id: value, optional: true }))
+            : []),
+        ];
       } else if (nonArrayNode?.kind === "FieldDefinition") {
         const node = ancestors[ancestors.length - 3];
         const typeName =
@@ -321,9 +344,20 @@ export class TsCodegenContext {
             this.typeContextMap[typeName] = {};
           }
 
-          this.typeContextMap[typeName][nonArrayNode.name.value] = values;
+          this.typeContextMap[typeName][nonArrayNode.name.value] = [
+            ...(values.required
+              ? values.required.map((value) => ({ id: value, optional: false }))
+              : []),
+            ...(values.optional
+              ? values.optional.map((value) => ({ id: value, optional: true }))
+              : []),
+          ];
         }
       }
+    }
+
+    if (values.optional?.length === 0) {
+      console.log(this.typeContextMap);
     }
   }
 
@@ -351,10 +385,10 @@ export class TsCodegenContext {
     this.resolverTypeMap[typeName].push(fieldName);
   }
 
-  getSubTypeNamesImportMap(subTypes: string[]) {
+  getSubTypeNamesImportMap(subTypes: ContextTypeItem[]) {
     const subTypeMetadata = this.getContextTypeExtensions();
     return subTypes.reduce<Record<string, string[]>>(
-      (acc: Record<string, string[]>, importName: string) => {
+      (acc: Record<string, string[]>, { id: importName }) => {
         const [namespace, subTypeName] = importName.split(":");
         const subType =
           subTypeMetadata?.contextTypes?.[namespace]?.[subTypeName];
@@ -801,39 +835,73 @@ export function extractContext(
           node.name.value === "context" &&
           options.contextTypeExtensions
         ) {
-          const subTypeKeys: Set<string> = new Set();
-          if (
-            node.arguments?.length !== 1 ||
-            node.arguments[0].name.value !== "uses" ||
-            node.arguments[0].value.kind !== "ObjectValue"
-          ) {
-            throw new Error("Invalid context use");
+          let requiredKeys: Set<string> | undefined;
+          let optionalKeys: Set<string> | undefined;
+          if (!node.arguments?.length) {
+            throw new Error(
+              "Invalid context use: No arguments provided. Provide either required or optional arguments",
+            );
           }
 
-          node.arguments[0].value.fields.forEach(({ name, value, kind }) => {
-            if (kind !== "ObjectField") {
-              throw new Error("Invalid context use");
-            }
-            const namespace = name.value;
-            if (value.kind !== "ListValue") {
-              throw new Error(
-                `Namespace "${namespace}" must be list of strings`,
-              );
-            }
+          const required = node.arguments.find(
+            (value) => value.name.value === "required",
+          );
+          const optional = node.arguments.find(
+            (value) => value.name.value === "optional",
+          );
 
-            const namespaceValues: string[] = value.values.map((v) => {
-              if (v.kind !== "StringValue") {
-                throw new Error(
-                  `Namespace "${namespace}" must be list of strings`,
-                );
-              }
-              return v.value;
-            });
+          if (!required && !optional) {
+            throw new Error(
+              "Invalid context use: Required and optional arguments must be provided",
+            );
+          }
 
-            if (!options.contextTypeExtensions?.contextTypes?.[namespace]) {
-              throw new Error(`Namespace "${namespace}" is not supported`);
-            }
+          if (required && required?.value.kind !== "ObjectValue") {
+            throw new Error(
+              `Invalid context use: "required" argument must be an object`,
+            );
+          }
 
+          if (optional && optional?.value.kind !== "ObjectValue") {
+            throw new Error(
+              `Invalid context use: "optional" argument must be an object`,
+            );
+          }
+
+          if (required) {
+            requiredKeys = new Set(
+              new Set(
+                getContextKeysFromArgument(
+                  required,
+                  options.contextTypeExtensions,
+                ),
+              ),
+            );
+          }
+
+          if (optional) {
+            optionalKeys = new Set(
+              new Set(
+                getContextKeysFromArgument(
+                  optional,
+                  options.contextTypeExtensions,
+                ),
+              ),
+            );
+          }
+
+          context.initContextMap(ancestors, {
+            required: requiredKeys ? Array.from(requiredKeys) : undefined,
+            optional: optionalKeys ? Array.from(optionalKeys) : undefined,
+          });
+        } else if (
+          options.contextTypeExtensions?.groups &&
+          options.contextTypeExtensions.groups[node.name.value]
+        ) {
+          const subTypeKeys: Set<string> = new Set();
+          const group = options.contextTypeExtensions.groups[node.name.value];
+
+          for (const [namespace, namespaceValues] of Object.entries(group)) {
             namespaceValues.forEach((namespaceValue) => {
               if (
                 !options.contextTypeExtensions?.contextTypes?.[namespace]?.[
@@ -847,9 +915,10 @@ export function extractContext(
 
               subTypeKeys.add(`${namespace}:${namespaceValue}`);
             });
-          });
-
-          context.initContextMap(ancestors, Array.from(subTypeKeys));
+            context.initContextMap(ancestors, {
+              required: Array.from(subTypeKeys),
+            });
+          }
         }
       },
     },
@@ -962,6 +1031,47 @@ export function extractContext(
   return context;
 }
 
+function getContextKeysFromArgument(
+  argumentNode: ArgumentNode,
+  contextTypeExtensions: SubTypeNamespace,
+) {
+  if (argumentNode?.value.kind !== "ObjectValue") {
+    throw new Error(`Invalid context use: arguments must be an object`);
+  }
+
+  const output: string[] = [];
+  argumentNode?.value.fields.forEach(({ name, value, kind }) => {
+    if (kind !== "ObjectField") {
+      throw new Error("Invalid context use");
+    }
+    const namespace = name.value;
+    if (value.kind !== "ListValue") {
+      throw new Error(`Namespace "${namespace}" must be list of strings`);
+    }
+
+    const namespaceValues: string[] = value.values.map((v) => {
+      if (v.kind !== "StringValue") {
+        throw new Error(`Namespace "${namespace}" must be list of strings`);
+      }
+      return v.value;
+    });
+
+    if (!contextTypeExtensions?.contextTypes?.[namespace]) {
+      throw new Error(`Namespace "${namespace}" is not supported`);
+    }
+
+    namespaceValues.forEach((namespaceValue) => {
+      if (!contextTypeExtensions?.contextTypes?.[namespace]?.[namespaceValue]) {
+        throw new Error(
+          `Value "${namespaceValue}" in namespace "${namespace}" is not supported`,
+        );
+      }
+
+      output.push(`${namespace}:${namespaceValue}`);
+    });
+  });
+  return output;
+}
 export class TypeLocation {
   constructor(private from: string | null, private name: string) {}
 

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -81,7 +81,7 @@ export function buildContextMetadataOutput(
     if (values === null) {
       if (contextMap[key]?.__context) {
         for (const contextValue of contextMap[key].__context) {
-          const [namespace, subTypeName] = contextValue.split(":");
+          const [namespace, subTypeName] = contextValue.id.split(":");
 
           if (!metadata[key]) {
             metadata[key] = {};
@@ -107,12 +107,12 @@ export function buildContextMetadataOutput(
     for (const value of values) {
       if (contextMap[key][value]) {
         for (const typeValue of contextMap[key][value]) {
-          buildContextMetadataOutputItem(metadata, typeValue, key, value);
+          buildContextMetadataOutputItem(metadata, typeValue.id, key, value);
         }
         continue;
       } else if (contextMap[key].__context) {
         for (const contextValue of contextMap[key].__context) {
-          buildContextMetadataOutputItem(metadata, contextValue, key, value);
+          buildContextMetadataOutputItem(metadata, contextValue.id, key, value);
         }
         continue;
       }

--- a/packages/ts-codegen/src/context/utilities.ts
+++ b/packages/ts-codegen/src/context/utilities.ts
@@ -1,6 +1,8 @@
 import { factory } from "typescript";
 import path from "path";
 import { ContextMap } from ".";
+import { ArgumentNode } from "graphql";
+import { SubTypeNamespace } from "../codegen";
 
 export function createImportDeclaration(
   importNames: string[],
@@ -120,6 +122,48 @@ export function buildContextMetadataOutput(
   }
 
   return metadata;
+}
+
+export function getContextKeysFromArgumentNode(
+  argumentNode: ArgumentNode,
+  contextTypeExtensions: SubTypeNamespace,
+) {
+  if (argumentNode?.value.kind !== "ObjectValue") {
+    throw new Error(`Invalid context use: arguments must be an object`);
+  }
+
+  const output: string[] = [];
+  argumentNode?.value.fields.forEach(({ name, value, kind }) => {
+    if (kind !== "ObjectField") {
+      throw new Error("Invalid context use");
+    }
+    const namespace = name.value;
+    if (value.kind !== "ListValue") {
+      throw new Error(`Namespace "${namespace}" must be list of strings`);
+    }
+
+    const namespaceValues: string[] = value.values.map((v) => {
+      if (v.kind !== "StringValue") {
+        throw new Error(`Namespace "${namespace}" must be list of strings`);
+      }
+      return v.value;
+    });
+
+    if (!contextTypeExtensions?.contextTypes?.[namespace]) {
+      throw new Error(`Namespace "${namespace}" is not supported`);
+    }
+
+    namespaceValues.forEach((namespaceValue) => {
+      if (!contextTypeExtensions?.contextTypes?.[namespace]?.[namespaceValue]) {
+        throw new Error(
+          `Value "${namespaceValue}" in namespace "${namespace}" is not supported`,
+        );
+      }
+
+      output.push(`${namespace}:${namespaceValue}`);
+    });
+  });
+  return output;
 }
 
 function buildContextMetadataOutputItem(

--- a/packages/ts-codegen/src/resolvers.ts
+++ b/packages/ts-codegen/src/resolvers.ts
@@ -6,6 +6,7 @@ import {
   TsCodegenContext,
   ResolverType,
   InterfaceType,
+  ContextTypeItem,
 } from "./context";
 import {
   getResolverReturnType,
@@ -137,13 +138,9 @@ function generateImports(context: TsCodegenContext) {
 
     const contextImportNames: Set<string> = new Set();
     for (const [, root] of Object.entries(context.getContextMap())) {
-      const rootValue: string[] | undefined = root.__context;
+      const rootValue: ContextTypeItem[] | undefined = root.__context;
       if (rootValue) {
-        if (
-          rootValue.every((importName: string) =>
-            contextImportNames.has(importName),
-          )
-        ) {
+        if (rootValue.every(({ id }) => contextImportNames.has(id))) {
           continue;
         }
 
@@ -156,11 +153,7 @@ function generateImports(context: TsCodegenContext) {
         if (key.startsWith("__")) {
           continue;
         }
-        if (
-          value.every((importName: string) =>
-            contextImportNames.has(importName),
-          )
-        ) {
+        if (value.every(({ id }) => contextImportNames.has(id))) {
           continue;
         }
 


### PR DESCRIPTION
New way how to define whether ten sub context type is optional or not
```
@context(
    required: { managers: [
        "managerA"
        "managerB"
      ]
     },
    optional: {...}
)
```

New way of pre-defining groups which then can be used as custom directive. It will 
```
    const contextTypeExtensions = {
      baseContextTypePath: "@package/default-context",
      baseContextTypeName: "DefaultContextType",
      groups: {
        UserTestGroup: {
          managers: ["user", "whatever"],
        },
        PostTestGroup: {
          managers: ["post", "whatever"],
          workflows: ["post-workflow"],
        },
      },
      ....
```

Usage of the grouping:

```
           extend type Query {
              requiredUsers: [User!]! @UserTestGroup
              optionalUsers: [User] @UserTestGroup
              optionalUser: User
                @context(
                  required: { managers: ["user"] }
                  optional: { managers: ["node"] }
                )
              requiredUser: User! @context(optional: { managers: ["node"] })
              requiredPost: Post!
              optionalPost: Post @PostTestGroup
            }
```
