### PR TITLE
[HOTFIX] group isLegacy param renamed to useLegacy

### DIFF
--- a/change/@graphitation-cli-861171b5-d2d8-4e42-bc33-a92a43e9c6ae.json
+++ b/change/@graphitation-cli-861171b5-d2d8-4e42-bc33-a92a43e9c6ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[HOTFIX] group isLegacy param renamed to useLegacy",
+  "packageName": "@graphitation/cli",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-ts-codegen-de89350f-123c-4d95-9bd1-9481317433fd.json
+++ b/change/@graphitation-ts-codegen-de89350f-123c-4d95-9bd1-9481317433fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[HOTFIX] group isLegacy param renamed to useLegacy",
+  "packageName": "@graphitation/ts-codegen",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/supermassive.ts
+++ b/packages/cli/src/supermassive.ts
@@ -72,7 +72,7 @@ export function supermassive(): Command {
     )
     .option(
       "--context-type-extensions-file [contextTypeExtensionsFile]",
-      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, groups?: { [groupName]: { isLegacy?: boolean, required?: {[namespace: string]]: string[] }}}, contextTypes: { required? :{ [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}}",
+      "Describes context types and their import paths. Used to generate resolver context type extensions. The file must be defined in the following format: { baseContextTypePath?: string, baseContextTypeName?: string, groups?: { [groupName]: { useLegacy?: boolean, required?: {[namespace: string]]: string[] }}}, contextTypes: { required? :{ [namespace: string]: { [type: string]: { importNamespaceName?: string, importPath: string, typeName: string }}}}",
     )
     .option(
       "--generate-resolver-map",

--- a/packages/ts-codegen/src/__tests__/context.test.ts
+++ b/packages/ts-codegen/src/__tests__/context.test.ts
@@ -26,7 +26,7 @@ describe(generateTS, () => {
           },
         },
         PostTestGroupWithLegacyContext: {
-          isLegacy: true,
+          useLegacy: true,
           required: {
             managers: ["post", "whatever"],
             workflows: ["post-workflow"],

--- a/packages/ts-codegen/src/context/index.ts
+++ b/packages/ts-codegen/src/context/index.ts
@@ -898,7 +898,7 @@ export function extractContext(
           options.contextTypeExtensions.groups[node.name.value]
         ) {
           const subTypeKeys: Set<string> = new Set();
-          const { required: groupItems, isLegacy: useLegacyContext } =
+          const { required: groupItems, useLegacy: useLegacyContext } =
             options.contextTypeExtensions.groups[node.name.value];
 
           if (!groupItems || Object.keys(groupItems).length === 0) {

--- a/packages/ts-codegen/src/types.ts
+++ b/packages/ts-codegen/src/types.ts
@@ -32,7 +32,7 @@ type ContextGroupItem = {
 
 type ContextGroup = {
   required?: ContextGroupItem;
-  isLegacy?: boolean;
+  useLegacy?: boolean;
 };
 
 export type ContextTypeExtension = {


### PR DESCRIPTION
Groups in contextExtensions changed shape to support useLegacy:
```
...
groups: {
        baseContextOnly: {},
        UserTestGroup: {
          required: {
            managers: ["user", "whatever"],
          },
        },
        PostTestGroup: {
          required: {
            managers: ["post", "whatever"],
            workflows: ["post-workflow"],
          },
        },
        PostTestGroupWithLegacyContext: {
          useLegacy: true,
          required: {
            managers: ["post", "whatever"],
            workflows: ["post-workflow"],
          },
        },
      },
...
```