### PR TITLE
fix(apollo-forest-run): tolerate divergent null/object node chunks during update

### DIFF
--- a/change/@graphitation-apollo-forest-run-6b6eb87f-21ce-43f0-b729-efe2047dfa19.json
+++ b/change/@graphitation-apollo-forest-run-6b6eb87f-21ce-43f0-b729-efe2047dfa19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): tolerate divergent null/object node chunks during update",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/change/@graphitation-apollo-forest-run-8f2a1c4d-6b3e-4a1f-9c7d-2e5b8a0d1f34.json
+++ b/change/@graphitation-apollo-forest-run-8f2a1c4d-6b3e-4a1f-9c7d-2e5b8a0d1f34.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Report the full data path (not just the last field/index) in incompatible-update invariant messages when the failing value is a non-addressable CompositeNull/CompositeUndefined",
-  "packageName": "@graphitation/apollo-forest-run",
-  "email": "vrazuvaev@microsoft.com_msteamsmdb",
-  "dependentChangeType": "patch"
-}

--- a/change/@graphitation-apollo-forest-run-8f2a1c4d-6b3e-4a1f-9c7d-2e5b8a0d1f34.json
+++ b/change/@graphitation-apollo-forest-run-8f2a1c4d-6b3e-4a1f-9c7d-2e5b8a0d1f34.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Report the full data path (not just the last field/index) in incompatible-update invariant messages when the failing value is a non-addressable CompositeNull/CompositeUndefined",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -1558,3 +1558,149 @@ test("correctly handles optimistic fragment write for deeply nested node", () =>
     { items: [item1, item2] },
   ]);
 });
+
+test("update must not crash when a node field is null in one chunk and an object in another", () => {
+  // Aliasing produces an Object chunk and a CompositeNull chunk for the same
+  // node; a later ObjectDifference is applied to both, asserting
+  // isObjectValue(base) on the null chunk.
+  const cache = new ForestRun();
+
+  const aliasedQuery = gql`
+    query Aliased {
+      x: foo {
+        __typename
+        id
+        details {
+          __typename
+          a
+          b
+        }
+      }
+      y: foo {
+        __typename
+        id
+        details {
+          __typename
+          a
+          b
+        }
+      }
+    }
+  `;
+  const singleQuery = gql`
+    query Single {
+      foo {
+        __typename
+        id
+        details {
+          __typename
+          a
+          b
+        }
+      }
+    }
+  `;
+
+  // Same node written twice in one operation: object via `x`, null via `y`.
+  cache.write({
+    query: aliasedQuery,
+    result: {
+      x: {
+        __typename: "Foo",
+        id: "1",
+        details: { __typename: "Detail", a: 1, b: 1 },
+      },
+      y: {
+        __typename: "Foo",
+        id: "1",
+        details: null,
+      },
+    },
+  });
+
+  // Changing details yields one ObjectDifference applied to every chunk,
+  // including the CompositeNull one.
+  const writeChanged = () =>
+    cache.write({
+      query: singleQuery,
+      result: {
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          details: { __typename: "Detail", a: 2, b: 1 },
+        },
+      },
+    });
+
+  expect(writeChanged).not.toThrow();
+});
+
+test("update must not crash when the same node id appears twice with divergent details (no alias)", () => {
+  // Same regression via a normalized node-id collision rather than aliasing:
+  // the same node id appears twice in one list result with `details` an object
+  // in one occurrence and null in the other, yielding an Object chunk and a
+  // CompositeNull chunk without aliasing.
+  const cache = new ForestRun();
+
+  const listQuery = gql`
+    query List {
+      foos {
+        __typename
+        id
+        details {
+          __typename
+          a
+          b
+        }
+      }
+    }
+  `;
+  const singleQuery = gql`
+    query Single {
+      foo {
+        __typename
+        id
+        details {
+          __typename
+          a
+          b
+        }
+      }
+    }
+  `;
+
+  // Same node id twice in one list result: object then null.
+  cache.write({
+    query: listQuery,
+    result: {
+      foos: [
+        {
+          __typename: "Foo",
+          id: "1",
+          details: { __typename: "Detail", a: 1, b: 1 },
+        },
+        {
+          __typename: "Foo",
+          id: "1",
+          details: null,
+        },
+      ],
+    },
+  });
+
+  // Changing details yields one ObjectDifference applied to every chunk,
+  // including the CompositeNull one.
+  const writeChanged = () =>
+    cache.write({
+      query: singleQuery,
+      result: {
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          details: { __typename: "Detail", a: 2, b: 1 },
+        },
+      },
+    });
+
+  expect(writeChanged).not.toThrow();
+});

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -1841,3 +1841,77 @@ test("merge policy on embedded object must not crash when a prior null operation
     },
   });
 });
+
+test("update must not crash when a list item is null in one chunk and an object in another", () => {
+  // Same divergent-chunk regression, but the null/object divergence is on a *list item*
+  // rather than a field. The list difference is applied to every chunk of the node, so the
+  // per-item ObjectDifference reaches the CompositeNull element of the divergent chunk
+  // (updateValue is called for list items without a null guard). It must be skipped, not crash.
+  const cache = new ForestRun();
+
+  const aliasedQuery = gql`
+    query Aliased {
+      x: foo {
+        __typename
+        id
+        items {
+          __typename
+          value
+        }
+      }
+      y: foo {
+        __typename
+        id
+        items {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const singleQuery = gql`
+    query Single {
+      foo {
+        __typename
+        id
+        items {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+
+  // Same node written twice in one operation: item object via `x`, null item via `y`.
+  cache.write({
+    query: aliasedQuery,
+    result: {
+      x: {
+        __typename: "Foo",
+        id: "1",
+        items: [{ __typename: "Item", value: 1 }],
+      },
+      y: {
+        __typename: "Foo",
+        id: "1",
+        items: [null],
+      },
+    },
+  });
+
+  // Changing the item yields one CompositeListDifference (with a per-item ObjectDifference)
+  // applied to every chunk, including the one whose item is CompositeNull.
+  const writeChanged = () =>
+    cache.write({
+      query: singleQuery,
+      result: {
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          items: [{ __typename: "Item", value: 2 }],
+        },
+      },
+    });
+
+  expect(writeChanged).not.toThrow();
+});

--- a/packages/apollo-forest-run/src/forest/__tests__/updateObject.test.ts
+++ b/packages/apollo-forest-run/src/forest/__tests__/updateObject.test.ts
@@ -83,6 +83,10 @@ const NESTED_INCOMPATIBLE_OBJECT_DIFF_ERROR =
   'Invariant violation: Failed to update "query BaseFeedQuery" ' +
   "at path listContainer.items.0.value (in Entity): expected CompositeList, got ObjectDifference";
 
+const NESTED_INCOMPATIBLE_NULL_DIFF_ERROR =
+  'Invariant violation: Failed to update "query BaseFeedQuery" ' +
+  "at path listContainer.items.0.value (in Entity): expected CompositeNull, got ObjectDifference";
+
 describe("incompatible object difference invariant", () => {
   it("reports operation and path for a field two levels deep below a list", () => {
     const cache = new ForestRun();
@@ -130,5 +134,53 @@ describe("incompatible object difference invariant", () => {
     expect((error as Error).message).toBe(
       NESTED_INCOMPATIBLE_OBJECT_DIFF_ERROR,
     );
+  });
+
+  it("reports the full path when the failing value is a nested CompositeNull", () => {
+    const cache = new ForestRun();
+
+    // Same setup as above, but here the same Entity's "value" is a null (with a
+    // sub-selection, i.e. a CompositeNull) under "listContainer" and an object under
+    // "objectContainer". A CompositeNull's source data is `null`, so it is not
+    // addressable by the path utils on its own - the reported path must therefore be
+    // derived from its parent chunk, yielding the full "listContainer.items.0.value"
+    // rather than just the final "value" segment.
+    cache.write({
+      query: nestedFeedListQuery,
+      result: {
+        objectContainer: {
+          __typename: "Container",
+          id: "object",
+          items: [{ __typename: "Entity", id: "1", value: { note: "old" } }],
+        },
+        listContainer: {
+          __typename: "Container",
+          id: "list",
+          items: [{ __typename: "Entity", id: "1", value: null }],
+        },
+      },
+    });
+
+    const run = () =>
+      cache.write({
+        query: nestedFeedObjectQuery,
+        result: {
+          objectContainer: {
+            __typename: "Container",
+            id: "object",
+            items: [{ __typename: "Entity", id: "1", value: { note: "new" } }],
+          },
+        },
+      });
+
+    let error: unknown;
+    try {
+      run();
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(NESTED_INCOMPATIBLE_NULL_DIFF_ERROR);
   });
 });

--- a/packages/apollo-forest-run/src/forest/__tests__/updateObject.test.ts
+++ b/packages/apollo-forest-run/src/forest/__tests__/updateObject.test.ts
@@ -35,6 +35,41 @@ describe("replaceValue invariant", () => {
       'Invariant violation: Failed to update "query ReplaceScalar": cannot replace Scalar with Object (of type Widget)',
     );
   });
+
+  it("still reports the invariant when path/node resolution throws", () => {
+    const operation = createTestOperation(gql`
+      query ReplaceObject {
+        node {
+          id
+        }
+      }
+    `);
+    // base is an addressable, keyless embedded object, so both path resolution and
+    // enclosing-node resolution must ascend the tree via findParent. A corrupt tree can
+    // make findParent throw while an invariant is being reported; the message builder must
+    // swallow that and still surface the invariant rather than the internal exception.
+    const objectBase = resolveFieldValue(
+      generateChunk(`query ObjectSource { embedded { field } }`).value,
+      "embedded",
+    ) as ObjectChunk;
+    const listReplacement = resolveFieldValue(
+      generateChunk(`query ListSource { items @mock(count: 2) { id } }`).value,
+      "items",
+    );
+
+    const context = {
+      operation,
+      findParent: () => {
+        throw new Error("corrupt tree: findParent exploded");
+      },
+    } as unknown as UpdateTreeContext;
+
+    expect(() =>
+      replaceValue(context, objectBase as any, listReplacement as any),
+    ).toThrow(
+      'Invariant violation: Failed to update "query ReplaceObject": cannot replace Object with CompositeList',
+    );
+  });
 });
 
 const nestedFeedListQuery = gql`

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -101,7 +101,8 @@ function updateObjectValue(
 
       const updated = updateValue(context, value, fieldDiff, {
         kind: "field",
-        fieldName: fieldInfo.name,
+        parent: base,
+        field: fieldInfo,
       });
 
       if (valueIsMissing && updated !== undefined) {
@@ -152,8 +153,8 @@ function updateObjectValue(
 }
 
 type UpdateValueLocation =
-  | { kind: "field"; fieldName: string }
-  | { kind: "listItem"; index: number };
+  | { kind: "field"; parent: GraphChunk; field: FieldInfo }
+  | { kind: "listItem"; parent: GraphChunk; index: number };
 
 function updateValue(
   context: UpdateTreeContext,
@@ -296,44 +297,77 @@ function updateFailureMessage(
   location?: UpdateValueLocation,
 ): string {
   const prefix = `Failed to update "${context.operation.debugName}"`;
-  const basePath = chunkPath(context, base);
-  const pathString = basePath?.length
-    ? basePath.join(".")
-    : location
-    ? describeLocation(location)
-    : undefined;
-  const nodeClause = nodeTypeClause(context, base);
+  const pathString = resolveFailurePath(context, base, location);
+  const nodeClause = nodeTypeClause(context, base, location);
   return pathString
     ? `${prefix} at path ${pathString}${nodeClause}: ${detail}`
     : `${prefix}${nodeClause}: ${detail}`;
 }
 
+// Full path to the failing value, e.g. "listContainer.items.0.value".
+//   The failing value itself may not be addressable by the path utils (e.g. a CompositeNull
+//   or CompositeUndefined, whose source data is null/undefined and cannot be located in the
+//   tree). In that case its own path resolves to nothing and we would otherwise only report
+//   the final field/index. So we prefer to derive the path from the failing value's parent
+//   chunk (always an ObjectChunk or CompositeListChunk, which *is* addressable) and append
+//   the field/index step, falling back to the value's own path or the bare step.
+function resolveFailurePath(
+  context: UpdateTreeContext,
+  base: GraphChunk,
+  location?: UpdateValueLocation,
+): string | undefined {
+  if (location) {
+    const parentPath = chunkPath(context, location.parent);
+    if (parentPath) {
+      return parentPath.concat(describeLocation(location)).join(".");
+    }
+  }
+  const basePath = chunkPath(context, base);
+  if (basePath?.length) {
+    return basePath.join(".");
+  }
+  return location ? describeLocation(location) : undefined;
+}
+
 function describeLocation(location: UpdateValueLocation): string {
   return location.kind === "field"
-    ? location.fieldName
+    ? location.field.dataKey
     : String(location.index);
 }
 
 // Best-effort " (in <TypeName>)" clause naming the closest enclosing node's __typename.
 //   Defensive: the tree may already be inconsistent when an invariant fires, so it is
 //   wrapped in try/catch and falls back to an empty clause (and aggregates are skipped,
-//   as they are not addressable by the path utils).
+//   as they are not addressable by the path utils). When the failing value itself is not
+//   addressable (e.g. a CompositeNull), the enclosing node is resolved from its parent.
 function nodeTypeClause(
   env: { findParent: ParentLocator },
   chunk: GraphChunk,
+  location?: UpdateValueLocation,
 ): string {
-  if (
-    (!Value.isObjectValue(chunk) && !Value.isCompositeListValue(chunk)) ||
-    chunk.isAggregate
-  ) {
+  const anchor = nodeAnchor(chunk) ?? nodeAnchor(location?.parent);
+  if (!anchor) {
     return "";
   }
   try {
-    const node = Value.findClosestNode(chunk, env.findParent);
+    const node = Value.findClosestNode(anchor, env.findParent);
     return node.type ? ` (in ${node.type})` : "";
   } catch {
     return "";
   }
+}
+
+function nodeAnchor(
+  chunk: GraphChunk | undefined,
+): ObjectChunk | CompositeListChunk | undefined {
+  if (
+    chunk &&
+    (Value.isObjectValue(chunk) || Value.isCompositeListValue(chunk)) &&
+    !chunk.isAggregate
+  ) {
+    return chunk;
+  }
+  return undefined;
 }
 
 // Path of a chunk within its tree, e.g. ["listContainer", "items", 0, "value"].
@@ -406,7 +440,7 @@ function updateCompositeListValue(
       context,
       Value.resolveListItemChunk(base, index),
       itemDiff,
-      { kind: "listItem", index },
+      { kind: "listItem", parent: base, index },
     );
     if (updatedValue === base.data[index]) {
       continue;

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -99,25 +99,6 @@ function updateObjectValue(
         continue;
       }
 
-      // A node can have divergent chunks for the same field: an explicit null
-      //   (CompositeNull) in one chunk and a composite object/list in another (e.g. aliased
-      //   selections or a repeated node id in a single write, or a partial/errored write).
-      //   The one object/list difference computed for the node is applied to every chunk, so
-      //   skip the null chunk here instead of asserting on it downstream in updateValue.
-      if (
-        Value.isCompositeNullValue(value) &&
-        (Difference.isObjectDifference(fieldDiff) ||
-          Difference.isCompositeListDifference(fieldDiff))
-      ) {
-        context.env.logger?.warn(
-          divergentNullFieldMessage(context, base, fieldDiff, {
-            kind: "field",
-            fieldName: fieldInfo.name,
-          }),
-        );
-        continue;
-      }
-
       const updated = updateValue(context, value, fieldDiff, {
         kind: "field",
         fieldName: fieldInfo.name,
@@ -188,6 +169,18 @@ function updateValue(
       // Note: building the diagnostic message is expensive (path/type lookups), so it is
       //   constructed only on the failure path rather than eagerly passed to assert().
       if (!Value.isObjectValue(base)) {
+        // A node can have divergent chunks for the same position: an explicit null
+        //   (CompositeNull) or a missing value (CompositeUndefined) in one chunk and a
+        //   composite object in another (e.g. aliased selections, a repeated node id in a
+        //   single write, or a partial/errored write). The one difference computed for the
+        //   node is applied to every chunk, so skip the null/missing chunk instead of
+        //   crashing. Genuine type mismatches (e.g. leaf null, scalars) still assert.
+        if (isNullOrMissingCompositeBase(base)) {
+          context.env.logger?.warn(
+            divergentCompositeMessage(context, base, difference, location),
+          );
+          return getSourceValue(base);
+        }
         assert(
           false,
           incompatibleDifferenceMessage(context, base, difference, location),
@@ -198,6 +191,12 @@ function updateValue(
 
     case DifferenceKind.CompositeListDifference: {
       if (!Value.isCompositeListValue(base)) {
+        if (isNullOrMissingCompositeBase(base)) {
+          context.env.logger?.warn(
+            divergentCompositeMessage(context, base, difference, location),
+          );
+          return getSourceValue(base);
+        }
         assert(
           false,
           incompatibleDifferenceMessage(context, base, difference, location),
@@ -237,31 +236,46 @@ function incompatibleDifferenceMessage(
   );
 }
 
-// Diagnostic for a node field that resolves to an explicit null (CompositeNull) in one
-//   chunk while an incoming ObjectDifference/CompositeListDifference expects a composite
-//   value in another. Such divergent chunks are skipped (left for a later write to
-//   reconcile) rather than crashing; this message stays at least as descriptive as the
-//   previous invariant and adds best-effort, actionable advice.
-function divergentNullFieldMessage(
+// True when an incoming composite (Object/CompositeList) difference is being applied to a
+//   base that is an explicit null (CompositeNull) or missing (CompositeUndefined). This
+//   happens when a node has divergent chunks for the same field/list-item across a single
+//   operation; such chunks are skipped rather than crashing. Genuine type mismatches (leaf
+//   null, scalars, complex scalars, etc.) are excluded and still assert.
+function isNullOrMissingCompositeBase(base: GraphChunk): boolean {
+  return Value.isCompositeNullValue(base) || Value.isMissingValue(base);
+}
+
+// Diagnostic for a field or list item that resolves to an explicit null (CompositeNull) or
+//   a missing value (CompositeUndefined) in one chunk while an incoming composite
+//   Object/CompositeList difference expects an object/list in another. Such divergent chunks
+//   are skipped (left unchanged) rather than crashing; this message stays at least as
+//   descriptive as the previous invariant and adds best-effort, actionable advice.
+function divergentCompositeMessage(
   context: UpdateTreeContext,
-  base: ObjectChunk,
-  fieldDiff: ObjectDifference | CompositeListDifference,
+  base: GraphChunk,
+  difference: ObjectDifference | CompositeListDifference,
   location: UpdateValueLocation,
 ): string {
-  const isObject = Difference.isObjectDifference(fieldDiff);
+  const isObject = Difference.isObjectDifference(difference);
   const differenceKind = isObject
     ? "ObjectDifference"
     : "CompositeListDifference";
   const expectedShape = isObject ? "object" : "list";
-  const typeClause = incomingTypeClause(differenceTypeName(fieldDiff));
+  const typeClause = incomingTypeClause(differenceTypeName(difference));
+  const isNull = Value.isCompositeNullValue(base);
+  const baseDesc = isNull
+    ? "an explicit null (CompositeNull)"
+    : "missing (CompositeUndefined)";
+  const otherDesc = isNull ? "null" : "missing";
+  const position = location.kind === "field" ? "field" : "list item";
   const detail =
-    `field is an explicit null (CompositeNull) in this chunk, but the incoming ` +
-    `${differenceKind}${typeClause} expects a composite ${expectedShape}; the node has ` +
-    `divergent chunks for this field (null in one, ${expectedShape} in another). ` +
-    `Leaving the null value unchanged. This usually means the same node was written with ` +
-    `conflicting values in a single ` +
-    `operation (e.g. aliased selections or a repeated node id) or via a partial/errored ` +
-    `write; ensure such selections resolve this field consistently.`;
+    `${position} is ${baseDesc} in this chunk, but the incoming ${differenceKind}` +
+    `${typeClause} expects a composite ${expectedShape}; the node has divergent chunks for ` +
+    `this ${position} (${otherDesc} in one, ${expectedShape} in another). ` +
+    `Leaving the ${otherDesc} value unchanged. This usually means the same node was written ` +
+    `with conflicting values in a single operation (e.g. aliased selections or a repeated ` +
+    `node id) or via a partial/errored write; ensure such selections resolve this ` +
+    `${position} consistently.`;
   return updateFailureMessage(
     context,
     base,

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -99,6 +99,25 @@ function updateObjectValue(
         continue;
       }
 
+      // A node can have divergent chunks for the same field: an explicit null
+      //   (CompositeNull) in one chunk and a composite object/list in another (e.g. aliased
+      //   selections or a repeated node id in a single write, or a partial/errored write).
+      //   The one object/list difference computed for the node is applied to every chunk, so
+      //   skip the null chunk here instead of asserting on it downstream in updateValue.
+      if (
+        Value.isCompositeNullValue(value) &&
+        (Difference.isObjectDifference(fieldDiff) ||
+          Difference.isCompositeListDifference(fieldDiff))
+      ) {
+        context.env.logger?.warn(
+          divergentNullFieldMessage(context, base, fieldDiff, {
+            kind: "field",
+            fieldName: fieldInfo.name,
+          }),
+        );
+        continue;
+      }
+
       const updated = updateValue(context, value, fieldDiff, {
         kind: "field",
         fieldName: fieldInfo.name,
@@ -218,6 +237,40 @@ function incompatibleDifferenceMessage(
   );
 }
 
+// Diagnostic for a node field that resolves to an explicit null (CompositeNull) in one
+//   chunk while an incoming ObjectDifference/CompositeListDifference expects a composite
+//   value in another. Such divergent chunks are skipped (left for a later write to
+//   reconcile) rather than crashing; this message stays at least as descriptive as the
+//   previous invariant and adds best-effort, actionable advice.
+function divergentNullFieldMessage(
+  context: UpdateTreeContext,
+  base: ObjectChunk,
+  fieldDiff: ObjectDifference | CompositeListDifference,
+  location: UpdateValueLocation,
+): string {
+  const isObject = Difference.isObjectDifference(fieldDiff);
+  const differenceKind = isObject
+    ? "ObjectDifference"
+    : "CompositeListDifference";
+  const expectedShape = isObject ? "object" : "list";
+  const typeClause = incomingTypeClause(differenceTypeName(fieldDiff));
+  const detail =
+    `field is an explicit null (CompositeNull) in this chunk, but the incoming ` +
+    `${differenceKind}${typeClause} expects a composite ${expectedShape}; the node has ` +
+    `divergent chunks for this field (null in one, ${expectedShape} in another). ` +
+    `Leaving the null chunk unchanged - it will be reconciled on the next write of this ` +
+    `node. This usually means the same node was written with conflicting values in a single ` +
+    `operation (e.g. aliased selections or a repeated node id) or via a partial/errored ` +
+    `write; ensure such selections resolve this field consistently.`;
+  return updateFailureMessage(
+    context,
+    base,
+    detail,
+    location,
+    `Skipping update for "${context.operation.debugName}"`,
+  );
+}
+
 function incompatibleReplacementMessage(
   context: UpdateTreeContext,
   base: GraphChunk,
@@ -294,8 +347,8 @@ function updateFailureMessage(
   base: GraphChunk,
   detail: string,
   location?: UpdateValueLocation,
+  prefix = `Failed to update "${context.operation.debugName}"`,
 ): string {
-  const prefix = `Failed to update "${context.operation.debugName}"`;
   const basePath = chunkPath(context, base);
   const pathString = basePath?.length
     ? basePath.join(".")

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -258,8 +258,8 @@ function divergentNullFieldMessage(
     `field is an explicit null (CompositeNull) in this chunk, but the incoming ` +
     `${differenceKind}${typeClause} expects a composite ${expectedShape}; the node has ` +
     `divergent chunks for this field (null in one, ${expectedShape} in another). ` +
-    `Leaving the null chunk unchanged - it will be reconciled on the next write of this ` +
-    `node. This usually means the same node was written with conflicting values in a single ` +
+    `Leaving the null value unchanged. This usually means the same node was written with ` +
+    `conflicting values in a single ` +
     `operation (e.g. aliased selections or a repeated node id) or via a partial/errored ` +
     `write; ensure such selections resolve this field consistently.`;
   return updateFailureMessage(

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -316,17 +316,23 @@ function resolveFailurePath(
   base: GraphChunk,
   location?: UpdateValueLocation,
 ): string | undefined {
-  if (location) {
-    const parentPath = chunkPath(context, location.parent);
-    if (parentPath) {
-      return parentPath.concat(describeLocation(location)).join(".");
+  try {
+    if (location) {
+      const parentPath = chunkPath(context, location.parent);
+      if (parentPath) {
+        return parentPath.concat(describeLocation(location)).join(".");
+      }
     }
+    const basePath = chunkPath(context, base);
+    if (basePath?.length) {
+      return basePath.join(".");
+    }
+    return location ? describeLocation(location) : undefined;
+  } catch {
+    // Diagnostics only: the tree is already inconsistent when an invariant fires,
+    //   so path resolution is best-effort and must never throw over the invariant.
+    return undefined;
   }
-  const basePath = chunkPath(context, base);
-  if (basePath?.length) {
-    return basePath.join(".");
-  }
-  return location ? describeLocation(location) : undefined;
 }
 
 function describeLocation(location: UpdateValueLocation): string {


### PR DESCRIPTION
## Summary

Relaxes an overly strict invariant that caused `Invariant violation` during `cache.write`:

```
Invariant violation: Failed to update "<query>" at path <field>: expected CompositeNull, got ObjectDifference
Invariant violation: Failed to update "<query>" at path 0: expected CompositeUndefined, got ObjectDifference
```

## Root cause

A normalized node can end up with two chunks for the same position (a field **or a list item**): one where it is a real embedded object/list and another where it is an explicit `null` (`CompositeNull`) or missing (`CompositeUndefined`). This happens with aliased selections, a repeated node id in a single write, or a partial/errored write.

A later write produces a single `ObjectDifference`/`CompositeListDifference`, which `updateAffectedTrees` → `updateTree` → `resolveAffectedChunks` applies to **every** chunk of the node. On the null/missing chunk, `updateValue` hits `assert(isObjectValue(base))` / `assert(isCompositeListValue(base))` and throws. The pre-existing "inconsistent state" guard only covered *missing field* values (`isMissingValue` on undefined) — not explicit nulls, and not list items at all (list items reach `updateValue` via `updateCompositeListValue` without any guard).

## Fix

Consolidated the tolerance into `updateValue`: when an `ObjectDifference`/`CompositeListDifference` is applied to a base that is `CompositeNull` or `CompositeUndefined`, the chunk is **skipped** (left unchanged) and a descriptive `warn` is logged — for both field and list-item locations. Genuine type mismatches (leaf null, scalars, complex scalars) still assert.

The `warn` is at least as descriptive as the previous invariant and adds actionable advice, e.g.:

```
Skipping update for "<query>" at path <field> (in <Type>): field is an explicit null
(CompositeNull) in this chunk, but the incoming ObjectDifference expects a composite
object; the node has divergent chunks for this field (null in one, object in another).
Leaving the null value unchanged. This usually means the same node was written with
conflicting values in a single operation (e.g. aliased selections or a repeated node id)
or via a partial/errored write; ensure such selections resolve this field consistently.
```

## Incorporates #689 (full data path in invariant/diagnostic messages)

Merged #689, which reports the **full** data path (not just the last field/index) when the failing value is a non-addressable `CompositeNull`/`CompositeUndefined` — deriving the path from the parent chunk. This benefits both the remaining genuine-mismatch invariants **and** the new divergent-null warning above, which now also carries the full path (e.g. `listContainer.items.0.value (in Entity)`). #689's message builders are wrapped defensively so path resolution never throws over the invariant being reported.

Since this PR relaxes the very invariant #689's nested-`CompositeNull` test asserted, that test was updated to reflect the new behaviour: the divergent-null case no longer throws — it logs a warning that still contains the full path.

## Tests

- `regression.test.ts` — three tests (public `ForestRun` API only): divergent null/object at a field via aliases, via a repeated node id in a list, and at a **list-item** position.
- `updateObject.test.ts` — full path is reported for a nested non-addressable value; the divergent-null warning carries the full path without throwing; and the message builder degrades gracefully (still surfaces the invariant) when `findParent` throws.

## Validation

- `yarn test:own` — 25 suites / 1099 tests pass
- `yarn types` — clean
- `yarn lint` — 0 errors (only pre-existing warnings)