### PR TITLE
Fix non semver version requirements

### DIFF
--- a/change/@graphitation-apollo-forest-run-2d475d7c-ac56-427b-9f79-496249a029d4.json
+++ b/change/@graphitation-apollo-forest-run-2d475d7c-ac56-427b-9f79-496249a029d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @apollo/client to a semver version",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-mock-client-957ff2b1-d32f-492f-afac-57d9def1f020.json
+++ b/change/@graphitation-apollo-mock-client-957ff2b1-d32f-492f-afac-57d9def1f020.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @apollo/client to a semver version",
+  "packageName": "@graphitation/apollo-mock-client",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-react-relay-duct-tape-65b2b275-5d49-4348-b268-54f63cc98975.json
+++ b/change/@graphitation-apollo-react-relay-duct-tape-65b2b275-5d49-4348-b268-54f63cc98975.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @apollo/client to a semver version",
+  "packageName": "@graphitation/apollo-react-relay-duct-tape",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-resolvers-models-eb49ba29-9fb3-4b3e-a11d-bbc3e4f42e06.json
+++ b/change/@graphitation-graphql-codegen-resolvers-models-eb49ba29-9fb3-4b3e-a11d-bbc3e4f42e06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @graphql-codegen/visitor-plugin-common to a semver version",
+  "packageName": "@graphitation/graphql-codegen-resolvers-models",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-0b9f5c86-b3d5-42eb-b852-b8f36bf2dedb.json
+++ b/change/@graphitation-graphql-codegen-supermassive-typed-document-node-plugin-0b9f5c86-b3d5-42eb-b852-b8f36bf2dedb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @graphql-codegen/visitor-plugin-common to a semver version",
+  "packageName": "@graphitation/graphql-codegen-supermassive-typed-document-node-plugin",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/package.json
+++ b/packages/apollo-forest-run/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@apollo/client": ">= ^3.3.0 < 3.7.0",
+    "@apollo/client": ">= 3.3.0 < 3.7.0",
     "graphql": "^15.0.0",
     "lodash": "^4.17.21",
     "monorepo-scripts": "*",
@@ -48,6 +48,6 @@
   "dependencies": {},
   "peerDependencies": {
     "graphql": "^15.0.0 || ^16.0.0 || ^17.0.0",
-    "@apollo/client": ">= ^3.6.0 < 3.7.0"
+    "@apollo/client": ">= 3.6.0 < 3.7.0"
   }
 }

--- a/packages/apollo-mock-client/package.json
+++ b/packages/apollo-mock-client/package.json
@@ -17,7 +17,7 @@
     "just": "monorepo-scripts"
   },
   "devDependencies": {
-    "@apollo/client": ">= ^3.3.0 < 3.7.0",
+    "@apollo/client": ">= 3.3.0 < 3.7.0",
     "@graphitation/graphql-js-tag": "^0.10.0",
     "@graphitation/graphql-js-operation-payload-generator": "^0.13.0",
     "@types/invariant": "^2.2.34",
@@ -30,7 +30,7 @@
     "react-test-renderer": "^18.2.0"
   },
   "peerDependencies": {
-    "@apollo/client": ">= ^3.3.0 < 3.7.0",
+    "@apollo/client": ">= 3.3.0 < 3.7.0",
     "graphql": "^15.0.0"
   },
   "dependencies": {

--- a/packages/apollo-react-relay-duct-tape/package.json
+++ b/packages/apollo-react-relay-duct-tape/package.json
@@ -20,7 +20,7 @@
     "duct-tape-compiler": "yarn duct-tape-compiler:compiled-hooks && yarn duct-tape-compiler:noop-hooks"
   },
   "devDependencies": {
-    "@apollo/client": ">= ^3.3.0 < 3.7.0",
+    "@apollo/client": ">= 3.3.0 < 3.7.0",
     "@graphitation/apollo-mock-client": "^0.12.0",
     "@graphitation/graphql-js-operation-payload-generator": "^0.13.0",
     "@graphitation/graphql-js-tag": "^0.10.0",
@@ -34,7 +34,7 @@
     "ts-expect": "^1.3.0"
   },
   "peerDependencies": {
-    "@apollo/client": ">= ^3.3.0 < 3.7.0",
+    "@apollo/client": ">= 3.3.0 < 3.7.0",
     "graphql": "^15.0.0",
     "react": "^18.2.0"
   },

--- a/packages/graphql-codegen-resolvers-models/package.json
+++ b/packages/graphql-codegen-resolvers-models/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@graphql-codegen/plugin-helpers": ">= 1.18.0 < 2",
-    "@graphql-codegen/visitor-plugin-common": ">= ^1.17.0 < 2",
+    "@graphql-codegen/visitor-plugin-common": ">= 1.17.0 < 2",
     "typescript": "^5.5.3"
   },
   "dependencies": {},

--- a/packages/graphql-codegen-supermassive-typed-document-node-plugin/package.json
+++ b/packages/graphql-codegen-supermassive-typed-document-node-plugin/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@graphql-codegen/plugin-helpers": ">= 1.18.0 < 2",
-    "@graphql-codegen/visitor-plugin-common": ">= ^1.17.0 < 2",
+    "@graphql-codegen/visitor-plugin-common": ">= 1.17.0 < 2",
     "graphql-tag": ">= 2.11.0 < 3",
     "@graphql-tools/optimize": "^1.0.1",
     "@graphitation/supermassive": "^3.11.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@>= ^3.3.0 < 3.7.0", "@apollo/client@~3.6.0":
+"@apollo/client@>= 3.3.0 < 3.7.0", "@apollo/client@~3.6.0":
   version "3.6.10"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.10.tgz#f12d1f0cc4811d6bfe68b3f48a18e08a757ee301"
   integrity sha512-zow8+Z7Wz8OeH+8bhIxqPtqqXY87APoUbXlaXD/rgs3O9ijSyHSbUt3E4DnkLNP9q3+/OsRWY+Mx+WxkQQ4oig==


### PR DESCRIPTION
Fixing non semver version requirements to @graphql-codegen/visitor-plugin-common and @apollo/client as some tools are unreliable with how they handle non semver.

The "^" inside the range is not valid semver (https://semver.npmjs.com/):
<img width="638" height="577" alt="image" src="https://github.com/user-attachments/assets/d43c6f57-3284-472a-9085-3c8022b24d33" />