### PR TITLE
feat(graphql-eslint-rules): recursively resolve fragments and support nested keyFields

### DIFF
--- a/change/@graphitation-graphql-eslint-rules-d9bba92a-6a32-4d06-ac86-865e8419d6bf.json
+++ b/change/@graphitation-graphql-eslint-rules-d9bba92a-6a32-4d06-ac86-865e8419d6bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(graphql-eslint-rules): recursively resolve fragments and support nested keyFields",
+  "packageName": "@graphitation/graphql-eslint-rules",
+  "email": "mnovikov@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/graphql-eslint-rules/src/__tests__/__snapshots__/missing-apollo-key-fields.test.ts.snap
+++ b/packages/graphql-eslint-rules/src/__tests__/__snapshots__/missing-apollo-key-fields.test.ts.snap
@@ -13,6 +13,15 @@ exports[`Invalid #1 1`] = `
           "keyFields": [
             "objectId"
           ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
         }
       }
     }
@@ -41,6 +50,15 @@ exports[`Invalid #2 1`] = `
           "keyFields": [
             "objectId"
           ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
         }
       }
     }
@@ -54,4 +72,147 @@ exports[`Invalid #2 1`] = `
 
       1 | query { keyField { objectId
       2 | id name } }"
+`;
+
+exports[`Invalid #3 1`] = `
+"#### ⌨️ Code
+
+      1 | query { hasId { name ...NestedNameOnly } }
+
+#### ⚙️ Options
+
+    {
+      "typePolicies": {
+        "KeyFieldType": {
+          "keyFields": [
+            "objectId"
+          ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
+        }
+      }
+    }
+
+#### ❌ Error
+
+    > 1 | query { hasId { name ...NestedNameOnly } }
+        |               ^^^^^^^^^^^^^^^^^^^^^^^^^ The key-field "id" must be selected for proper Apollo Client store denormalisation purposes.
+
+#### 🔧 Autofix output
+
+      1 | query { hasId { id
+      2 | name ...NestedNameOnly } }"
+`;
+
+exports[`Invalid #4 1`] = `
+"#### ⌨️ Code
+
+      1 | query { books { author { name } } }
+
+#### ⚙️ Options
+
+    {
+      "typePolicies": {
+        "KeyFieldType": {
+          "keyFields": [
+            "objectId"
+          ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
+        }
+      }
+    }
+
+#### ❌ Error
+
+    > 1 | query { books { author { name } } }
+        |               ^^^^^^^^^^^^^^^^^^ The key-field "title" must be selected for proper Apollo Client store denormalisation purposes.
+
+#### 🔧 Autofix output
+
+      1 | query { books { title
+      2 | author { name } } }"
+`;
+
+exports[`Invalid #5 1`] = `
+"#### ⌨️ Code
+
+      1 | query { books { title author { age } } }
+
+#### ⚙️ Options
+
+    {
+      "typePolicies": {
+        "KeyFieldType": {
+          "keyFields": [
+            "objectId"
+          ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
+        }
+      }
+    }
+
+#### ❌ Error
+
+    > 1 | query { books { title author { age } } }
+        |               ^^^^^^^^^^^^^^^^^^^^^^^ The key-field "author.name" must be selected for proper Apollo Client store denormalisation purposes."
+`;
+
+exports[`Invalid #6 1`] = `
+"#### ⌨️ Code
+
+      1 | query { books { author { age } } }
+
+#### ⚙️ Options
+
+    {
+      "typePolicies": {
+        "KeyFieldType": {
+          "keyFields": [
+            "objectId"
+          ]
+        },
+        "Book": {
+          "keyFields": [
+            "title",
+            "author",
+            [
+              "name"
+            ]
+          ]
+        }
+      }
+    }
+
+#### ❌ Error
+
+    > 1 | query { books { author { age } } }
+        |               ^^^^^^^^^^^^^^^^^ The key-fields "title and author.name" must be selected for proper Apollo Client store denormalisation purposes.
+
+#### 🔧 Autofix output
+
+      1 | query { books { title
+      2 | author { age } } }"
 `;

--- a/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
@@ -19,6 +19,7 @@ const TEST_SCHEMA = /* GraphQL */ `
     vehicles: [Vehicle!]!
     keyField: [KeyFieldType]!
     flying: [Flying!]!
+    books: [Book!]!
   }
   type NoId {
     name: String!
@@ -45,6 +46,14 @@ const TEST_SCHEMA = /* GraphQL */ `
     id: ID!
     name: String!
   }
+  type Book {
+    title: String!
+    author: Author!
+  }
+  type Author {
+    name: String!
+    age: Int
+  }
 `;
 
 const WITH_SCHEMA = {
@@ -54,6 +63,31 @@ const WITH_SCHEMA = {
       `fragment HasIdFields on HasId {
         id
       }`,
+      `fragment NestedHasIdFields on HasId {
+        ...HasIdFields
+      }`,
+      `fragment DeeplyNestedHasIdFields on HasId {
+        ...NestedHasIdFields
+      }`,
+      `fragment NestedNameOnly on HasId {
+        ...NameOnly
+      }`,
+      `fragment NameOnly on HasId {
+        name
+      }`,
+      `fragment InlineFragmentWithId on Vehicle {
+        ...on Car {
+          id
+        }
+      }`,
+      `fragment BookAuthorName on Book {
+        author {
+          name
+        }
+      }`,
+      `fragment AuthorName on Author {
+        name
+      }`,
     ],
   },
 };
@@ -62,6 +96,9 @@ const ruleTester = new GraphQLRuleTester();
 export const typePolicies = {
   KeyFieldType: {
     keyFields: ["objectId"],
+  },
+  Book: {
+    keyFields: ["title", "author", ["name"]],
   },
 };
 
@@ -88,6 +125,41 @@ ruleTester.runGraphQLTests(
       {
         ...WITH_SCHEMA,
         code: `query { hasId { ...HasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { ...NestedHasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { ...DeeplyNestedHasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { vehicles { ...InlineFragmentWithId } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { name } } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { name age } } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title ...BookAuthorName } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { ...AuthorName } } }`,
         options: [{ typePolicies }],
       },
       {
@@ -130,6 +202,49 @@ ruleTester.runGraphQLTests(
         errors: [
           {
             message: `The key-field "objectId" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { name ...NestedNameOnly } }`,
+        output: `query { hasId { id\nname ...NestedNameOnly } }`,
+        errors: [
+          {
+            message: `The key-field "id" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { author { name } } }`,
+        output: `query { books { title\nauthor { name } } }`,
+        errors: [
+          {
+            message: `The key-field "title" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { age } } }`,
+        errors: [
+          {
+            message: `The key-field "author.name" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { author { age } } }`,
+        output: `query { books { title\nauthor { age } } }`,
+        errors: [
+          {
+            message: `The key-fields "title and author.name" must be selected for proper Apollo Client store denormalisation purposes.`,
           },
         ],
         options: [{ typePolicies }],

--- a/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
@@ -10,7 +10,9 @@ import {
   GraphQLRuleTester,
   ParserOptions,
 } from "@graphql-eslint/eslint-plugin";
-import missingApolloKeyFieldsRule from "../missing-apollo-key-fields";
+import missingApolloKeyFieldsRule, {
+  parseKeySpecifier,
+} from "../missing-apollo-key-fields";
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {
@@ -19,6 +21,7 @@ const TEST_SCHEMA = /* GraphQL */ `
     vehicles: [Vehicle!]!
     keyField: [KeyFieldType]!
     flying: [Flying!]!
+    books: [Book!]!
   }
   type NoId {
     name: String!
@@ -45,6 +48,14 @@ const TEST_SCHEMA = /* GraphQL */ `
     id: ID!
     name: String!
   }
+  type Book {
+    title: String!
+    author: Author!
+  }
+  type Author {
+    name: String!
+    age: Int
+  }
 `;
 
 const WITH_SCHEMA = {
@@ -54,6 +65,31 @@ const WITH_SCHEMA = {
       `fragment HasIdFields on HasId {
         id
       }`,
+      `fragment NestedHasIdFields on HasId {
+        ...HasIdFields
+      }`,
+      `fragment DeeplyNestedHasIdFields on HasId {
+        ...NestedHasIdFields
+      }`,
+      `fragment NestedNameOnly on HasId {
+        ...NameOnly
+      }`,
+      `fragment NameOnly on HasId {
+        name
+      }`,
+      `fragment InlineFragmentWithId on Vehicle {
+        ...on Car {
+          id
+        }
+      }`,
+      `fragment BookAuthorName on Book {
+        author {
+          name
+        }
+      }`,
+      `fragment AuthorName on Author {
+        name
+      }`,
     ],
   },
 };
@@ -62,6 +98,9 @@ const ruleTester = new GraphQLRuleTester();
 export const typePolicies = {
   KeyFieldType: {
     keyFields: ["objectId"],
+  },
+  Book: {
+    keyFields: ["title", "author", ["name"]],
   },
 };
 
@@ -88,6 +127,41 @@ ruleTester.runGraphQLTests(
       {
         ...WITH_SCHEMA,
         code: `query { hasId { ...HasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { ...NestedHasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { ...DeeplyNestedHasIdFields } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { vehicles { ...InlineFragmentWithId } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { name } } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { name age } } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title ...BookAuthorName } }`,
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { ...AuthorName } } }`,
         options: [{ typePolicies }],
       },
       {
@@ -134,6 +208,88 @@ ruleTester.runGraphQLTests(
         ],
         options: [{ typePolicies }],
       },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { name ...NestedNameOnly } }`,
+        output: `query { hasId { id\nname ...NestedNameOnly } }`,
+        errors: [
+          {
+            message: `The key-field "id" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { author { name } } }`,
+        output: `query { books { title\nauthor { name } } }`,
+        errors: [
+          {
+            message: `The key-field "title" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { title author { age } } }`,
+        errors: [
+          {
+            message: `The key-field "author.name" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { books { author { age } } }`,
+        output: `query { books { title\nauthor { age } } }`,
+        errors: [
+          {
+            message: `The key-fields "title and author.name" must be selected for proper Apollo Client store denormalisation purposes.`,
+          },
+        ],
+        options: [{ typePolicies }],
+      },
     ],
   },
 );
+
+describe("parseKeySpecifier", () => {
+  it("parses a flat list of string key fields", () => {
+    expect(parseKeySpecifier(["objectId"])).toEqual([{ name: "objectId" }]);
+  });
+
+  it("parses nested key specifiers attached to the preceding field", () => {
+    expect(parseKeySpecifier(["title", "author", ["name"]])).toEqual([
+      { name: "title" },
+      { name: "author", nested: [{ name: "name" }] },
+    ]);
+  });
+
+  it("parses deeply nested key specifiers", () => {
+    expect(
+      parseKeySpecifier(["author", ["name", "address", ["street"]]]),
+    ).toEqual([
+      {
+        name: "author",
+        nested: [
+          { name: "name" },
+          { name: "address", nested: [{ name: "street" }] },
+        ],
+      },
+    ]);
+  });
+
+  it("throws when a key field is neither a string nor a nested specifier", () => {
+    expect(() => parseKeySpecifier([42 as unknown as string])).toThrowError(
+      "Expected keyFields to be an array of strings and nested key specifiers",
+    );
+  });
+
+  it("throws when a nested specifier does not follow a field name", () => {
+    expect(() => parseKeySpecifier([["name"]])).toThrowError(
+      "Expected a field name to precede nested keyFields",
+    );
+  });
+});

--- a/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
+++ b/packages/graphql-eslint-rules/src/__tests__/missing-apollo-key-fields.test.ts
@@ -12,7 +12,9 @@ import {
 } from "@graphql-eslint/eslint-plugin";
 import missingApolloKeyFieldsRule, {
   parseKeySpecifier,
+  keyFieldsForType,
 } from "../missing-apollo-key-fields";
+import { buildSchema, GraphQLObjectType } from "graphql";
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {
@@ -166,6 +168,16 @@ ruleTester.runGraphQLTests(
       },
       {
         ...WITH_SCHEMA,
+        code: `query { hasId { name } }`,
+        options: [{ typePolicies: { HasId: { keyFields: false } } }],
+      },
+      {
+        ...WITH_SCHEMA,
+        code: `query { hasId { name } }`,
+        options: [{ typePolicies: { HasId: { keyFields: () => "id" } } }],
+      },
+      {
+        ...WITH_SCHEMA,
         code: `query { vehicles { id ...on Car { id mileage } } }`,
         options: [{ typePolicies }],
       },
@@ -290,6 +302,38 @@ describe("parseKeySpecifier", () => {
   it("throws when a nested specifier does not follow a field name", () => {
     expect(() => parseKeySpecifier([["name"]])).toThrowError(
       "Expected a field name to precede nested keyFields",
+    );
+  });
+});
+
+describe("keyFieldsForType", () => {
+  const schema = buildSchema(TEST_SCHEMA);
+  const hasId = schema.getType("HasId") as GraphQLObjectType;
+  const noId = schema.getType("NoId") as GraphQLObjectType;
+
+  it("falls back to `id` when no type policy is configured", () => {
+    expect(keyFieldsForType(hasId, {})).toEqual([{ name: "id" }]);
+  });
+
+  it("returns no key fields for a type without `id` and no policy", () => {
+    expect(keyFieldsForType(noId, {})).toEqual([]);
+  });
+
+  it("returns no required key fields when normalization is disabled with `false`", () => {
+    expect(keyFieldsForType(hasId, { HasId: { keyFields: false } })).toEqual(
+      [],
+    );
+  });
+
+  it("returns no required key fields when keyFields is a function", () => {
+    expect(
+      keyFieldsForType(hasId, { HasId: { keyFields: () => "id" } }),
+    ).toEqual([]);
+  });
+
+  it("parses configured array key fields", () => {
+    expect(keyFieldsForType(hasId, { HasId: { keyFields: ["name"] } })).toEqual(
+      [{ name: "name" }],
     );
   });
 });

--- a/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
+++ b/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
@@ -31,6 +31,28 @@ type TypePolicies = Record<
   { keyFields?: KeySpecifier | false | (() => unknown) }
 >;
 type KeySpecifier = (string | KeySpecifier)[];
+interface KeyFieldSpec {
+  name: string;
+  nested?: KeyFieldSpec[];
+}
+
+function parseKeySpecifier(specifier: KeySpecifier): KeyFieldSpec[] {
+  const specs: KeyFieldSpec[] = [];
+  for (const keyField of specifier) {
+    if (typeof keyField === "string") {
+      specs.push({ name: keyField });
+    } else if (Array.isArray(keyField)) {
+      const previous = specs[specs.length - 1];
+      if (!previous) {
+        throw new Error("Expected a field name to precede nested keyFields");
+      }
+      previous.nested = parseKeySpecifier(keyField);
+    } else {
+      throw new Error("Expected keyFields to be array of strings");
+    }
+  }
+  return specs;
+}
 
 function getBaseType(type: GraphQLOutputType): GraphQLNamedType {
   if (isNonNullType(type) || isListType(type)) {
@@ -43,42 +65,17 @@ function getBaseType(type: GraphQLOutputType): GraphQLNamedType {
 function keyFieldsForType(
   type: GraphQLObjectType | GraphQLInterfaceType,
   typePolicies: TypePolicies,
-) {
-  const keyFields: string[] = [];
+): KeyFieldSpec[] {
   const typePolicy = typePolicies[type.name];
   if (typePolicy && typePolicy.keyFields) {
     if (Array.isArray(typePolicy.keyFields)) {
-      typePolicy.keyFields.forEach((keyField) => {
-        if (typeof keyField === "string") {
-          keyFields.push(keyField);
-        } else {
-          throw new Error("Expected keyFields to be array of strings");
-        }
-      });
-    } else {
-      throw new Error("Expected keyFields to be array of strings");
+      return parseKeySpecifier(typePolicy.keyFields);
     }
+    throw new Error("Expected keyFields to be array of strings");
   } else if (type.getFields().id !== undefined) {
-    keyFields.push(DEFAULT_KEY_FIELD_NAME);
+    return [{ name: DEFAULT_KEY_FIELD_NAME }];
   }
-  return keyFields;
-}
-
-function getKeyFieldsObjectForCheck(keyFields: string[]) {
-  return keyFields.reduce((acc, id) => {
-    acc[id] = false;
-    return acc;
-  }, {} as Record<string, boolean>);
-}
-
-function getUnusedKeyFields(keyFieldsObjectForCheck: Record<string, boolean>) {
-  return Object.entries(keyFieldsObjectForCheck).reduce((acc, [key, value]) => {
-    if (value) {
-      return acc;
-    }
-    acc.push(key);
-    return acc;
-  }, [] as string[]);
+  return [];
 }
 
 function hasIdFieldInInterfaceSelectionSet(node: unknown, keyFields: string[]) {
@@ -190,54 +187,122 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
             const checkedFragmentSpreads = new Set();
 
             if (keyFields.length) {
-              const keyFieldsFound = getKeyFieldsObjectForCheck(keyFields);
-
-              for (const selection of node.selections) {
-                if (
-                  selection.kind === "Field" &&
-                  keyFieldsFound[selection.name.value] === false
-                ) {
-                  keyFieldsFound[selection.name.value] = true;
-                } else if (selection.kind === "InlineFragment") {
-                  for (const fragmentSelection of selection.selectionSet
-                    ?.selections || []) {
-                    if (
-                      fragmentSelection.kind === "Field" &&
-                      keyFieldsFound[fragmentSelection.name.value] === false
-                    ) {
-                      keyFieldsFound[fragmentSelection.name.value] = true;
-                    }
+              const gatherPresentFields = (
+                selections: readonly ASTNode[] | undefined,
+                visited: Set<string>,
+              ): Map<string, (readonly ASTNode[])[]> => {
+                const fields = new Map<string, (readonly ASTNode[])[]>();
+                const mergeInto = (
+                  source: Map<string, (readonly ASTNode[])[]>,
+                ) => {
+                  for (const [name, subs] of source) {
+                    fields.set(name, (fields.get(name) ?? []).concat(subs));
                   }
-                } else if (siblings && selection.kind === "FragmentSpread") {
-                  const foundSpread = siblings.getFragment(
-                    selection.name.value,
-                  );
+                };
 
-                  if (foundSpread[0]) {
-                    checkedFragmentSpreads.add(
-                      foundSpread[0].document.name.value,
+                for (const selection of selections || []) {
+                  if (selection.kind === "Field") {
+                    const name = selection.name.value;
+                    const existing = fields.get(name) ?? [];
+                    if (selection.selectionSet?.selections) {
+                      existing.push(selection.selectionSet.selections);
+                    }
+                    fields.set(name, existing);
+                  } else if (selection.kind === "InlineFragment") {
+                    mergeInto(
+                      gatherPresentFields(
+                        selection.selectionSet?.selections,
+                        visited,
+                      ),
                     );
+                  } else if (siblings && selection.kind === "FragmentSpread") {
+                    const fragmentName = selection.name.value;
+                    if (visited.has(fragmentName)) {
+                      continue;
+                    }
+                    visited.add(fragmentName);
 
-                    for (const fragmentSpreadSelection of foundSpread[0]
-                      .document.selectionSet?.selections || []) {
-                      if (
-                        fragmentSpreadSelection.kind === "Field" &&
-                        keyFieldsFound[fragmentSpreadSelection.name.value] ===
-                          false
-                      ) {
-                        keyFieldsFound[fragmentSpreadSelection.name.value] =
-                          true;
-                      }
+                    const foundSpread = siblings.getFragment(fragmentName);
+                    if (foundSpread[0]) {
+                      checkedFragmentSpreads.add(
+                        foundSpread[0].document.name.value,
+                      );
+                      mergeInto(
+                        gatherPresentFields(
+                          foundSpread[0].document.selectionSet
+                            ?.selections as unknown as readonly ASTNode[],
+                          visited,
+                        ),
+                      );
                     }
                   }
                 }
-              }
+                return fields;
+              };
 
-              const unusedKeyFields = getUnusedKeyFields(keyFieldsFound);
+              const getUnusedKeyFieldPaths = (
+                specs: KeyFieldSpec[],
+                presentFields: Map<string, (readonly ASTNode[])[]>,
+              ): string[] => {
+                const unused: string[] = [];
+                for (const spec of specs) {
+                  const occurrences = presentFields.get(spec.name);
+                  if (!occurrences) {
+                    unused.push(spec.name);
+                    continue;
+                  }
+                  if (spec.nested && spec.nested.length) {
+                    const nestedFields = new Map<
+                      string,
+                      (readonly ASTNode[])[]
+                    >();
+                    for (const subSelections of occurrences) {
+                      const gathered = gatherPresentFields(
+                        subSelections,
+                        new Set<string>(),
+                      );
+                      for (const [name, subs] of gathered) {
+                        nestedFields.set(
+                          name,
+                          (nestedFields.get(name) ?? []).concat(subs),
+                        );
+                      }
+                    }
+                    for (const nestedUnused of getUnusedKeyFieldPaths(
+                      spec.nested,
+                      nestedFields,
+                    )) {
+                      unused.push(`${spec.name}.${nestedUnused}`);
+                    }
+                  }
+                }
+                return unused;
+              };
+
+              const presentFields = gatherPresentFields(
+                node.selections as unknown as readonly ASTNode[],
+                new Set<string>(),
+              );
+              const unusedKeyFields = getUnusedKeyFieldPaths(
+                keyFields,
+                presentFields,
+              );
+              const keyFieldNames = keyFields.map((spec) => spec.name);
+
               if (
                 unusedKeyFields.length &&
-                !hasIdFieldInInterfaceSelectionSet(node, keyFields)
+                !hasIdFieldInInterfaceSelectionSet(node, keyFieldNames)
               ) {
+                const nestedKeyFieldNames = new Set(
+                  keyFields
+                    .filter((spec) => spec.nested && spec.nested.length)
+                    .map((spec) => spec.name),
+                );
+                const fixableKeyFields = unusedKeyFields.filter(
+                  (field) =>
+                    !field.includes(".") && !nestedKeyFieldNames.has(field),
+                );
+
                 context.report({
                   node: node,
                   message: `The key-field${
@@ -250,7 +315,7 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
                         unusedKeyFields[unusedKeyFields.length - 1]
                   }" must be selected for proper Apollo Client store denormalisation purposes.`,
                   fix(fixer) {
-                    if (!node.selections.length) {
+                    if (!fixableKeyFields.length || !node.selections.length) {
                       return null;
                     }
 
@@ -263,7 +328,7 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
                     return fixer.insertTextBefore(
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                       firstSelection as any,
-                      `${unusedKeyFields.join(`\n`)}\n`,
+                      `${fixableKeyFields.join(`\n`)}\n`,
                     );
                   },
                 });

--- a/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
+++ b/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
@@ -48,7 +48,9 @@ function parseKeySpecifier(specifier: KeySpecifier): KeyFieldSpec[] {
       }
       previous.nested = parseKeySpecifier(keyField);
     } else {
-      throw new Error("Expected keyFields to be array of strings");
+      throw new Error(
+        "Expected keyFields to be an array of strings and nested key specifiers",
+      );
     }
   }
   return specs;
@@ -71,7 +73,9 @@ function keyFieldsForType(
     if (Array.isArray(typePolicy.keyFields)) {
       return parseKeySpecifier(typePolicy.keyFields);
     }
-    throw new Error("Expected keyFields to be array of strings");
+    throw new Error(
+      "Expected keyFields to be an array of strings and nested key specifiers",
+    );
   } else if (type.getFields().id !== undefined) {
     return [{ name: DEFAULT_KEY_FIELD_NAME }];
   }

--- a/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
+++ b/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
@@ -30,7 +30,31 @@ type TypePolicies = Record<
   string,
   { keyFields?: KeySpecifier | false | (() => unknown) }
 >;
-type KeySpecifier = (string | KeySpecifier)[];
+export type KeySpecifier = (string | KeySpecifier)[];
+export interface KeyFieldSpec {
+  name: string;
+  nested?: KeyFieldSpec[];
+}
+
+export function parseKeySpecifier(specifier: KeySpecifier): KeyFieldSpec[] {
+  const specs: KeyFieldSpec[] = [];
+  for (const keyField of specifier) {
+    if (typeof keyField === "string") {
+      specs.push({ name: keyField });
+    } else if (Array.isArray(keyField)) {
+      const previous = specs[specs.length - 1];
+      if (!previous) {
+        throw new Error("Expected a field name to precede nested keyFields");
+      }
+      previous.nested = parseKeySpecifier(keyField);
+    } else {
+      throw new Error(
+        "Expected keyFields to be an array of strings and nested key specifiers",
+      );
+    }
+  }
+  return specs;
+}
 
 function getBaseType(type: GraphQLOutputType): GraphQLNamedType {
   if (isNonNullType(type) || isListType(type)) {
@@ -43,42 +67,19 @@ function getBaseType(type: GraphQLOutputType): GraphQLNamedType {
 function keyFieldsForType(
   type: GraphQLObjectType | GraphQLInterfaceType,
   typePolicies: TypePolicies,
-) {
-  const keyFields: string[] = [];
+): KeyFieldSpec[] {
   const typePolicy = typePolicies[type.name];
   if (typePolicy && typePolicy.keyFields) {
     if (Array.isArray(typePolicy.keyFields)) {
-      typePolicy.keyFields.forEach((keyField) => {
-        if (typeof keyField === "string") {
-          keyFields.push(keyField);
-        } else {
-          throw new Error("Expected keyFields to be array of strings");
-        }
-      });
-    } else {
-      throw new Error("Expected keyFields to be array of strings");
+      return parseKeySpecifier(typePolicy.keyFields);
     }
+    throw new Error(
+      "Expected keyFields to be an array of strings and nested key specifiers",
+    );
   } else if (type.getFields().id !== undefined) {
-    keyFields.push(DEFAULT_KEY_FIELD_NAME);
+    return [{ name: DEFAULT_KEY_FIELD_NAME }];
   }
-  return keyFields;
-}
-
-function getKeyFieldsObjectForCheck(keyFields: string[]) {
-  return keyFields.reduce((acc, id) => {
-    acc[id] = false;
-    return acc;
-  }, {} as Record<string, boolean>);
-}
-
-function getUnusedKeyFields(keyFieldsObjectForCheck: Record<string, boolean>) {
-  return Object.entries(keyFieldsObjectForCheck).reduce((acc, [key, value]) => {
-    if (value) {
-      return acc;
-    }
-    acc.push(key);
-    return acc;
-  }, [] as string[]);
+  return [];
 }
 
 function hasIdFieldInInterfaceSelectionSet(node: unknown, keyFields: string[]) {
@@ -190,54 +191,122 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
             const checkedFragmentSpreads = new Set();
 
             if (keyFields.length) {
-              const keyFieldsFound = getKeyFieldsObjectForCheck(keyFields);
-
-              for (const selection of node.selections) {
-                if (
-                  selection.kind === "Field" &&
-                  keyFieldsFound[selection.name.value] === false
-                ) {
-                  keyFieldsFound[selection.name.value] = true;
-                } else if (selection.kind === "InlineFragment") {
-                  for (const fragmentSelection of selection.selectionSet
-                    ?.selections || []) {
-                    if (
-                      fragmentSelection.kind === "Field" &&
-                      keyFieldsFound[fragmentSelection.name.value] === false
-                    ) {
-                      keyFieldsFound[fragmentSelection.name.value] = true;
-                    }
+              const gatherPresentFields = (
+                selections: readonly ASTNode[] | undefined,
+                visited: Set<string>,
+              ): Map<string, (readonly ASTNode[])[]> => {
+                const fields = new Map<string, (readonly ASTNode[])[]>();
+                const mergeInto = (
+                  source: Map<string, (readonly ASTNode[])[]>,
+                ) => {
+                  for (const [name, subs] of source) {
+                    fields.set(name, (fields.get(name) ?? []).concat(subs));
                   }
-                } else if (siblings && selection.kind === "FragmentSpread") {
-                  const foundSpread = siblings.getFragment(
-                    selection.name.value,
-                  );
+                };
 
-                  if (foundSpread[0]) {
-                    checkedFragmentSpreads.add(
-                      foundSpread[0].document.name.value,
+                for (const selection of selections || []) {
+                  if (selection.kind === "Field") {
+                    const name = selection.name.value;
+                    const existing = fields.get(name) ?? [];
+                    if (selection.selectionSet?.selections) {
+                      existing.push(selection.selectionSet.selections);
+                    }
+                    fields.set(name, existing);
+                  } else if (selection.kind === "InlineFragment") {
+                    mergeInto(
+                      gatherPresentFields(
+                        selection.selectionSet?.selections,
+                        visited,
+                      ),
                     );
+                  } else if (siblings && selection.kind === "FragmentSpread") {
+                    const fragmentName = selection.name.value;
+                    if (visited.has(fragmentName)) {
+                      continue;
+                    }
+                    visited.add(fragmentName);
 
-                    for (const fragmentSpreadSelection of foundSpread[0]
-                      .document.selectionSet?.selections || []) {
-                      if (
-                        fragmentSpreadSelection.kind === "Field" &&
-                        keyFieldsFound[fragmentSpreadSelection.name.value] ===
-                          false
-                      ) {
-                        keyFieldsFound[fragmentSpreadSelection.name.value] =
-                          true;
-                      }
+                    const foundSpread = siblings.getFragment(fragmentName);
+                    if (foundSpread[0]) {
+                      checkedFragmentSpreads.add(
+                        foundSpread[0].document.name.value,
+                      );
+                      mergeInto(
+                        gatherPresentFields(
+                          foundSpread[0].document.selectionSet
+                            ?.selections as unknown as readonly ASTNode[],
+                          visited,
+                        ),
+                      );
                     }
                   }
                 }
-              }
+                return fields;
+              };
 
-              const unusedKeyFields = getUnusedKeyFields(keyFieldsFound);
+              const getUnusedKeyFieldPaths = (
+                specs: KeyFieldSpec[],
+                presentFields: Map<string, (readonly ASTNode[])[]>,
+              ): string[] => {
+                const unused: string[] = [];
+                for (const spec of specs) {
+                  const occurrences = presentFields.get(spec.name);
+                  if (!occurrences) {
+                    unused.push(spec.name);
+                    continue;
+                  }
+                  if (spec.nested && spec.nested.length) {
+                    const nestedFields = new Map<
+                      string,
+                      (readonly ASTNode[])[]
+                    >();
+                    for (const subSelections of occurrences) {
+                      const gathered = gatherPresentFields(
+                        subSelections,
+                        new Set<string>(),
+                      );
+                      for (const [name, subs] of gathered) {
+                        nestedFields.set(
+                          name,
+                          (nestedFields.get(name) ?? []).concat(subs),
+                        );
+                      }
+                    }
+                    for (const nestedUnused of getUnusedKeyFieldPaths(
+                      spec.nested,
+                      nestedFields,
+                    )) {
+                      unused.push(`${spec.name}.${nestedUnused}`);
+                    }
+                  }
+                }
+                return unused;
+              };
+
+              const presentFields = gatherPresentFields(
+                node.selections as unknown as readonly ASTNode[],
+                new Set<string>(),
+              );
+              const unusedKeyFields = getUnusedKeyFieldPaths(
+                keyFields,
+                presentFields,
+              );
+              const keyFieldNames = keyFields.map((spec) => spec.name);
+
               if (
                 unusedKeyFields.length &&
-                !hasIdFieldInInterfaceSelectionSet(node, keyFields)
+                !hasIdFieldInInterfaceSelectionSet(node, keyFieldNames)
               ) {
+                const nestedKeyFieldNames = new Set(
+                  keyFields
+                    .filter((spec) => spec.nested && spec.nested.length)
+                    .map((spec) => spec.name),
+                );
+                const fixableKeyFields = unusedKeyFields.filter(
+                  (field) =>
+                    !field.includes(".") && !nestedKeyFieldNames.has(field),
+                );
+
                 context.report({
                   node: node,
                   message: `The key-field${
@@ -250,7 +319,7 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
                         unusedKeyFields[unusedKeyFields.length - 1]
                   }" must be selected for proper Apollo Client store denormalisation purposes.`,
                   fix(fixer) {
-                    if (!node.selections.length) {
+                    if (!fixableKeyFields.length || !node.selections.length) {
                       return null;
                     }
 
@@ -263,7 +332,7 @@ const missingApolloKeyFieldsRule: GraphQLESLintRule<
                     return fixer.insertTextBefore(
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                       firstSelection as any,
-                      `${unusedKeyFields.join(`\n`)}\n`,
+                      `${fixableKeyFields.join(`\n`)}\n`,
                     );
                   },
                 });

--- a/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
+++ b/packages/graphql-eslint-rules/src/missing-apollo-key-fields.ts
@@ -64,19 +64,28 @@ function getBaseType(type: GraphQLOutputType): GraphQLNamedType {
   return type;
 }
 
-function keyFieldsForType(
+export function keyFieldsForType(
   type: GraphQLObjectType | GraphQLInterfaceType,
   typePolicies: TypePolicies,
 ): KeyFieldSpec[] {
   const typePolicy = typePolicies[type.name];
-  if (typePolicy && typePolicy.keyFields) {
-    if (Array.isArray(typePolicy.keyFields)) {
-      return parseKeySpecifier(typePolicy.keyFields);
+  if (typePolicy && "keyFields" in typePolicy) {
+    const { keyFields } = typePolicy;
+    if (Array.isArray(keyFields)) {
+      return parseKeySpecifier(keyFields);
     }
-    throw new Error(
-      "Expected keyFields to be an array of strings and nested key specifiers",
-    );
-  } else if (type.getFields().id !== undefined) {
+    // `false` disables normalization and a function computes key fields
+    // dynamically; in both cases no specific fields are required.
+    if (keyFields === false || typeof keyFields === "function") {
+      return [];
+    }
+    if (keyFields !== undefined) {
+      throw new Error(
+        "Expected keyFields to be an array of strings and nested key specifiers",
+      );
+    }
+  }
+  if (type.getFields().id !== undefined) {
     return [{ name: DEFAULT_KEY_FIELD_NAME }];
   }
   return [];


### PR DESCRIPTION
Resolve fragment spreads and inline fragments recursively in the missing-apollo-key-fields rule so key fields provided via nested fragments are detected. Also support Apollo nested key specifiers (e.g. keyFields: ["title", "author", ["name"]]), reporting missing nested keys as dotted paths (author.name).