### PR TITLE
fix(apollo-forest-run): report the malformed payload behind a corrupted list instead of dereferencing a hole

### DIFF
--- a/change/@graphitation-apollo-forest-run-387221ff-213a-41af-b36f-03b6c4fd98fc.json
+++ b/change/@graphitation-apollo-forest-run-387221ff-213a-41af-b36f-03b6c4fd98fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): report a descriptive error instead of 'Cannot read properties of undefined (reading value)' when re-indexing a corrupted list. No behavior change - the malformed write is still accepted, it is only reported better when it is hit",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -464,6 +464,337 @@ test("properly replaces objects containing nested composite lists", () => {
   });
 });
 
+// Regression coverage for `TypeError: Cannot read properties of undefined (reading 'value')`
+// thrown by reIndexList (src/forest/indexTree.ts). Everything below goes through
+// the public cache API only.
+//
+// The crash needed a four way conjunction:
+//  1. The same node (Thread:1) is selected twice in one operation with two
+//     *different* selections. aggregateFieldChunks only dedupes chunks sharing
+//     both selection and operation, so here the node value stays an aggregate.
+//  2. The two selections carry lists of different lengths (14 vs 3) and the
+//     aggregate iterates the longer one.
+//  3. The longer list starts with nulls. diffCompositeListLayout pushes `null`
+//     into the layout for them and diffCompositeListValue skips those indices
+//     (`baseItemIndex` is not a number), so index 4 is the *first* index
+//     resolved against the aggregate.
+//  4. aggregateListItemValue -> resolveListItemChunk assigns `itemChunks[4]` on
+//     the 3 item chunk with no bounds check. The array grows past its data
+//     length and index 3 is left unresolved.
+//
+// Steps 1+2 are the actual defect in the payload, but nothing reads the hole it
+// leaves until a *later* write recycles that chunk - which is why the stack trace
+// blames a write that is entirely innocent. reIndexList now detects the hole
+// instead of dereferencing it, and reports what is known about the damaged list.
+const seedQuery = gql`
+  query MessageListSeed {
+    thread {
+      __typename
+      id
+      messages {
+        __typename
+        id
+        text
+      }
+    }
+  }
+`;
+
+const messageListQuery = gql`
+  query MessageList {
+    conversation {
+      __typename
+      id
+      thread {
+        __typename
+        id
+        messages {
+          __typename
+          id
+          text
+        }
+      }
+    }
+    pinned {
+      __typename
+      id
+      thread {
+        __typename
+        id
+        title
+        messages {
+          __typename
+          id
+          text
+          author {
+            __typename
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+const messageIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+const message = (id: string) => ({ __typename: "Message", id, text: id });
+const pinnedMessage = (id: string) => ({
+  ...message(id),
+  author: { __typename: "User", id: "1" },
+});
+const conversation = (messages: unknown[]) => ({
+  __typename: "Conversation",
+  id: "1",
+  thread: { __typename: "Thread", id: "1", messages },
+});
+const createPinned = (ids: string[] = ["1", "2", "3"]) => ({
+  __typename: "Pinned",
+  id: "1",
+  thread: {
+    __typename: "Thread",
+    id: "1",
+    title: "Pinned",
+    messages: ids.map(pinnedMessage),
+  },
+});
+
+const seedThread = (cache: ForestRun) =>
+  cache.write({
+    query: seedQuery,
+    result: {
+      thread: {
+        __typename: "Thread",
+        id: "1",
+        messages: messageIds.map(message),
+      },
+    },
+  });
+
+// Without the leading nulls the same payload grows the 3 item chunk densely and
+// leaves no hole behind, so this exact shape is what the check can see.
+const conversationMessages = [
+  null,
+  null,
+  null,
+  null,
+  ...messageIds.map(message),
+];
+
+test("reports an unresolved list item instead of dereferencing it", () => {
+  const cache = new ForestRun();
+  seedThread(cache);
+
+  // Thread:1 appears twice: 14 messages under `conversation`, 3 under `pinned`.
+  // This write punches the hole and is accepted - nothing reads it yet.
+  const pinned = createPinned();
+  cache.write({
+    query: messageListQuery,
+    result: { conversation: conversation(conversationMessages), pinned },
+  });
+
+  // Reusing the same source objects makes indexTree recycle the damaged subtree
+  // instead of indexing it again, and recycling walks every item reference.
+  let error: Error | undefined;
+  try {
+    cache.write({
+      query: messageListQuery,
+      result: { conversation: conversation(conversationMessages), pinned },
+    });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  expect(error?.message).toMatch(
+    /^Invariant violation: Detected malformed payload written to the cache/,
+  );
+  // This phrase is the first thing a human reads in a telemetry dashboard, so keep it
+  // stable across rewordings of the rest.
+  expect(error?.message).toContain(
+    'a "Thread" node occurs multiple times in a single write with a different ' +
+      'number of items in the "messages" list',
+  );
+  // The write being recycled is the one that produced the malformed payload. Recycling is
+  // always same-operation, so there is no second operation to name.
+  expect(error?.message).toContain("Operation:  query MessageList");
+  expect(error?.message).toContain("Node type:  Thread");
+  // Both occurrences are the same entity - that is what makes the divergence a conflict -
+  // but the id itself must not leak, so the message states the fact without printing it.
+  expect(error?.message).toContain(
+    "Node id:    same in both occurrences (not shown)",
+  );
+  expect(error?.message).toContain("Field:      messages");
+  // Both conflicting occurrences, reconstructed from the tree being recycled.
+  expect(error?.message).toContain(
+    "Occurrence 1: 14 items at data.conversation.thread.messages",
+  );
+  expect(error?.message).toContain(
+    "Occurrence 2: 3 items at data.pinned.thread.messages",
+  );
+  expect(error?.message).not.toContain("Thread:1");
+});
+
+test("accepts a payload repeating a node with lists of equal length", () => {
+  const cache = new ForestRun();
+  seedThread(cache);
+
+  // Thread:1 still appears twice under two different selections (`pinned` also
+  // selects `title` and `author`), which is legal as long as the shared list
+  // field resolves to the same items. Guards the check against over rejecting.
+  const pinned = createPinned(messageIds);
+
+  cache.write({
+    query: messageListQuery,
+    result: {
+      conversation: conversation(messageIds.map(message)),
+      pinned,
+    },
+  });
+
+  // Reusing the same `pinned` source object makes indexTree recycle that subtree
+  // instead of indexing it again: reIndexObject -> reIndexObject -> reIndexList,
+  // which walks every item reference of the list. Both lists keep the same
+  // length, only the message text changes.
+  expect(() =>
+    cache.write({
+      query: messageListQuery,
+      result: {
+        conversation: conversation(
+          messageIds.map((id) => ({ ...message(id), text: `${id} edited` })),
+        ),
+        pinned,
+      },
+    }),
+  ).not.toThrow();
+});
+
+// The same defect one level deeper: the repeated node is a list *item* rather than
+// a field of the root, and the divergent list hangs off it. Both occurrences carry
+// a list index, which is what this pins - the error has to address them by index.
+//
+// The two occurrences use different selections because that is what the indexing
+// path needs: aggregateFieldChunks drops adjacent chunks sharing selection and
+// operation, so a node repeated under one selection is collapsed before its lists
+// are aggregated. Other routes into resolveListItemChunk do not go through that
+// dedupe, so this is a constraint on the test, not on the defect.
+const fileNode = (id: string) => ({ __typename: "File", id });
+const messageWithFiles = (id: string, files: unknown[]) => ({
+  __typename: "Message",
+  id,
+  files,
+});
+
+const attachmentSeedQuery = gql`
+  query AttachmentSeed {
+    message {
+      __typename
+      id
+      files {
+        __typename
+        id
+      }
+    }
+  }
+`;
+
+const attachmentQuery = gql`
+  query Attachments {
+    inbox {
+      __typename
+      id
+      messages {
+        __typename
+        id
+        files {
+          __typename
+          id
+        }
+      }
+    }
+    starred {
+      __typename
+      id
+      messages {
+        __typename
+        id
+        subject
+        files {
+          __typename
+          id
+        }
+      }
+    }
+  }
+`;
+
+test("reports list indices when the repeated node is itself a list item", () => {
+  const cache = new ForestRun();
+  cache.write({
+    query: attachmentSeedQuery,
+    result: {
+      message: messageWithFiles("7", [fileNode("a"), fileNode("b")]),
+    },
+  });
+
+  // Message:7 is at index 2 of `inbox.messages` with 4 files and at index 1 of
+  // `starred.messages` with 1. Only the subtree holding the shorter list keeps
+  // its identity, so it is the one recycled by the second write.
+  const starred = {
+    __typename: "Starred",
+    id: "1",
+    messages: [
+      { ...messageWithFiles("3", []), subject: "s" },
+      { ...messageWithFiles("7", [fileNode("a")]), subject: "s" },
+    ],
+  };
+  const inbox = () => ({
+    __typename: "Inbox",
+    id: "1",
+    messages: [
+      messageWithFiles("1", []),
+      messageWithFiles("2", []),
+      messageWithFiles("7", [null, null, fileNode("a"), fileNode("b")]),
+    ],
+  });
+
+  cache.write({
+    query: attachmentQuery,
+    result: { inbox: inbox(), starred },
+  });
+
+  let error: Error | undefined;
+  try {
+    cache.write({
+      query: attachmentQuery,
+      result: { inbox: inbox(), starred },
+    });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  expect(error?.message).toContain(
+    'a "Message" node occurs multiple times in a single write with a different ' +
+      'number of items in the "files" list',
+  );
+  expect(error?.message).toContain("Node type:  Message");
+  expect(error?.message).toContain("Field:      files");
+  // Each occurrence is addressed by its index in the enclosing list, and a single
+  // item reads as "1 item" rather than "1 items".
+  expect(error?.message).toContain(
+    "Occurrence 1: 4 items at data.inbox.messages.2.files",
+  );
+  expect(error?.message).toContain(
+    "Occurrence 2: 1 item at data.starred.messages.1.files",
+  );
+  expect(error?.message).not.toContain("Message:7");
+});
+
+// The same defect, benign symptom: when every out of bounds index is resolved in
+// order the shorter chunk densifies instead of growing a hole, so there is
+// nothing for reIndexList to trip over even though the cache state is just as
+// wrong. Catching that needs the payload itself to be validated while it is
+// indexed, which is a follow up.
+test.todo("rejects repeated nodes with divergent list lengths at index time");
+
 test("properly reads plain objects from nested lists", () => {
   const query1 = gql`
     {

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -482,6 +482,12 @@ test("properly replaces objects containing nested composite lists", () => {
 //     the 3 item chunk with no bounds check. The array grows past its data
 //     length and index 3 is left unresolved.
 //
+// Only the *first* out of range index decides whether a hole is left: resolving in
+// ascending order grows the short chunk densely. Leading nulls are the cheapest way
+// to start above its length, not the only one - `layout` is a key lookup
+// (findKeyIndex), so a reordered keyed list visits base indices out of order too,
+// and descendToChunk/retrieveEmbeddedValue resolve a single index with no scan.
+//
 // Steps 1+2 are the actual defect in the payload, but nothing reads the hole it
 // leaves until a *later* write recycles that chunk - which is why the stack trace
 // blames a write that is entirely innocent. reIndexList now detects the hole

--- a/packages/apollo-forest-run/src/forest/indexTree.ts
+++ b/packages/apollo-forest-run/src/forest/indexTree.ts
@@ -9,6 +9,7 @@ import type {
   NodeMap,
   ObjectChunk,
   ObjectDraft,
+  ObjectFieldReference,
   OperationResult,
   RootChunkReference,
   SourceCompositeList,
@@ -17,12 +18,18 @@ import type {
   ParentLocator,
 } from "../values/types";
 import type {
+  NormalizedFieldEntry,
   OperationDescriptor,
   PossibleSelections,
 } from "../descriptor/types";
 import type { ForestEnv, IndexedTree } from "./types";
 import { ValueKind } from "../values/types";
-import { resolveSelection } from "../descriptor/resolvedSelection";
+import {
+  fieldEntriesAreEqual,
+  getFieldName,
+  resolveNormalizedField,
+  resolveSelection,
+} from "../descriptor/resolvedSelection";
 import { accumulate } from "../jsutils/map";
 import { assert } from "../jsutils/assert";
 import { CircularBuffer } from "../jsutils/circularBuffer";
@@ -32,6 +39,9 @@ import {
   createCompositeUndefinedChunk,
   createObjectChunk,
   createParentLocator,
+  getDataPathForDebugging,
+  isParentListRef,
+  isParentObjectRef,
   isRootRef,
   isSourceCompositeValue,
   isSourceObject,
@@ -398,7 +408,13 @@ function reIndexList(
   const { dataMap } = context;
   dataMap.set(recyclable.data, parent);
 
-  for (const itemRef of recyclable.itemChunks.values()) {
+  const itemChunks = recyclable.itemChunks;
+  for (let index = 0; index < itemChunks.length; index++) {
+    const itemRef = itemChunks[index];
+    if (itemRef === undefined) {
+      // A hole means the write that *indexed* this list was malformed. Report that one.
+      assert(false, malformedPayloadError(context, recyclable, parent));
+    }
     const itemChunk = itemRef.value;
     if (
       itemChunk?.kind === ValueKind.Object ||
@@ -412,4 +428,145 @@ function reIndexList(
     }
   }
   return recyclable;
+}
+
+type ListFieldOccurrence = { items: number; path: string };
+
+/**
+ * Everything printed here ships to telemetry: schema level names, data paths and item counts
+ * only. Never the node key (it embeds the entity id) or argument values.
+ */
+function malformedPayloadError(
+  context: Context,
+  damaged: CompositeListChunk,
+  parent: GraphChunkReference,
+): string {
+  // The offending payload is still in the tree being recycled, so report that write, not this one.
+  const tree = findIndexingTree(context, damaged);
+  const findParent = createParentLocator(tree?.dataMap ?? context.dataMap);
+  const owner = findOwningField(findParent, parent);
+  const typeName = owner?.parent.type || "(unknown type)";
+  const fieldEntry = owner
+    ? resolveNormalizedField(owner.parent.selection, owner.field)
+    : null;
+  const fieldName = fieldEntry ? getFieldName(fieldEntry) : "(unknown field)";
+  const occurrences = findOccurrences(
+    tree,
+    owner,
+    fieldEntry,
+    damaged,
+    findParent,
+  );
+
+  return [
+    `Detected malformed payload written to the cache: a "${typeName}" node occurs multiple ` +
+      `times in a single write with a different number of items in the "${fieldName}" list.`,
+    ``,
+    `  Operation:  ${damaged.operation.debugName}`,
+    `  Node type:  ${typeName}`,
+    // Occurrences are collected by node key, so they are the same entity by construction.
+    ...(occurrences.length > 1
+      ? [`  Node id:    same in both occurrences (not shown)`]
+      : []),
+    `  Field:      ${fieldEntry ? describeFieldEntry(fieldEntry) : fieldName}`,
+    ``,
+    ...occurrences.map(
+      (occurrence, i) =>
+        `  Occurrence ${i + 1}: ${occurrence.items} ` +
+        `${occurrence.items === 1 ? "item" : "items"} at ${occurrence.path}`,
+    ),
+  ].join("\n");
+}
+
+// The tree that indexed the damaged chunk is the one carrying the malformed payload.
+function findIndexingTree(
+  context: Context,
+  chunk: CompositeListChunk,
+): IndexedTree | null {
+  for (let tree = context.recycleTree; tree; tree = tree.prev) {
+    if (tree.dataMap.has(chunk.data)) {
+      return tree;
+    }
+  }
+  return null;
+}
+
+// The conflicting occurrence is a sibling chunk of the same node with a different item count.
+function findOccurrences(
+  tree: IndexedTree | null,
+  owner: ObjectFieldReference | null,
+  fieldEntry: NormalizedFieldEntry | null,
+  damaged: CompositeListChunk,
+  findParent: ParentLocator,
+): ListFieldOccurrence[] {
+  const key = owner?.parent.key;
+  const found: CompositeListChunk[] = [];
+  if (tree && fieldEntry && typeof key === "string") {
+    for (const chunk of tree.nodes.get(key) ?? EMPTY_ARRAY) {
+      for (const ref of chunk.fieldChunks.values()) {
+        const list = ref.value;
+        if (
+          list.kind === ValueKind.CompositeList &&
+          fieldEntriesAreEqual(
+            resolveNormalizedField(chunk.selection, ref.field),
+            fieldEntry,
+          )
+        ) {
+          found.push(list);
+        }
+      }
+    }
+  }
+  const other = found.find((list) => list.data.length !== damaged.data.length);
+  const occurrences = !other
+    ? [damaged]
+    : found.indexOf(other) < found.indexOf(damaged)
+    ? [other, damaged]
+    : [damaged, other];
+
+  return occurrences.map((list) => ({
+    items: list.data.length,
+    path: describePath(findParent, list, owner),
+  }));
+}
+
+// A list of lists has no field of its own: walk up to the field the outermost list is assigned to.
+function findOwningField(
+  findParent: ParentLocator,
+  parent: GraphChunkReference,
+): ObjectFieldReference | null {
+  try {
+    let ref = parent;
+    while (isParentListRef(ref)) {
+      ref = findParent(ref.parent);
+    }
+    return isParentObjectRef(ref) ? ref : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function describeFieldEntry(fieldEntry: NormalizedFieldEntry): string {
+  if (typeof fieldEntry === "string") {
+    return fieldEntry;
+  }
+  // Argument *names* are schema, argument values are not: elide the values.
+  const args = [...(fieldEntry.args?.keys() ?? [])]
+    .map((name) => `${name}: ...`)
+    .join(", ");
+  return args ? `${fieldEntry.name}(${args})` : fieldEntry.name;
+}
+
+function describePath(
+  findParent: ParentLocator,
+  list: CompositeListChunk,
+  owner: ObjectFieldReference | null,
+): string {
+  // Stay defensive: this runs while reporting an error, on a tree that is known to be broken.
+  try {
+    const path = getDataPathForDebugging({ findParent }, list);
+    return path.length ? `data.${path.join(".")}` : "data";
+  } catch (e) {
+    return `<unknown path>.${owner?.field.dataKey ?? "<unknown field>"}`;
+  }
 }


### PR DESCRIPTION
# Report the malformed payload behind a corrupted list instead of dereferencing a hole

Replaces the production `TypeError: Cannot read properties of undefined (reading 'value')` from
`reIndexList` (`src/forest/indexTree.ts`) - reported against 0.24.5 for
`ComponentsChatQueriesMessageListQuery` - with an error naming the write that caused it.

**Scope: this only improves the error raised when the condition is hit.** It does not change what the
cache accepts, and does not stop the bad state from being created — both are follow ups below.

## The defect

A payload may contain the same node twice, and indexing aggregates the occurrences — sound only when
they agree. When two occurrences carry **different lengths for the same list field**,
`resolveListItemChunk` applies an index valid for the longer one to the shorter chunk. `itemChunks`
is a lazily populated sparse cache of `data`, so assigning past the end grows it and leaves the
skipped indices as **holes**. Payload `null`s are what make one durable: they are skipped when the
list layout is built and again when items are diffed, so nothing backfills them.

That hole sits in committed cache state and reads fine (reads go through `data`). It only surfaces
when a later write recycles the chunk, since `reIndexList` is the one place that walks every item
reference — which is why the operation in the stack trace is innocent.

## The change

`reIndexList` checks the reference before dereferencing it. Detection happens there, but the message
describes the write that *created* the hole: the tree being recycled still holds the offending
payload, so both occurrences are reconstructed from it.

```
Invariant violation: Detected malformed payload written to the cache: a "Thread" node occurs multiple times in a single write with a different number of items in the "messages" list.

  Operation:  query MessageList
  Node type:  Thread
  Node id:    same in both occurrences (not shown)
  Field:      messages

  Occurrence 1: 14 items at data.conversation.thread.messages
  Occurrence 2: 3 items at data.pinned.thread.messages
```

`Operation` is the write that produced the payload — recycling is always same-operation, so there is
no second one to name. `Node id` states what makes the divergence a conflict (both paths resolve to
the same entity) without printing the id.

Hot path cost is one `=== undefined` per list item; the message is built only on failure.

**Telemetry safety.** The `Invariant violation: ` prefix from `assert` is load bearing — the
consuming Apollo wrapper allowlists on `startsWith("Invariant")` and *replaces* non-matching messages
with a character count. Everything printed is schema level: type names, field names, data paths,
counts. Never the node key (it embeds the entity id) or argument values.

## Tests

`src/__tests__/regression.test.ts`, public cache API only.

| test | what it pins |
| --- | --- |
| `reports an unresolved list item instead of dereferencing it` | the production shape: one write punches the hole, the next recycles it; asserts the full message and that the entity id does not leak |
| `reports list indices when the repeated node is itself a list item` | repeated node is a list item with the divergent list hanging off it — occurrences render with their index (`data.inbox.messages.2.files`), and a single item reads `1 item` |
| `accepts a payload repeating a node with lists of equal length` | equal lengths still recycle cleanly — guards against over firing |

Both failing tests return the original error when the guard alone is reverted:

```
Received string: "Cannot read properties of undefined (reading 'value')"
```

Suite: 26 suites, 1114 passed, 12 skipped, 8 todo.

## Follow ups

Both prevent the bad state rather than report it, which is why neither is here.

- **Validate the payload at index time.** Would blame the right operation *and* catch the variant
  where out of range indices resolve in order — the chunk densifies, no hole is left, and this check
  sees nothing. Costs a traversal over repeated nodes and needs its own risk assessment.
  Marked `test.todo("rejects repeated nodes with divergent list lengths at index time")`.
- **Bounds check in `resolveListItemChunk`.** Stops the state being created at all, for every
  producer; a disabled assert for exactly this already sits a few lines above the write. It changes
  out of range semantics (fabricated absence becomes real absence), so it deserves its own PR.
