### PR TITLE
feat(apollo-forest-run): enable cleanupNonCacheableOperations by default

### DIFF
--- a/change/@graphitation-apollo-forest-run-3f7c1a94-2c50-4d1e-9a2f-2b6f0f9a1c77.json
+++ b/change/@graphitation-apollo-forest-run-3f7c1a94-2c50-4d1e-9a2f-2b6f0f9a1c77.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable cleanupNonCacheableOperations by default",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/ForestRun.ts
+++ b/packages/apollo-forest-run/src/ForestRun.ts
@@ -31,7 +31,7 @@ import {
   evictOldData,
   getEffectiveReadLayers,
   maybeEvictOldData,
-  releaseNonCacheableOperations,
+  releasePendingNonCacheableOperations,
   removeOptimisticLayers,
   resetStore,
 } from "./cache/store";
@@ -544,10 +544,6 @@ export class ForestRun<
       watchesToNotify: null,
       forceOptimistic,
       changelog: [],
-      // Accumulate into the outermost transaction, which releases them all at once on completion
-      nonCacheableOperations:
-        parentTransaction?.nonCacheableOperations ??
-        (this.env.cleanupNonCacheableOperations ? new Set() : null),
     };
     this.transactionStack.push(activeTransaction);
     let error;
@@ -573,11 +569,7 @@ export class ForestRun<
     if (!parentTransaction) {
       // Descriptors still referenced by an optimistic layer are skipped here and released
       // by removeOptimisticLayers instead (including the removeOptimistic calls below)
-      releaseNonCacheableOperations(
-        this.env,
-        this.store,
-        activeTransaction.nonCacheableOperations,
-      );
+      releasePendingNonCacheableOperations(this.store);
     }
 
     if (error) {

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -49,7 +49,7 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     historyConfig: config?.historyConfig,
     optimizeFragmentReads: config?.optimizeFragmentReads ?? false,
     cleanupNonCacheableOperations:
-      config?.cleanupNonCacheableOperations ?? false,
+      config?.cleanupNonCacheableOperations ?? true,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     partitionConfig: resolvePartitionConfig(
       {

--- a/packages/apollo-forest-run/src/cache/store.ts
+++ b/packages/apollo-forest-run/src/cache/store.ts
@@ -56,6 +56,7 @@ export function createStore(_: CacheEnv): Store {
     atime: new Map(),
     partitions: new WeakMap(),
     pendingEviction: null,
+    pendingNonCacheableOperations: null,
   };
   return store;
 }
@@ -259,14 +260,25 @@ export function releaseOperationDescriptor(
   return true;
 }
 
-export function releaseNonCacheableOperations(
-  env: CacheEnv,
-  store: Store,
-  operations: Iterable<OperationDescriptor> | null | undefined,
-): number {
-  if (!env.cleanupNonCacheableOperations || !operations) {
+/**
+ * Releases the descriptors accumulated by writes since the outermost transaction started.
+ *
+ * The pending set is allocated lazily by `write`, so a cache that never writes a non-cacheable
+ * operation pays nothing for this beyond a null check per transaction.
+ */
+export function releasePendingNonCacheableOperations(store: Store): number {
+  const operations = store.pendingNonCacheableOperations;
+  if (!operations) {
     return 0;
   }
+  store.pendingNonCacheableOperations = null;
+  return releaseOperations(store, operations);
+}
+
+function releaseOperations(
+  store: Store,
+  operations: Iterable<OperationDescriptor>,
+): number {
   let released = 0;
   for (const operation of operations) {
     if (
@@ -369,15 +381,16 @@ export function removeOptimisticLayers<T>(
   // Optimistic layers do store results of non-cacheable operations (e.g. optimistic mutation
   // responses), which kept their descriptors alive. Now that the layers are gone, retry.
   if (env.cleanupNonCacheableOperations) {
-    const candidates: OperationDescriptor[] = [];
     for (const layer of deletedLayers) {
       for (const tree of layer.trees.values()) {
-        if (!tree.operation.cache) {
-          candidates.push(tree.operation);
+        if (
+          !tree.operation.cache &&
+          canReleaseOperationDescriptor(store, tree.operation)
+        ) {
+          releaseOperationDescriptor(store, tree.operation);
         }
       }
     }
-    releaseNonCacheableOperations(env, store, candidates);
   }
   return affectedOperationSet;
 }
@@ -500,6 +513,7 @@ export function resetStore(store: Store): void {
   operations.clear();
   optimisticReadResults.clear();
   optimisticLayers.length = 0;
+  store.pendingNonCacheableOperations = null;
 }
 
 const getRootNode = (result: IndexedTree): NodeChunk | undefined =>

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -127,6 +127,10 @@ export type Store = {
   partitions: WeakMap<IndexedTree, ResolvedPartition>;
   // Pending scheduled auto-eviction
   pendingEviction: ScheduledEvictionHandle | null;
+  // Descriptors of written operations whose results are not cached (mutations without `@cache`).
+  // Allocated lazily on the first such write and only when `env.cleanupNonCacheableOperations`
+  // is enabled; released and reset by the outermost transaction when it completes.
+  pendingNonCacheableOperations: Set<OperationDescriptor> | null;
 };
 
 export type Transaction = {
@@ -136,11 +140,6 @@ export type Transaction = {
   watchesToNotify: Set<Cache.WatchOptions> | null;
   forceOptimistic: boolean | null;
   changelog: (WriteResult | ModifyResult)[];
-  // Descriptors of operations whose results are not cached (mutations without `@cache`).
-  // Only populated when `env.cleanupNonCacheableOperations` is enabled.
-  // Owned by the outermost transaction: nested transactions share the same set by reference
-  // and the outermost one releases everything at once when it completes.
-  nonCacheableOperations: Set<OperationDescriptor> | null;
 };
 
 export type WriteResult = {

--- a/packages/apollo-forest-run/src/cache/write.ts
+++ b/packages/apollo-forest-run/src/cache/write.ts
@@ -67,11 +67,12 @@ export function write(
     rootNodeKey,
   );
   touchOperation(env, store, operationDescriptor);
-  if (!operationDescriptor.cache) {
+  if (env.cleanupNonCacheableOperations && !operationDescriptor.cache) {
     // Results of this operation are never stored, so nothing will ever evict its descriptor.
     // Remember it, so that the outermost transaction can release it on completion.
-    // (the set only exists when `env.cleanupNonCacheableOperations` is enabled)
-    activeTransaction.nonCacheableOperations?.add(operationDescriptor);
+    (store.pendingNonCacheableOperations ??= new Set()).add(
+      operationDescriptor,
+    );
   }
   const operationResult: OperationResult = { data: writeData };
 


### PR DESCRIPTION
Flips the default of the `cleanupNonCacheableOperations` config flag (added in #705) from `false` to `true` in `packages/apollo-forest-run/src/cache/env.ts`.

Context: #705 fixed unbounded growth of memoized operation descriptors for non-cacheable operations (e.g. mutations without `@cache`), whose descriptors and `variablesKey` strings were never evicted because eviction only walks tree-backed operations. The fix landed opt-in.

This PR is opened primarily to run the full CI suite with the flag enabled.

## Benchmark regression fix

The first benchmark run on this branch reported memory regressions on `write-no-changes` and `modify-affecting-0-objects` (+231 / +232 / +849 bytes). Those scenarios never write a non-cacheable operation, so the regression was pure overhead from the flag being on.

Root cause: `runTransaction` eagerly allocated a `Set` to accumulate descriptors to release. The benchmark's `memory` metric is a `heapUsed` delta around a single scenario run, so it measures allocation rather than retention, and an empty V8 `Set` retains ~174 bytes. The extra `Transaction` field accounted for the remainder. Every `cache.write` and `cache.modify` opens a transaction, so this hit every operation.

Fix (891f88cd): the accumulator moved from `Transaction` to `Store` and is allocated lazily on the first non-cacheable write. Semantics are unchanged (still accumulated across nested transactions and released once by the outermost one), but a workload that never writes a non-cacheable operation allocates nothing and only pays a null check per transaction.

Measured locally against the same build, flag off vs flag on, median of 6 epochs:

| scenario | before | after |
| --- | --- | --- |
| write-no-changes_0 | +232 B (+6.8%) | 0 B (0.0%) |
| modify-affecting-0-objects_0 | +232 B (+7.0%) | 0 B (-0.1%) |
| write-no-changes_50 | +218 B (+3.1%) | 0 B (0.0%) |
| modify-affecting-0-objects_50 | +204 B (+6.2%) | 0 B (0.0%) |

Draft - do not merge until CI and the benchmark are green.