### PR TITLE
feat(ForestRun): rename conflicting method

### DIFF
--- a/change/@graphitation-apollo-forest-run-4054d47f-58b7-41cb-a7f1-48b6db7d561f.json
+++ b/change/@graphitation-apollo-forest-run-4054d47f-58b7-41cb-a7f1-48b6db7d561f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "rename conflicting API",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "pavelglac@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -346,7 +346,7 @@ export class ForestRun<
     return this.env.optimizeFragmentReads &&
       isFragmentDocument(watch.query) &&
       (watch.id || watch.rootId)
-      ? this.watchFragment(watch)
+      ? this.watchFragmentInternal(watch)
       : this.watchOperation(watch);
   }
 
@@ -371,9 +371,17 @@ export class ForestRun<
     };
   }
 
-  private watchFragment(watch: Cache.WatchOptions) {
+  private watchFragmentInternal(watch: Cache.WatchOptions) {
     const id = watch.id ?? watch.rootId;
     assert(id !== undefined);
+
+    if (watch.immediate) {
+      const diff = this.diff(watch);
+      if (this.shouldNotifyWatch(watch, diff)) {
+        this.notifyWatch(watch, diff);
+      }
+    }
+
     accumulate(this.store.fragmentWatches, id, watch);
 
     return () => {
@@ -480,6 +488,7 @@ export class ForestRun<
     if (options?.discardWatches) {
       this.newWatches.clear();
       this.store.watches.clear();
+      this.store.fragmentWatches.clear();
     }
 
     return Promise.resolve();


### PR DESCRIPTION
Apollo has a public method [`watchFragment`](https://github.com/apollographql/apollo-client/blob/v3.13.9/src/cache/core/cache.ts#L250). To ensure the compatibility with newer version we need to avoid the override.

Also the watchFragment is called watch with `immediate: true,` so we need to possibility to fragments be notified once subscribed.