### PR TITLE
fix(apollo-forest-run): tolerate null embedded parent in merge policy

### DIFF
--- a/change/@graphitation-apollo-forest-run-ce82ec5b-8a94-4dfb-a972-22203ea6297e.json
+++ b/change/@graphitation-apollo-forest-run-ce82ec5b-8a94-4dfb-a972-22203ea6297e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tolerate an explicit null embedded parent when applying a merge policy at write time",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -1558,3 +1558,140 @@ test("correctly handles optimistic fragment write for deeply nested node", () =>
     { items: [item1, item2] },
   ]);
 });
+
+test("merge policy on embedded object must not crash when a prior operation wrote null (draftHelpers:72)", () => {
+  // A keyless ("embedded") type with a field `merge` policy. If a previous
+  // operation wrote that position as an explicit `null`, the merge machinery
+  // must not crash resolving the existing parent at write time.
+  const cache = new ForestRun({
+    typePolicies: {
+      Container: {
+        keyFields: false,
+        fields: {
+          items: {
+            merge(existing = [], incoming) {
+              return [...existing, ...incoming];
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const queryA = gql`
+    query A {
+      container {
+        __typename
+        items {
+          __typename
+          id
+          value
+        }
+      }
+    }
+  `;
+  const queryB = gql`
+    query B {
+      container {
+        __typename
+        items {
+          __typename
+          id
+          value
+        }
+      }
+    }
+  `;
+
+  // Prior operation commits an explicit null for the embedded field.
+  cache.write({ query: queryA, result: { container: null } });
+
+  const writeRealResult = () =>
+    cache.write({
+      query: queryB,
+      result: {
+        container: {
+          __typename: "Container",
+          items: [{ __typename: "Item", id: "1", value: "hi" }],
+        },
+      },
+    });
+
+  expect(writeRealResult).not.toThrow();
+
+  expect(cache.read({ query: queryB, optimistic: true })).toEqual({
+    container: {
+      __typename: "Container",
+      items: [{ __typename: "Item", id: "1", value: "hi" }],
+    },
+  });
+});
+
+test("merge policy on embedded object must not crash when a prior null operation has a broader selection (draftHelpers:72)", () => {
+  // As above, but the prior null operation has a broader selection than the
+  // later write, which may take a different cross-operation resolution path.
+  const cache = new ForestRun({
+    typePolicies: {
+      Container: {
+        keyFields: false,
+        fields: {
+          items: {
+            merge(existing = [], incoming) {
+              return [...existing, ...incoming];
+            },
+          },
+        },
+      },
+    },
+  });
+
+  // `extra` makes query A's selection broader than query B's.
+  const queryA = gql`
+    query A {
+      container {
+        __typename
+        extra
+        items {
+          __typename
+          id
+          value
+        }
+      }
+    }
+  `;
+  const queryB = gql`
+    query B {
+      container {
+        __typename
+        items {
+          __typename
+          id
+          value
+        }
+      }
+    }
+  `;
+
+  // Prior operation commits an explicit null for the embedded field.
+  cache.write({ query: queryA, result: { container: null } });
+
+  const writeRealResult = () =>
+    cache.write({
+      query: queryB,
+      result: {
+        container: {
+          __typename: "Container",
+          items: [{ __typename: "Item", id: "1", value: "hi" }],
+        },
+      },
+    });
+
+  expect(writeRealResult).not.toThrow();
+
+  expect(cache.read({ query: queryB, optimistic: true })).toEqual({
+    container: {
+      __typename: "Container",
+      items: [{ __typename: "Item", id: "1", value: "hi" }],
+    },
+  });
+});

--- a/packages/apollo-forest-run/src/cache/draftHelpers.ts
+++ b/packages/apollo-forest-run/src/cache/draftHelpers.ts
@@ -73,7 +73,11 @@ export function* getEmbeddedObjectChunks(
   for (const chunk of nodeChunks) {
     const value = retrieveEmbeddedValue(pathEnv, chunk, ref);
     // An explicit `null` (CompositeNull) parent has no embedded object to resolve.
-    if (value === undefined || isMissingValue(value) || isCompositeNullValue(value)) {
+    if (
+      value === undefined ||
+      isMissingValue(value) ||
+      isCompositeNullValue(value)
+    ) {
       continue;
     }
     if (!isObjectValue(value) || value.key !== false) {

--- a/packages/apollo-forest-run/src/cache/draftHelpers.ts
+++ b/packages/apollo-forest-run/src/cache/draftHelpers.ts
@@ -22,6 +22,7 @@ import {
   isMissingValue,
   isNodeValue,
   isObjectValue,
+  isCompositeNullValue,
   findClosestNode,
   getDataPathForDebugging,
   resolveGraphValueReference,
@@ -71,7 +72,8 @@ export function* getEmbeddedObjectChunks(
 ): Generator<ObjectChunk> {
   for (const chunk of nodeChunks) {
     const value = retrieveEmbeddedValue(pathEnv, chunk, ref);
-    if (value === undefined || isMissingValue(value)) {
+    // An explicit `null` (CompositeNull) parent has no embedded object to resolve.
+    if (value === undefined || isMissingValue(value) || isCompositeNullValue(value)) {
       continue;
     }
     if (!isObjectValue(value) || value.key !== false) {


### PR DESCRIPTION
## Why

A keyless ("embedded") GraphQL type that carries a field `merge` policy crashes at write time with an `Invariant violation` when a *prior* operation wrote that embedded position as an explicit `null`.

The prior `null` is indexed as a `CompositeNull` chunk. When a later operation writes a real object, the embedded `merge` policy runs and `applyMergePolicies` -> `transformField` resolves the existing parent via `findExistingChunk(...) ?? findChunk(...)`. `findExistingChunk` already tolerates `CompositeNull` and returns `undefined`, so the strict `findChunk` path runs and `getEmbeddedObjectChunks` asserts because the existing value is `CompositeNull` rather than an embedded object. `isMissingValue` only skips `undefined` (`CompositeUndefined`), so a literal `null` slipped past the guard.

## Approach

`getEmbeddedObjectChunks` (`draftHelpers.ts`) now also skips `CompositeNull` values via `isCompositeNullValue`, the same way the same-operation `findExistingChunk` lookup already tolerates them. With no embedded parent to resolve, `findChunk` returns `undefined` and the merge policy runs with its default `existing` value instead of crashing.

## Tests

Two regression tests added to `regression.test.ts`, both using only the public `ForestRun` API (`write` / `read`):

- Prior `null` operation and the later write share an identical selection.
- Prior `null` operation has a *broader* selection than the later write. These exercise potentially distinct cross-operation resolution paths (identical vs mismatched selections), so we guard against regressing either.

Full `apollo-forest-run/src` suite passes (25 suites, 1094 tests).