### PR TITLE
[HOTFIX] fragment naming conventions allows numbers in suffix

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-c17a6252-1ca6-4cf9-a62e-5d30f4e8629e.json
+++ b/change/@graphitation-graphql-eslint-rules-c17a6252-1ca6-4cf9-a62e-5d30f4e8629e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fragment suffixes now support numbers",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "77059398+vejrj@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/fragment-naming-conventions.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/fragment-naming-conventions.test.ts.snap
@@ -63,6 +63,21 @@ exports[`Invalid #4 1`] = `
 exports[`Invalid #5 1`] = `
 "#### ⌨️ Code
 
+      1 | fragment GraphqlEslintRulesUserFragment_2invalid on User { id name }
+
+#### ❌ Error
+
+    > 1 | fragment GraphqlEslintRulesUserFragment_2invalid on User { id name }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment should follow the naming conventions, the expected name is GraphqlEslintRulesUserFragment OR GraphqlEslintRulesUserFragment_optionalSuffix It's possible to chain suffixes using underscore
+
+#### 🔧 Autofix output
+
+      1 | fragment GraphqlEslintRulesUserFragment on User { id name }"
+`;
+
+exports[`Invalid #6 1`] = `
+"#### ⌨️ Code
+
       1 | fragment GraphqlEslintRulesUserFragment on User { id name }
 
 #### ❌ Error
@@ -71,7 +86,7 @@ exports[`Invalid #5 1`] = `
         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Filename should start with the package directory name: "graphql-eslint-rules""
 `;
 
-exports[`Invalid #6 1`] = `
+exports[`Invalid #7 1`] = `
 "#### ⌨️ Code
 
       1 | fragment GraphqlEslintRulesUserFragment on User { id name }

--- a/packages/graphql-eslint-rules/src/__tests__/fragment-naming-conventions.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/fragment-naming-conventions.test.ts
@@ -45,6 +45,21 @@ ruleTester.runGraphQLTests(
         filename: "src/graphql-eslint-rules-user-fragment.graphql",
         code: `fragment GraphqlEslintRulesUserFragment_optionalSuffix_anotherOptionalSuffix on User { id name }`,
       },
+      {
+        ...WITH_SCHEMA,
+        filename: "src/graphql-eslint-rules-user-fragment.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment_v2 on User { id name }`,
+      },
+      {
+        ...WITH_SCHEMA,
+        filename: "src/graphql-eslint-rules-user-fragment.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment_someV2Suffix on User { id name }`,
+      },
+      {
+        ...WITH_SCHEMA,
+        filename: "src/graphql-eslint-rules-user-fragment.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment_suffix2 on User { id name }`,
+      },
     ],
     invalid: [
       {
@@ -84,6 +99,17 @@ ruleTester.runGraphQLTests(
         ...WITH_SCHEMA,
         filename: "src/graphql-eslint-rules-user-query.graphql",
         code: `fragment UserFragment on User { id name }`,
+        output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
+        errors: [
+          {
+            message: errorMessage,
+          },
+        ],
+      },
+      {
+        ...WITH_SCHEMA,
+        filename: "src/graphql-eslint-rules-user-query.graphql",
+        code: `fragment GraphqlEslintRulesUserFragment_2invalid on User { id name }`,
         output: "fragment GraphqlEslintRulesUserFragment on User { id name }",
         errors: [
           {

--- a/packages/graphql-eslint-rules/src/fragment-naming-conventions.ts
+++ b/packages/graphql-eslint-rules/src/fragment-naming-conventions.ts
@@ -3,7 +3,7 @@ import { pascalCase, getFileInfo } from "./utils";
 import { reportError } from "./operation-naming-conventions";
 
 const OPERATIONS = ["Query", "Mutation", "Subscription"];
-const CONDITIONAL_SUFFIX_REGEXP = /^[a-z]+(?:[A-Z][a-z]+)*$/;
+const CONDITIONAL_SUFFIX_REGEXP = /^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$/;
 
 function getMissingLastDirectoryPrefixErrorMessage(lastDirectory: string) {
   return `Filename should start with the package directory name: "${lastDirectory}"`;


### PR DESCRIPTION
# Changes

## feat: support numbers in fragment name optional suffixes

Updated `fragment-naming-conventions` rule to allow digits in optional suffixes (the part after `_`), with the restriction that a suffix cannot start with a number.

**Examples:**
- `MyFragment_v2` — valid
- `MyFragment_someV2Suffix` — valid
- `MyFragment_suffix2` — valid
- `MyFragment_2invalid` — invalid (digit as first character)
