### PR TITLE
docs(apollo-forest-run): correct the hole precondition in the corrupted-list regression test

### DIFF
--- a/change/@graphitation-apollo-forest-run-5c1f9a2e-8b34-4d71-9e6a-2f8d41c7b093.json
+++ b/change/@graphitation-apollo-forest-run-5c1f9a2e-8b34-4d71-9e6a-2f8d41c7b093.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs(apollo-forest-run): correct an inaccurate comment in the corrupted-list regression test. Test comment only, no product or test behavior change",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "none"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -482,11 +482,12 @@ test("properly replaces objects containing nested composite lists", () => {
 //     the 3 item chunk with no bounds check. The array grows past its data
 //     length and index 3 is left unresolved.
 //
-// Only the *first* out of range index decides whether a hole is left: resolving in
-// ascending order grows the short chunk densely. Leading nulls are the cheapest way
-// to start above its length, not the only one - `layout` is a key lookup
-// (findKeyIndex), so a reordered keyed list visits base indices out of order too,
-// and descendToChunk/retrieveEmbeddedValue resolve a single index with no scan.
+// The gap has to survive: an out of range index resolved early is backfilled by the
+// later ascending pass, and ascending resolution alone just grows the short chunk
+// densely. Nulls are what make it durable - they are skipped both when the layout is
+// built and again when items are diffed, so nothing fills them in. Measured:
+// insertions and re-sorts of a keyed list leave no hole. The routes with no scan in
+// front of them (descendToChunk, retrieveEmbeddedValue) are not covered here.
 //
 // Steps 1+2 are the actual defect in the payload, but nothing reads the hole it
 // leaves until a *later* write recycles that chunk - which is why the stack trace


### PR DESCRIPTION
# Correct the hole precondition in the corrupted-list regression test

Follow up to #708. Comment only — no product or test behaviour change.

## What's wrong

The comment merged in #708 says a reordered keyed list can leave a hole in `itemChunks`, because the
diff layout is built by key lookup (`findKeyIndex`) rather than by position:

```
// Leading nulls are the cheapest way to start above its length, not the only one -
// `layout` is a key lookup (findKeyIndex), so a reordered keyed list visits base
// indices out of order too ...
```

The premise is true, the conclusion isn't. This is the sentence a reader uses to decide whether their
own writer is affected, and as written it puts every ordered-insert list in scope — which is the wrong
answer.

## Measurement

Public cache API, `resolveListItemChunk` instrumented to record every out-of-range write on the short
chunk, with the guard from #708 as the durability detector (a surviving hole throws on the recycling
write).

| scenario | out-of-range writes | durable hole | recycle throws |
| --- | --- | --- | --- |
| leading nulls (control) | 10 | **1** | **yes** |
| insert at model position 0–5 | 8 | 0 | no |
| move an item to the front | 7 | 0 | no |
| full reverse | 7 | 0 | no |

## Why

The corrupted chunk is on the **model** side, and model indices come from `model.data.keys()` —
always ascending. Base indices do permute exactly as the old comment says; it just doesn't matter,
because the base isn't the aggregate carrying the short chunk.

Insertions are the interesting case — they *do* punch a hole, transiently:

```
{ dataLen: 3, index: 4, itemChunksLenBefore: 3, leavesHole: true  }
{ dataLen: 3, index: 3, itemChunksLenBefore: 5, leavesHole: false }   <- backfill
```

An unmatched item has no base index, so `diffCompositeListLayout` resolves it to push a value into
the layout — ahead of the ascending pass, opening a gap. The item loop then reaches that index and
fills it back in.

So the precondition is not *"the first out of range index starts above the length"* but **"the gap is
never backfilled"**. Payload `null`s are the only construct found that qualifies: `diffCompositeListLayout`
pushes `null` and continues *without* resolving the item, and `diffCompositeListValue` skips the same
index again. Skipped on both passes, so nothing fills it.

## New text

```
// The gap has to survive: an out of range index resolved early is backfilled by the
// later ascending pass, and ascending resolution alone just grows the short chunk
// densely. Nulls are what make it durable - they are skipped both when the layout is
// built and again when items are diffed, so nothing fills them in. Measured:
// insertions and re-sorts of a keyed list leave no hole. The routes with no scan in
// front of them (descendToChunk, retrieveEmbeddedValue) are not covered here.
```

Change file is `type: none` — nothing shipped changes, so there's no version to bump.

Regression suite green (40 passed, 1 skipped, 1 todo).