### PR TITLE
fix(apollo-forest-run): do not throw on empty covers value

### DIFF
--- a/change/@graphitation-apollo-forest-run-1a155e08-99cf-44bf-8c98-181d8c98e805.json
+++ b/change/@graphitation-apollo-forest-run-1a155e08-99cf-44bf-8c98-181d8c98e805.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): do not throw on empty covers value",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/descriptor/__tests__/operation.test.ts
+++ b/packages/apollo-forest-run/src/descriptor/__tests__/operation.test.ts
@@ -599,10 +599,14 @@ describe("@cache(covers)", () => {
     ).toThrowError(/Could not extract covers/);
   });
 
-  it("throws when covers is an empty list", () => {
-    expect(() =>
-      describeOp(`query Q @cache(covers: []) { field }`),
-    ).toThrowError(/Could not extract covers/);
+  it("returns empty covers when covers is an empty list", () => {
+    const op = describeOp(`query Q @cache(covers: []) { field }`);
+    expect(op.covers).toEqual([]);
+  });
+
+  it("returns empty covers when covers is null", () => {
+    const op = describeOp(`query Q @cache(covers: null) { field }`);
+    expect(op.covers).toEqual([]);
   });
 
   it("throws when covers contains empty strings", () => {
@@ -631,6 +635,22 @@ describe("@cache(covers)", () => {
       `query Preloader($ops: [String!] = ["DefaultOp"]) @cache(covers: $ops) { field }`,
     );
     expect(op.covers).toEqual(["DefaultOp"]);
+  });
+
+  it("returns empty covers when variable is an empty array", () => {
+    const op = describeOp(
+      `query Preloader($ops: [String!]) @cache(covers: $ops) { field }`,
+      { ops: [] },
+    );
+    expect(op.covers).toEqual([]);
+  });
+
+  it("returns empty covers when variable is null", () => {
+    const op = describeOp(
+      `query Preloader($ops: [String!]) @cache(covers: $ops) { field }`,
+      { ops: null },
+    );
+    expect(op.covers).toEqual([]);
   });
 
   it("supports both keyVars and covers in same @cache directive", () => {

--- a/packages/apollo-forest-run/src/descriptor/operation.ts
+++ b/packages/apollo-forest-run/src/descriptor/operation.ts
@@ -150,12 +150,15 @@ function getCovers(
     return EMPTY_COVERS;
   }
   const value = valueFromASTUntyped(astValue, variables);
-  if (value === undefined) {
+  if (
+    value === undefined ||
+    value === null ||
+    (Array.isArray(value) && value.length === 0)
+  ) {
     return EMPTY_COVERS;
   }
   if (
     !Array.isArray(value) ||
-    !value.length ||
     value.some((variable) => typeof variable !== "string" || variable === "")
   ) {
     throw new Error(


### PR DESCRIPTION
ForestRun: variants with empty `covers` shouldn't throw validation error:

- `query Q @cache(covers: []) { field }`
- `query Q @cache(covers: null) { field }`