### PR TITLE
fix(apollo-forest-run): release descriptors of non-cacheable operations

### DIFF
--- a/change/@graphitation-apollo-forest-run-12c1dd1b-88ca-4972-bf9c-b827bc4a2926.json
+++ b/change/@graphitation-apollo-forest-run-12c1dd1b-88ca-4972-bf9c-b827bc4a2926.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Release descriptors of non-cacheable operations (opt-in via cleanupNonCacheableOperations)",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -570,6 +570,16 @@ export class ForestRun<
     assert(activeTransaction === peek(this.transactionStack));
     this.transactionStack.pop();
 
+    if (!parentTransaction) {
+      // Descriptors still referenced by an optimistic layer are skipped here and released
+      // by removeOptimisticLayers instead (including the removeOptimistic calls below)
+      releaseNonCacheableOperations(
+        this.env,
+        this.store,
+        activeTransaction.nonCacheableOperations,
+      );
+    }
+
     if (error) {
       // Cleanup
       if (typeof removeOptimistic === "string") {
@@ -577,13 +587,6 @@ export class ForestRun<
       }
       if (typeof optimistic === "string") {
         this.removeOptimistic(optimistic);
-      }
-      if (!parentTransaction) {
-        releaseNonCacheableOperations(
-          this.env,
-          this.store,
-          activeTransaction.nonCacheableOperations,
-        );
       }
       throw error;
     }
@@ -607,11 +610,6 @@ export class ForestRun<
       );
       logUpdateStats(this.env, activeTransaction.changelog, watchesToNotify);
     }
-    releaseNonCacheableOperations(
-      this.env,
-      this.store,
-      activeTransaction.nonCacheableOperations,
-    );
     maybeEvictOldData(this.env, this.store);
 
     return result as T;

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -31,6 +31,7 @@ import {
   evictOldData,
   getEffectiveReadLayers,
   maybeEvictOldData,
+  releaseNonCacheableOperations,
   removeOptimisticLayers,
   resetStore,
 } from "./cache/store";
@@ -465,9 +466,17 @@ export class ForestRun<
   }
 
   public getStats() {
+    let operationCount = 0;
+    for (const variants of this.store.operations.values()) {
+      operationCount += variants.size;
+    }
     return {
       docCount: this.store.operations.size,
+      // Total number of memoized operation descriptors (one per document + variables combination)
+      operationCount,
       treeCount: this.store.dataForest.trees.size,
+      // Number of operations tracked for LRU eviction
+      atimeCount: this.store.atime.size,
     };
   }
 
@@ -535,6 +544,10 @@ export class ForestRun<
       watchesToNotify: null,
       forceOptimistic,
       changelog: [],
+      // Accumulate into the outermost transaction, which releases them all at once on completion
+      nonCacheableOperations:
+        parentTransaction?.nonCacheableOperations ??
+        (this.env.cleanupNonCacheableOperations ? new Set() : null),
     };
     this.transactionStack.push(activeTransaction);
     let error;
@@ -565,6 +578,13 @@ export class ForestRun<
       if (typeof optimistic === "string") {
         this.removeOptimistic(optimistic);
       }
+      if (!parentTransaction) {
+        releaseNonCacheableOperations(
+          this.env,
+          this.store,
+          activeTransaction.nonCacheableOperations,
+        );
+      }
       throw error;
     }
     if (typeof removeOptimistic === "string") {
@@ -587,6 +607,11 @@ export class ForestRun<
       );
       logUpdateStats(this.env, activeTransaction.changelog, watchesToNotify);
     }
+    releaseNonCacheableOperations(
+      this.env,
+      this.store,
+      activeTransaction.nonCacheableOperations,
+    );
     maybeEvictOldData(this.env, this.store);
 
     return result as T;

--- a/packages/apollo-forest-run/src/__tests__/nonCacheableOperations.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/nonCacheableOperations.test.ts
@@ -1,0 +1,355 @@
+import { ForestRun } from "../ForestRun";
+import { gql } from "./helpers/descriptor";
+
+const MUTATION = gql`
+  mutation SendMessage($id: ID!, $text: String!) {
+    sendMessage(id: $id, text: $text) {
+      __typename
+      id
+      text
+    }
+  }
+`;
+
+const CACHED_MUTATION = gql`
+  mutation CachedMutation($id: ID!) @cache {
+    cachedMutation(id: $id) {
+      __typename
+      id
+      text
+    }
+  }
+`;
+
+const QUERY = gql`
+  query GetMessage($id: ID!) {
+    message(id: $id) {
+      __typename
+      id
+      text
+    }
+  }
+`;
+
+const mutationResult = (id: string, text: string) => ({
+  sendMessage: { __typename: "Message", id, text },
+});
+
+const createCache = (cleanupNonCacheableOperations: boolean) =>
+  new ForestRun({ cleanupNonCacheableOperations, autoEvict: false });
+
+describe("non-cacheable operation descriptors", () => {
+  it("accumulates mutation descriptors when the flag is disabled", () => {
+    const cache = createCache(false);
+
+    for (let i = 0; i < 5; i++) {
+      cache.write({
+        query: MUTATION,
+        variables: { id: String(i), text: `text-${i}` },
+        result: mutationResult(String(i), `text-${i}`),
+      });
+    }
+
+    // One descriptor per distinct set of variables, none of which has a data tree
+    expect(cache.getStats()).toEqual(
+      expect.objectContaining({
+        docCount: 1,
+        operationCount: 5,
+        treeCount: 0,
+        atimeCount: 5,
+      }),
+    );
+  });
+
+  it("releases mutation descriptors when the flag is enabled", () => {
+    const cache = createCache(true);
+
+    for (let i = 0; i < 5; i++) {
+      cache.write({
+        query: MUTATION,
+        variables: { id: String(i), text: `text-${i}` },
+        result: mutationResult(String(i), `text-${i}`),
+      });
+    }
+
+    expect(cache.getStats()).toEqual(
+      expect.objectContaining({
+        docCount: 0,
+        operationCount: 0,
+        treeCount: 0,
+        atimeCount: 0,
+      }),
+    );
+  });
+
+  it("does not grow with the number of mutation writes", () => {
+    const cache = createCache(true);
+
+    for (let i = 0; i < 100; i++) {
+      cache.write({
+        query: MUTATION,
+        variables: { id: String(i), text: `text-${i}` },
+        result: mutationResult(String(i), `text-${i}`),
+      });
+      expect(cache.getStats().operationCount).toBe(0);
+    }
+  });
+
+  it("keeps descriptors of cacheable operations", () => {
+    const cache = createCache(true);
+
+    cache.write({
+      query: QUERY,
+      variables: { id: "1" },
+      result: { message: { __typename: "Message", id: "1", text: "hi" } },
+    });
+    cache.write({
+      query: MUTATION,
+      variables: { id: "1", text: "bye" },
+      result: mutationResult("1", "bye"),
+    });
+
+    // Only the query descriptor survives
+    expect(cache.getStats()).toEqual(
+      expect.objectContaining({
+        docCount: 1,
+        operationCount: 1,
+        treeCount: 1,
+      }),
+    );
+    expect(
+      cache.read({ query: QUERY, variables: { id: "1" }, optimistic: true }),
+    ).toEqual({ message: { __typename: "Message", id: "1", text: "bye" } });
+  });
+
+  it("keeps descriptors of mutations marked with @cache", () => {
+    const cache = createCache(true);
+
+    cache.write({
+      query: CACHED_MUTATION,
+      variables: { id: "1" },
+      result: { cachedMutation: { __typename: "Message", id: "1", text: "a" } },
+    });
+
+    expect(cache.getStats()).toEqual(
+      expect.objectContaining({ operationCount: 1, treeCount: 1 }),
+    );
+  });
+
+  it("still propagates mutation results to watched queries", () => {
+    const cache = createCache(true);
+    const callback = jest.fn();
+
+    cache.write({
+      query: QUERY,
+      variables: { id: "1" },
+      result: { message: { __typename: "Message", id: "1", text: "hi" } },
+    });
+    cache.watch({
+      query: QUERY,
+      variables: { id: "1" },
+      optimistic: true,
+      callback,
+    });
+
+    cache.write({
+      query: MUTATION,
+      variables: { id: "1", text: "updated" },
+      result: mutationResult("1", "updated"),
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0].result).toEqual({
+      message: { __typename: "Message", id: "1", text: "updated" },
+    });
+    expect(cache.getStats().operationCount).toBe(1); // query only
+  });
+
+  it("retains the descriptor while its optimistic layer is alive", () => {
+    const cache = createCache(true);
+
+    cache.write({
+      query: QUERY,
+      variables: { id: "1" },
+      result: { message: { __typename: "Message", id: "1", text: "hi" } },
+    });
+    const baseline = cache.getStats().operationCount;
+
+    cache.batch({
+      optimistic: "layer-1",
+      update: () =>
+        cache.write({
+          query: MUTATION,
+          variables: { id: "1", text: "optimistic" },
+          result: mutationResult("1", "optimistic"),
+        }),
+    });
+
+    // The layer stores the optimistic mutation result, so its descriptor must stay
+    expect(cache.getStats().operationCount).toBe(baseline + 1);
+    expect(
+      cache.read({ query: QUERY, variables: { id: "1" }, optimistic: true }),
+    ).toEqual({
+      message: { __typename: "Message", id: "1", text: "optimistic" },
+    });
+
+    cache.removeOptimistic("layer-1");
+
+    expect(cache.getStats().operationCount).toBe(baseline);
+    expect(
+      cache.read({ query: QUERY, variables: { id: "1" }, optimistic: true }),
+    ).toEqual({ message: { __typename: "Message", id: "1", text: "hi" } });
+  });
+
+  it("releases descriptors of non-optimistic writes inside a transaction", () => {
+    const cache = createCache(true);
+
+    cache.batch({
+      optimistic: false,
+      update: () =>
+        cache.write({
+          query: MUTATION,
+          variables: { id: "1", text: "a" },
+          result: mutationResult("1", "a"),
+        }),
+    });
+
+    expect(cache.getStats().operationCount).toBe(0);
+  });
+
+  it("defers release to the outermost transaction", () => {
+    const cache = createCache(true);
+    let innerCount = -1;
+
+    cache.batch({
+      update: () => {
+        cache.batch({
+          update: () =>
+            cache.write({
+              query: MUTATION,
+              variables: { id: "1", text: "a" },
+              result: mutationResult("1", "a"),
+            }),
+        });
+        innerCount = cache.getStats().operationCount;
+      },
+    });
+
+    expect(innerCount).toBe(1);
+    expect(cache.getStats().operationCount).toBe(0);
+  });
+
+  it("releases descriptors when a transaction throws", () => {
+    const cache = createCache(true);
+
+    expect(() =>
+      cache.batch({
+        update: () => {
+          cache.write({
+            query: MUTATION,
+            variables: { id: "1", text: "a" },
+            result: mutationResult("1", "a"),
+          });
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+
+    expect(cache.getStats().operationCount).toBe(0);
+  });
+
+  it("releases descriptors when an optimistic transaction throws", () => {
+    const cache = createCache(true);
+
+    expect(() =>
+      cache.batch({
+        optimistic: "layer-1",
+        update: () => {
+          cache.write({
+            query: MUTATION,
+            variables: { id: "1", text: "a" },
+            result: mutationResult("1", "a"),
+          });
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+
+    expect(cache.getStats().operationCount).toBe(0);
+  });
+
+  it("does not accumulate descriptors across full mutation lifecycles", () => {
+    const cache = createCache(true);
+    cache.write({
+      query: QUERY,
+      variables: { id: "1" },
+      result: { message: { __typename: "Message", id: "1", text: "initial" } },
+    });
+    const baseline = cache.getStats().operationCount;
+
+    // Mimics how Apollo drives a mutation: optimistic response in a named layer,
+    // then the layer is dropped and the real result is written to the data forest.
+    for (let i = 0; i < 25; i++) {
+      const layerTag = `mutation-${i}`;
+      cache.batch({
+        optimistic: layerTag,
+        update: () =>
+          cache.write({
+            query: MUTATION,
+            variables: { id: "1", text: `optimistic-${i}` },
+            result: mutationResult("1", `optimistic-${i}`),
+          }),
+      });
+      // NOTE: intentionally not asserting the optimistic read here — writing to a
+      // freshly created optimistic layer does not invalidate previously cached
+      // optimistic read results (pre-existing behavior, unrelated to this flag).
+      expect(cache.getStats().operationCount).toBeGreaterThanOrEqual(baseline);
+
+      cache.batch({
+        optimistic: false,
+        removeOptimistic: layerTag,
+        update: () =>
+          cache.write({
+            query: MUTATION,
+            variables: { id: "1", text: `confirmed-${i}` },
+            result: mutationResult("1", `confirmed-${i}`),
+          }),
+      });
+      expect(
+        cache.read({ query: QUERY, variables: { id: "1" }, optimistic: true }),
+      ).toEqual({
+        message: { __typename: "Message", id: "1", text: `confirmed-${i}` },
+      });
+    }
+
+    expect(cache.getStats().operationCount).toBe(baseline);
+    expect(cache.getStats().atimeCount).toBe(baseline);
+  });
+
+  it("re-creates an equivalent descriptor on a repeated write", () => {
+    const cache = createCache(true);
+    const variables = { id: "1", text: "same" };
+
+    cache.write({
+      query: QUERY,
+      variables: { id: "1" },
+      result: { message: { __typename: "Message", id: "1", text: "initial" } },
+    });
+    cache.write({
+      query: MUTATION,
+      variables,
+      result: mutationResult("1", "same"),
+    });
+    // Descriptor was released after the first write, so this one re-creates it
+    cache.write({
+      query: MUTATION,
+      variables,
+      result: mutationResult("1", "same"),
+    });
+
+    expect(cache.getStats().operationCount).toBe(1); // query only
+    expect(
+      cache.read({ query: QUERY, variables: { id: "1" }, optimistic: true }),
+    ).toEqual({ message: { __typename: "Message", id: "1", text: "same" } });
+  });
+});

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -48,6 +48,8 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     logStaleOperations: config?.logStaleOperations ?? false,
     historyConfig: config?.historyConfig,
     optimizeFragmentReads: config?.optimizeFragmentReads ?? false,
+    cleanupNonCacheableOperations:
+      config?.cleanupNonCacheableOperations ?? false,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     partitionConfig: resolvePartitionConfig(
       {

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -184,6 +184,101 @@ function canEvict(env: CacheEnv, store: Store, resultTree: DataTree) {
   return true;
 }
 
+/**
+ * Operation descriptors are memoized in `store.operations` for the whole lifetime of the cache.
+ * They are normally released by `removeDataTree` during LRU eviction — but eviction only ever
+ * sees operations that produced a data tree.
+ *
+ * Non-cacheable operations (mutations without the `@cache` directive) never produce one:
+ * `shouldCache` discards their result right after indexing it. So without an explicit release
+ * their descriptors — and the `variablesKey` strings used as their cache keys — accumulate
+ * forever, one per distinct set of variables.
+ *
+ * This returns true when nothing references the descriptor anymore, so that dropping it from
+ * the memo cannot cause two live descriptors to exist for the same operation.
+ */
+export function canReleaseOperationDescriptor(
+  store: Store,
+  operation: OperationDescriptor,
+): boolean {
+  if (operation.cache) {
+    // Results are cached, so the descriptor is owned by its data tree and released by eviction
+    return false;
+  }
+  if (
+    store.watches.has(operation) ||
+    store.optimisticReadResults.has(operation) ||
+    store.partialReadResults.has(operation)
+  ) {
+    return false;
+  }
+  if (isReferencedByForest(store.dataForest, operation)) {
+    return false;
+  }
+  for (const layer of store.optimisticLayers) {
+    if (isReferencedByForest(layer, operation)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isReferencedByForest(
+  forest: DataForest | OptimisticLayer,
+  operation: OperationDescriptor,
+): boolean {
+  return (
+    forest.trees.has(operation.id) ||
+    forest.readResults.has(operation) ||
+    forest.operationsWithErrors.has(operation)
+  );
+}
+
+/**
+ * Removes an operation descriptor from the memo in `store.operations`.
+ *
+ * Note: this only drops the memoized entry. Any object still holding a reference to the
+ * descriptor keeps working — callers must ensure nothing does (see canReleaseOperationDescriptor),
+ * otherwise a subsequent lookup would mint a second descriptor for the same operation.
+ */
+export function releaseOperationDescriptor(
+  store: Store,
+  operation: OperationDescriptor,
+): boolean {
+  const variants = store.operations.get(operation.document);
+  const cacheKey = operationCacheKey(operation);
+  if (variants?.get(cacheKey) !== operation) {
+    // Already released, or superseded by a different descriptor
+    return false;
+  }
+  variants.delete(cacheKey);
+  if (!variants.size) {
+    store.operations.delete(operation.document);
+  }
+  store.atime.delete(operation.id);
+  return true;
+}
+
+export function releaseNonCacheableOperations(
+  env: CacheEnv,
+  store: Store,
+  operations: Iterable<OperationDescriptor> | null | undefined,
+): number {
+  if (!env.cleanupNonCacheableOperations || !operations) {
+    return 0;
+  }
+  let released = 0;
+  for (const operation of operations) {
+    if (
+      canReleaseOperationDescriptor(store, operation) &&
+      releaseOperationDescriptor(store, operation)
+    ) {
+      released++;
+    }
+  }
+  return released;
+}
+
 export function createOptimisticLayer(
   layerTag: string,
   replay: <T>(cache: T) => any,
@@ -269,6 +364,20 @@ export function removeOptimisticLayers<T>(
     if (!deletedLayers.includes(layer)) {
       layer.replay(cache);
     }
+  }
+
+  // Optimistic layers do store results of non-cacheable operations (e.g. optimistic mutation
+  // responses), which kept their descriptors alive. Now that the layers are gone, retry.
+  if (env.cleanupNonCacheableOperations) {
+    const candidates: OperationDescriptor[] = [];
+    for (const layer of deletedLayers) {
+      for (const tree of layer.trees.values()) {
+        if (!tree.operation.cache) {
+          candidates.push(tree.operation);
+        }
+      }
+    }
+    releaseNonCacheableOperations(env, store, candidates);
   }
   return affectedOperationSet;
 }

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -136,6 +136,11 @@ export type Transaction = {
   watchesToNotify: Set<Cache.WatchOptions> | null;
   forceOptimistic: boolean | null;
   changelog: (WriteResult | ModifyResult)[];
+  // Descriptors of operations whose results are not cached (mutations without `@cache`).
+  // Only populated when `env.cleanupNonCacheableOperations` is enabled.
+  // Owned by the outermost transaction: nested transactions share the same set by reference
+  // and the outermost one releases everything at once when it completes.
+  nonCacheableOperations: Set<OperationDescriptor> | null;
 };
 
 export type WriteResult = {
@@ -191,6 +196,7 @@ export type ForestRunAdditionalConfig<
   logUpdateStats?: boolean;
   logStaleOperations?: boolean;
   optimizeFragmentReads?: boolean;
+  cleanupNonCacheableOperations?: boolean;
 
   historyConfig?: HistoryConfig<TPartitions>;
 };
@@ -265,6 +271,15 @@ export type CacheEnv<TPartitions extends HistoryPartitions = any> = {
   logUpdateStats: boolean;
   logStaleOperations: boolean;
   optimizeFragmentReads: boolean;
+  /**
+   * When enabled, operation descriptors of non-cacheable operations (i.e. mutations without
+   * the `@cache` directive) are released as soon as nothing references them anymore.
+   *
+   * Such operations never produce a data tree, so they are invisible to LRU eviction
+   * (which only iterates tree-backed operations) and would otherwise accumulate in
+   * `store.operations` for the lifetime of the cache.
+   */
+  cleanupNonCacheableOperations: boolean;
   historyConfig?: HistoryConfig<TPartitions>;
 };
 

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -67,6 +67,12 @@ export function write(
     rootNodeKey,
   );
   touchOperation(env, store, operationDescriptor);
+  if (!operationDescriptor.cache) {
+    // Results of this operation are never stored, so nothing will ever evict its descriptor.
+    // Remember it, so that the outermost transaction can release it on completion.
+    // (the set only exists when `env.cleanupNonCacheableOperations` is enabled)
+    activeTransaction.nonCacheableOperations?.add(operationDescriptor);
+  }
   const operationResult: OperationResult = { data: writeData };
 
   if (


### PR DESCRIPTION
## Why

Operation descriptors are memoized in `store.operations` and the only code path that ever removed one was `removeDataTree` during LRU eviction. Eviction is driven by `operationsByPartitions`, so it only ever sees operations that produced a data tree.

Mutations without the `@cache` directive get `cache: false` from `describeOperation`, and `shouldCache` throws their result away right after indexing it. They never produce a tree, so their descriptors, along with the `variablesKey` strings used as their memo keys, accumulate for the entire lifetime of the cache. One entry per distinct set of variables, forever.

The growth is unbounded and proportional to the number of distinct (mutation, variables) pairs an application issues, so it is worst for long-lived sessions that fire high-frequency mutations with varying variables. Nothing in the current design ever reclaims those entries, and no eviction tuning can reach them, because eviction only walks tree-backed operations.

## Approach

Non-cacheable descriptors are released as soon as the outermost transaction that wrote them completes, or when the optimistic layer holding them is removed. This is deterministic and bounds the peak at the number of in-flight mutations, rather than deferring to a `gc()` sweep, which may not run at all when auto-eviction is disabled.

- `write.ts` records `!operation.cache` descriptors on the active transaction.
- The outermost transaction owns the set. Nested transactions share it by reference, so there is exactly one release point per top-level batch plus the error path. The set is only allocated when the flag is on.
- `removeOptimisticLayers` retries release after layers are spliced out and replayed, since a descriptor kept alive by a layer tree cannot be released at transaction end.

`canReleaseOperationDescriptor` is the safety gate. The hazard here is not use-after-free, since dropping a memo entry never breaks an existing holder. It is identity divergence: a later lookup minting a *second* descriptor while the first is still live. So release requires that the descriptor is not `cache`, not in `watches` / `optimisticReadResults` / `partialReadResults`, and not referenced by `dataForest` or any optimistic layer (`trees` / `readResults` / `operationsWithErrors`). Deletion is identity checked (`variants.get(key) === operation`), so it can never evict a newer descriptor.

Guarded by a new `cleanupNonCacheableOperations` flag, **defaulting to false**, following the existing `logUpdateStats` / `optimizeFragmentReads` pattern.

## Performance

Effectively free. Everything expensive stays memoized by `DocumentNode` and is unaffected by descriptor lifetime: `documentCache`, `definitionsCache`, and critically `resultTreeDescriptors`, which holds `possibleSelections`. `applyDefaultValues` and `createVariablesKey` already run before the memo lookup on every call, so a hit never saved them.

What is lost is the `describeOperation` allocation and the per-descriptor `operation.selections` memo. That memo's output depends on `variablesWithDefaults`, so it could only ever be reused for byte-identical variables, which is exactly the case that creates zero new descriptors today. Mutation writes already run a full `indexTree` and discard the tree, so the recompute is a small fraction of existing work.

## Observability

`getStats()` now also returns `operationCount` (sum of all memoized descriptors) and `atimeCount`. The pre-existing `docCount` counts *documents*, not descriptors, which is why this growth was hard to spot.

## Tests

13 new tests in `nonCacheableOperations.test.ts`, using only the public API plus `getStats()`: leak reproduction with the flag off, release with it on, 100-write no-growth, cacheable operations kept, `@cache` mutations kept, watch propagation intact, optimistic layer retention and release on `removeOptimistic`, nested transactions, both throw paths, and a 25 iteration full mutation lifecycle.

Full package suite passes: 26 suites, 1111 tests. `tsc` clean, eslint clean.

## Notes for reviewers

- `operationsWithDanglingRefs` is deliberately not checked in the release gate. It is a `Map<NodeKey, Set<OperationDescriptor>>` and would be O(n) to scan, it is only populated from the read path, and anything with a read result is already excluded via `readResults`. Mutations are never read.
- `diffDescriptors` is a `WeakMap<Cache.DiffOptions, OperationDescriptor>` that can outlive a purged memo entry. Restricting release to `!operation.cache` sidesteps it, since nothing diffs or watches a mutation.
- Unrelated pre-existing bug found while writing tests: writing to a *freshly created* optimistic layer does not invalidate an already-cached `optimisticReadResults` entry for a base-forest query, because `resolveAffectedOperations` only consults the target forest's `operationsByNodes`, which is empty for a new layer. It reproduces identically with the flag on and off. Noted in a test comment rather than asserted, and left for a separate change.
- The Apollo compat suite was not run locally (it wants a fresh `npm i`). Since the flag defaults to false, its behaviour is unchanged by default.