### PR TITLE
feat(apollo-forest-run): introduce partitions for evictions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "jestrunner.configPath": "scripts/config/jest.config.js",
   "files.eol": "\n",
   "jest.jestCommandLine": "node node_modules/jest-cli/bin/jest.js --config scripts/config/jest.config.js",
-  "jest.runMode": "on-demand"
+  "jest.runMode": "on-demand",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "never"
+  }
 }

--- a/change/@graphitation-apollo-forest-run-b8abfe6c-acee-4443-bd26-fcc6eef53b42.json
+++ b/change/@graphitation-apollo-forest-run-b8abfe6c-acee-4443-bd26-fcc6eef53b42.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(apollo-forest-run): add partitioning for evictions",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "joe@joeflateau.net",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/eviction.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/eviction.test.ts
@@ -152,7 +152,7 @@ it("allows partitioned eviction", () => {
     maxOperationCount: 1,
     autoEvict: false,
     partitionConfig: {
-      partitionKey: (o) => o.debugName,
+      partitionKey: (o) => o.operation.debugName,
       partitions: {
         "query a": { maxOperationCount: 1 },
         "query b": { maxOperationCount: 2 },

--- a/packages/apollo-forest-run/src/__tests__/eviction.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/eviction.test.ts
@@ -143,3 +143,118 @@ it("allows to opt out operations from eviction", () => {
   expect(result1).toEqual({ b: 1 });
   expect(result2).toEqual({ c: 2 });
 });
+
+it("allows partitioned eviction", () => {
+  // query a and b have their own partitions, so they can be evicted independently
+  // query c and d do not have their own partitions, so they will be evicted together
+  // as part of the default partition
+  const cache = new ForestRun({
+    maxOperationCount: 1,
+    autoEvict: false,
+    partitionConfig: {
+      partitionKey: (o) => o.debugName,
+      partitions: {
+        "query a": { maxOperationCount: 1 },
+        "query b": { maxOperationCount: 2 },
+      },
+    },
+  });
+  const a = gql`
+    query a($i: Int) {
+      foo(i: $i)
+    }
+  `;
+
+  const b = gql`
+    query b($i: Int) {
+      bar(i: $i)
+    }
+  `;
+
+  const c = gql`
+    query c($i: Int) {
+      baz(i: $i)
+    }
+  `;
+
+  const d = gql`
+    query d($i: Int) {
+      qux(i: $i)
+    }
+  `;
+
+  cache.write({ query: a, variables: { i: 0 }, result: { foo: 0 } });
+  cache.write({ query: a, variables: { i: 1 }, result: { foo: 1 } });
+  cache.write({ query: a, variables: { i: 2 }, result: { foo: 2 } });
+  cache.write({ query: b, variables: { i: 0 }, result: { bar: 0 } });
+  cache.write({ query: b, variables: { i: 1 }, result: { bar: 1 } });
+  cache.write({ query: b, variables: { i: 2 }, result: { bar: 2 } });
+  cache.write({ query: c, variables: { i: 0 }, result: { baz: 0 } });
+  cache.write({ query: c, variables: { i: 1 }, result: { baz: 1 } });
+  cache.write({ query: d, variables: { i: 0 }, result: { qux: 0 } });
+  cache.write({ query: d, variables: { i: 1 }, result: { qux: 1 } });
+
+  cache.gc();
+
+  const resultA0 = cache.read({
+    query: a,
+    variables: { i: 0 },
+    optimistic: true,
+  });
+  const resultA1 = cache.read({
+    query: a,
+    variables: { i: 1 },
+    optimistic: true,
+  });
+  const resultA2 = cache.read({
+    query: a,
+    variables: { i: 2 },
+    optimistic: true,
+  });
+  const resultB0 = cache.read({
+    query: b,
+    variables: { i: 0 },
+    optimistic: true,
+  });
+  const resultB1 = cache.read({
+    query: b,
+    variables: { i: 1 },
+    optimistic: true,
+  });
+  const resultB2 = cache.read({
+    query: b,
+    variables: { i: 2 },
+    optimistic: true,
+  });
+  const resultC0 = cache.read({
+    query: c,
+    variables: { i: 0 },
+    optimistic: true,
+  });
+  const resultC1 = cache.read({
+    query: c,
+    variables: { i: 1 },
+    optimistic: true,
+  });
+  const resultD0 = cache.read({
+    query: d,
+    variables: { i: 0 },
+    optimistic: true,
+  });
+  const resultD1 = cache.read({
+    query: d,
+    variables: { i: 1 },
+    optimistic: true,
+  });
+
+  expect(resultA0).toEqual(null);
+  expect(resultA1).toEqual(null);
+  expect(resultA2).toEqual({ foo: 2 });
+  expect(resultB0).toEqual(null);
+  expect(resultB1).toEqual({ bar: 1 });
+  expect(resultB2).toEqual({ bar: 2 });
+  expect(resultC0).toEqual(null);
+  expect(resultC1).toEqual(null);
+  expect(resultD0).toEqual(null);
+  expect(resultD1).toEqual({ qux: 1 });
+});

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -11,7 +11,7 @@ import {
 } from "../descriptor/types";
 import { getMergePolicyFn, getReadPolicyFn } from "./policies";
 import { SourceObject } from "../values/types";
-import { logger } from "../jsutils/logger";
+import { createExtendedLogger, logger } from "../jsutils/logger";
 
 export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
   const possibleTypes = config?.possibleTypes;
@@ -40,8 +40,10 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     optimizeFragmentReads: config?.optimizeFragmentReads ?? false,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     maxOperationCount: config?.maxOperationCount ?? 1000,
-    partitionConfig: config?.partitionConfig,
-    logger: config && "logger" in config ? config.logger : logger,
+    partitionConfig: config?.unstable_partitionConfig,
+    logger: createExtendedLogger(
+      config && "logger" in config ? config.logger : logger,
+    ),
     notify: config?.notify,
     now: () => ++tick, // Logical time
     genId: () => ++id,

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -40,6 +40,7 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     optimizeFragmentReads: config?.optimizeFragmentReads ?? false,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     maxOperationCount: config?.maxOperationCount ?? 1000,
+    partitionConfig: config?.partitionConfig,
     logger: config && "logger" in config ? config.logger : logger,
     notify: config?.notify,
     now: () => ++tick, // Logical time

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -76,25 +76,93 @@ export function maybeEvictOldData(env: CacheEnv, store: Store): OperationId[] {
 export function evictOldData(env: CacheEnv, store: Store): OperationId[] {
   assert(env.maxOperationCount);
   const { dataForest, atime } = store;
+
+  const partitionsOps = new Map<string, OperationId[]>();
+  const partitionKey = env.partitionConfig?.partitionKey;
+  const configuredPartitionKeys = new Set(
+    Object.keys(env.partitionConfig?.partitions ?? {}),
+  );
+
   let nonEvictable = 0;
-  const toEvict: number[] = [];
+  const DEFAULT_PARTITION = "__default__";
+
   for (const tree of dataForest.trees.values()) {
     if (!canEvict(env, store, tree)) {
       nonEvictable++;
-      continue;
+      continue; // Skip non-evictable operations entirely
     }
-    toEvict.push(tree.operation.id);
+
+    let partition = partitionKey?.(tree.operation);
+    if (!partition || !configuredPartitionKeys.has(partition)) {
+      partition = DEFAULT_PARTITION; // Default partition if not specified or not configured
+    }
+    let partitionOps = partitionsOps.get(partition);
+    if (!partitionOps) {
+      partitionOps = [];
+      partitionsOps.set(partition, partitionOps);
+    }
+
+    partitionOps.push(tree.operation.id);
   }
-  toEvict.sort((a, b) => (atime.get(a) ?? 0) - (atime.get(b) ?? 0));
-  toEvict.length = Math.max(
-    0,
-    dataForest.trees.size - (env.maxOperationCount + nonEvictable),
-  );
+
+  const toEvict: OperationId[] = [];
+
+  // Process each partition
+  for (const [partition, evictableOperationIds] of partitionsOps) {
+    const maxCount =
+      env.partitionConfig?.partitions[partition]?.maxOperationCount ??
+      env.maxOperationCount;
+
+    if (evictableOperationIds.length <= maxCount) {
+      console.log(
+        `Evicting no operations from partition '${partition}' (${[
+          `evictable: ${evictableOperationIds.length}`,
+          partition === DEFAULT_PARTITION
+            ? `non-evictable: ${nonEvictable}`
+            : null,
+          `max: ${maxCount}`,
+        ]
+          .filter(Boolean)
+          .join(", ")})`,
+      );
+      continue; // No eviction needed for this partition
+    }
+
+    // Sort by access time (LRU) and determine how many to evict
+    evictableOperationIds.sort(
+      (a, b) => (atime.get(a) ?? 0) - (atime.get(b) ?? 0),
+    );
+
+    const evictCount = Math.max(
+      0,
+      evictableOperationIds.length -
+        (partition === DEFAULT_PARTITION ? maxCount - nonEvictable : maxCount),
+    );
+
+    console.log(
+      `Evicting ${evictCount} operations from partition '${partition}' (${[
+        `evictable: ${evictableOperationIds.length}`,
+        partition === DEFAULT_PARTITION
+          ? `non-evictable: ${nonEvictable}`
+          : null,
+        `max: ${maxCount}`,
+      ]
+        .filter(Boolean)
+        .join(", ")})`,
+    );
+
+    toEvict.push(...evictableOperationIds.slice(0, evictCount));
+  }
+
+  console.log(`Evicting ${toEvict.length} operations from the store`);
+
+  // Remove evicted operations
   for (const opId of toEvict) {
     const tree = store.dataForest.trees.get(opId);
     assert(tree);
     removeDataTree(store, tree);
   }
+
   return toEvict;
 }
 

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -90,7 +90,7 @@ export function evictOldData(env: CacheEnv, store: Store): OperationId[] {
       continue; // Skip non-evictable operations entirely
     }
 
-    let partition = partitionKey?.(tree.operation);
+    let partition = partitionKey?.(tree);
     if (!partition || !configuredPartitionKeys.has(partition)) {
       partition = DEFAULT_PARTITION; // Default partition if not specified or not configured
     }

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -39,7 +39,7 @@ export type PartitionConfig = {
       maxOperationCount?: number;
     };
   };
-  partitionKey: (operation: OperationDescriptor) => string | undefined;
+  partitionKey: (operation: IndexedTree) => string | undefined;
 };
 
 export type DataTree = IndexedTree & {

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -29,17 +29,17 @@ import type {
   FieldReadFunction,
 } from "@apollo/client/cache/inmemory/policies";
 import type { TelemetryEvent } from "../telemetry/types";
-import { Logger } from "../jsutils/logger";
+import { ExtendedLogger, Logger } from "../jsutils/logger";
 import { GraphDifference, GraphDiffError } from "../diff/diffTree";
 import { ObjectDifference } from "../diff/types";
 
 export type PartitionConfig = {
   partitions: {
     [key: string]: {
-      maxOperationCount?: number;
+      maxOperationCount: number;
     };
   };
-  partitionKey: (operation: IndexedTree) => string | undefined;
+  partitionKey: (operation: IndexedTree) => string | null;
 };
 
 export type DataTree = IndexedTree & {
@@ -133,7 +133,7 @@ export type ForestRunAdditionalConfig = {
   autoEvict?: boolean;
   maxOperationCount?: number;
   nonEvictableQueries?: Set<string>;
-  partitionConfig?: PartitionConfig;
+  unstable_partitionConfig?: PartitionConfig;
   apolloCompat_keepOrphanNodes?: boolean;
   logger?: Logger;
   notify?: (event: TelemetryEvent) => void;
@@ -187,7 +187,7 @@ export type CacheEnv = {
   ) => Key | KeySpecifier | undefined;
 
   notify?: (event: TelemetryEvent) => void;
-  logger?: Logger;
+  logger?: ExtendedLogger;
 
   // ApolloCompat:
   //   Apollo can track dirty entries in results of read operations even if some "key" fields are missing in selection

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -33,6 +33,15 @@ import { Logger } from "../jsutils/logger";
 import { GraphDifference, GraphDiffError } from "../diff/diffTree";
 import { ObjectDifference } from "../diff/types";
 
+export type PartitionConfig = {
+  partitions: {
+    [key: string]: {
+      maxOperationCount?: number;
+    };
+  };
+  partitionKey: (operation: OperationDescriptor) => string | undefined;
+};
+
 export type DataTree = IndexedTree & {
   grown?: boolean;
 };
@@ -124,6 +133,7 @@ export type ForestRunAdditionalConfig = {
   autoEvict?: boolean;
   maxOperationCount?: number;
   nonEvictableQueries?: Set<string>;
+  partitionConfig?: PartitionConfig;
   apolloCompat_keepOrphanNodes?: boolean;
   logger?: Logger;
   notify?: (event: TelemetryEvent) => void;
@@ -197,6 +207,7 @@ export type CacheEnv = {
   autoEvict: boolean;
   nonEvictableQueries: Set<string>;
   maxOperationCount: number;
+  partitionConfig?: PartitionConfig;
 
   // Feature flags
   logUpdateStats: boolean;

--- a/packages/apollo-forest-run/src/jsutils/logger.ts
+++ b/packages/apollo-forest-run/src/jsutils/logger.ts
@@ -6,3 +6,32 @@ export type Logger = {
 };
 
 export const logger: Logger = console;
+
+export type ExtendedLogger = Logger & {
+  warnOnce: (key: string, message: string) => void;
+};
+
+export function createExtendedLogger(
+  baseLogger: Logger | undefined,
+): ExtendedLogger | undefined {
+  if (!baseLogger) {
+    return undefined;
+  }
+
+  const warnings = new Set<string>();
+
+  return {
+    // bind dynamically to the base logger methods so mocks work as expected
+    debug: (...args) => baseLogger.debug(...args),
+    log: (...args) => baseLogger.log(...args),
+    warn: (...args) => baseLogger.warn(...args),
+    error: (...args) => baseLogger.error(...args),
+    // add the warnOnce method
+    warnOnce(key: string, message: string): void {
+      if (!warnings.has(key)) {
+        warnings.add(key);
+        baseLogger.warn(key, message);
+      }
+    },
+  };
+}


### PR DESCRIPTION
Allows us to put items in different buckets for purposes of eviction/retention. 

This would retain a max of 500 "default partition" items and an independent 120 "CriticalChatQueries" items.

Example:

```ts
        maxOperationCount: 500,
        partitionConfig: {
          partitionKey: op => {
            switch (op.operation.debugName) {
              case "query ChatMetadataQuery":
              case "query ChatMessageListQuery":
              case "query ChatAppsQuery":
                return "CriticalChatQueries";
            }
            return;
          },
          partitions: {
            CriticalChatQueries: {
              maxOperationCount: 120,
            },
          },
        },
```

or

```ts
        maxOperationCount: 500,
        partitionConfig: {
          partitionKey: op => {
            const rootFields = getRootFields(op);
            if (["messages", "chat", "apps"].some(field => rootFields?.has(field))) {
              return "CriticalChatQueries";
            }
            return;
          },
          partitions: {
            CriticalChatQueries: {
              maxOperationCount: 120,
            },
          },
        },

```