### PR TITLE
fix(apollo-forest-run): report all occurrences behind a malformed payload error

### DIFF
--- a/change/@graphitation-apollo-forest-run-9f2c1a04-6b3e-4d71-8c55-1e7a3f0b2d94.json
+++ b/change/@graphitation-apollo-forest-run-9f2c1a04-6b3e-4d71-8c55-1e7a3f0b2d94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): report every occurrence of a divergent list in the malformed payload error, not just the damaged one. Also reports the slot/hole shape of the corrupted list, and never throws from the reporting itself",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/malformedPayloadReporting.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/malformedPayloadReporting.test.ts
@@ -96,6 +96,9 @@ test("degrades instead of throwing when path resolution fails", () => {
     error = e as Error;
   }
 
+  // The invariant is still what surfaces, degraded to what can be read off the damaged chunk
+  // itself. The underlying failure is named rather than swallowed, so telemetry can tell a
+  // broken description apart from a payload that genuinely has nothing more to report.
   expect(error?.message).toContain("malformed payload");
-  expect(error?.message).not.toContain("parent lookup exploded");
+  expect(error?.message).toContain("reporting failed: parent lookup exploded");
 });

--- a/packages/apollo-forest-run/src/__tests__/malformedPayloadReporting.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/malformedPayloadReporting.test.ts
@@ -1,0 +1,101 @@
+import { gql } from "@apollo/client";
+import { createParentLocator } from "../values";
+import { ForestRun } from "../ForestRun";
+
+// The malformed payload message is assembled by walking a tree that is, by definition, already
+// broken. Traversal must never be the thing that surfaces: a throw here would replace a
+// diagnosable invariant with an unrelated stack trace in telemetry.
+jest.mock("../values", () => {
+  const actual = jest.requireActual("../values");
+  return {
+    ...actual,
+    createParentLocator: jest.fn(actual.createParentLocator),
+  };
+});
+
+const participantFields = `
+  __typename
+  summary {
+    __typename
+    participants {
+      __typename
+      edges {
+        __typename
+        cursor
+        node {
+          __typename
+          id
+        }
+      }
+    }
+  }
+`;
+
+const feedQuery = gql`
+  query Feed {
+    feed {
+      __typename
+      id
+      lastMessage { id subject ${participantFields} }
+      messages { id ${participantFields} }
+    }
+  }
+`;
+
+const seedQuery = gql`
+  query Seed {
+    message { id ${participantFields} }
+  }
+`;
+
+const edge = (cursor: string) => ({
+  __typename: "ParticipantEdge",
+  cursor,
+  node: { __typename: "User", id: cursor },
+});
+
+const message = (edges: unknown[]) => ({
+  __typename: "Message",
+  id: "message-1",
+  summary: {
+    __typename: "ThreadSummary",
+    participants: { __typename: "ParticipantConnection", edges },
+  },
+});
+
+test("degrades instead of throwing when path resolution fails", () => {
+  (createParentLocator as jest.Mock).mockImplementation(() => () => {
+    throw new Error("parent lookup exploded");
+  });
+
+  const cache = new ForestRun({
+    typePolicies: { ParticipantEdge: { keyFields: ["cursor"] } },
+  });
+  cache.write({
+    query: seedQuery,
+    result: { message: message([edge("a"), edge("b")]) },
+  });
+
+  const feed = {
+    __typename: "Feed",
+    id: "feed-1",
+    lastMessage: {
+      ...message([null, null, edge("a"), edge("b")]),
+      subject: "subject",
+    },
+    messages: [message([])],
+  };
+
+  let error: Error | undefined;
+  try {
+    // The second write recycles the chunk corrupted by the first one, which is when the hole
+    // left behind by the divergent lengths is finally dereferenced.
+    cache.write({ query: feedQuery, result: { feed } });
+    cache.write({ query: feedQuery, result: { feed } });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  expect(error?.message).toContain("malformed payload");
+  expect(error?.message).not.toContain("parent lookup exploded");
+});

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -801,6 +801,357 @@ test("reports list indices when the repeated node is itself a list item", () => 
 // indexed, which is a follow up.
 test.todo("rejects repeated nodes with divergent list lengths at index time");
 
+// Both tests above have the divergent list hanging directly off the repeated *node*
+// (`Thread.messages`, `Message.files`). Production hit a shape neither covers: the list
+// belongs to an embedded, keyless object (a Relay connection) nested under the repeated
+// node - `Message.threadSummary.participants.edges`.
+//
+// `findOccurrences` used to key its search on the object owning the list field:
+//
+//     const key = owner?.parent.key;
+//     if (tree && fieldEntry && typeof key === "string") { ...search siblings... }
+//
+// A connection has no id, so its chunk key is `false`, the search was skipped, `found`
+// stayed empty and only the damaged chunk was reported - under a `Node type` naming the
+// connection, which is not a node and cannot be repeated:
+//
+//   ... a "ParticipantConnection" node occurs multiple times in a single write with a
+//   different number of items in the "edges" list.
+//     Operation:  query MessageFeed
+//     Node type:  ParticipantConnection
+//     Field:      edges
+//     Occurrence 1: 0 items at data.feed.messages.0.threadSummary.participants.edges
+//
+// The missing "Node id" line - printed only when two occurrences are found - is what
+// identified that as under-reporting rather than truncation in the telemetry pipeline.
+// The search now climbs to the enclosing `Message` and descends the embedded path, and
+// reporting has two branches: the list is a field of the node (`Node type`), or a field of
+// an object embedded under it (`Object type` + `Parent node type`).
+const participantEdge = (id: string) => ({
+  __typename: "ParticipantEdge",
+  cursor: id,
+  node: { __typename: "User", id },
+});
+
+const threadSummary = (edges: unknown[]) => ({
+  __typename: "ThreadSummary",
+  participants: {
+    __typename: "ParticipantConnection",
+    edges,
+  },
+});
+
+const summarizedMessage = (id: string, edges: unknown[]) => ({
+  __typename: "Message",
+  id,
+  threadSummary: threadSummary(edges),
+});
+
+const summarySeedQuery = gql`
+  query SummarySeed {
+    message {
+      __typename
+      id
+      threadSummary {
+        __typename
+        participants {
+          __typename
+          edges {
+            __typename
+            cursor
+            node {
+              __typename
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// `lastMessage` is selected before `messages`, so its 4 item chunk is aggregated first and
+// the out of range indices are applied to the 0 item chunk at `messages.0`. Its extra
+// `subject` field is what makes the two selections differ: aggregateFieldChunks drops
+// adjacent chunks sharing a selection and operation, so without it the repeat is collapsed
+// before the lists are aggregated and nothing diverges.
+const messageFeedQuery = gql`
+  query MessageFeed {
+    feed {
+      __typename
+      id
+      lastMessage {
+        __typename
+        id
+        subject
+        threadSummary {
+          __typename
+          participants {
+            __typename
+            edges {
+              __typename
+              cursor
+              node {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+      messages {
+        __typename
+        id
+        threadSummary {
+          __typename
+          participants {
+            __typename
+            edges {
+              __typename
+              cursor
+              node {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function writeDivergentConnection(): Error | undefined {
+  // Keyed edges are required: with keyless items diffCompositeListLayout falls through to
+  // the item loop, which resolves every index in order and densifies the short chunk
+  // instead of leaving a hole.
+  const cache = new ForestRun({
+    typePolicies: {
+      ParticipantEdge: { keyFields: ["cursor"] },
+    },
+  });
+  cache.write({
+    query: summarySeedQuery,
+    result: {
+      message: summarizedMessage("7", [
+        participantEdge("a"),
+        participantEdge("b"),
+      ]),
+    },
+  });
+
+  // Message:7 twice in one payload: 4 edges under `lastMessage`, 0 under `messages.0`.
+  const feed = {
+    __typename: "Feed",
+    id: "1",
+    lastMessage: {
+      ...summarizedMessage("7", [
+        null,
+        null,
+        participantEdge("a"),
+        participantEdge("b"),
+      ]),
+      subject: "s",
+    },
+    messages: [summarizedMessage("7", [])],
+  };
+
+  try {
+    // First write punches the hole and is accepted; the second recycles the subtree.
+    cache.write({ query: messageFeedQuery, result: { feed } });
+    cache.write({ query: messageFeedQuery, result: { feed } });
+  } catch (e) {
+    return e as Error;
+  }
+  return undefined;
+}
+
+test("reports both occurrences when the divergent list belongs to an embedded object", () => {
+  const error = writeDivergentConnection();
+
+  // Occurrences are addressed in payload order, so the conflicting one comes first here.
+  // It is the half that explains the divergence, and the half that used to be missing:
+  // `findOccurrences` searched by the key of the *connection*, which is `false`.
+  expect(error?.message).toContain(
+    "Occurrence 1: 4 items at data.feed.lastMessage.threadSummary.participants.edges",
+  );
+  // The damaged (empty) occurrence - the one being recycled when the hole is hit.
+  expect(error?.message).toContain(
+    "Occurrence 2: 0 items at data.feed.messages.0.threadSummary.participants.edges" +
+      " (4 slots, holes at 0,1)",
+  );
+  // Printed only when two occurrences are found, so it tracks the assertions above.
+  expect(error?.message).toContain(
+    "Parent node id:    same in both occurrences (not shown)",
+  );
+  expect(error?.message).not.toContain("Message:7");
+});
+
+test("names the node behind a divergent list of an embedded object", () => {
+  const error = writeDivergentConnection();
+
+  // `edges` is declared by the connection, so that is the type named next to it - saying
+  // "Message" there would point at a type with no such field.
+  expect(error?.message).toContain("Object type:       ParticipantConnection");
+  expect(error?.message).toContain("Field:             edges");
+  // The connection has no id and cannot be repeated on its own: the node occurring twice
+  // is the enclosing Message, and the path says where the connection hangs off it.
+  expect(error?.message).toContain("Parent node type:  Message");
+  expect(error?.message).toContain(
+    "Path in node:      threadSummary.participants.edges",
+  );
+  expect(error?.message).toContain(
+    'a "ParticipantConnection" object embedded in a "Message" node occurs multiple ' +
+      'times in a single write with a different number of items in the "edges" list',
+  );
+});
+
+// Nothing above requires the repeat to be visible in the payload as a repeated *message*.
+// When the summary carries its own id, two different messages pointing at the same summary
+// repeat that node instead - so a query selecting one plain list of messages is enough, and
+// the two occurrences sit at two items of that single list.
+//
+// The two summary chunks survive `aggregateFieldChunks` because `replyTo.threadSummary` and
+// `threadSummary` are separate selection sets: chunks are only collapsed when adjacent and
+// sharing both selection and operation, which is what happens when every item of a list
+// reaches the same node through the same path.
+const keyedSummary = (id: string, edges: unknown[]) => ({
+  __typename: "ThreadSummary",
+  id,
+  participants: {
+    __typename: "ParticipantConnection",
+    edges,
+  },
+});
+
+const keyedSummarySeedQuery = gql`
+  query KeyedSummarySeed {
+    summary {
+      __typename
+      id
+      participants {
+        __typename
+        edges {
+          __typename
+          cursor
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+const messageThreadsQuery = gql`
+  query MessageThreads {
+    feed {
+      __typename
+      id
+      messages {
+        __typename
+        id
+        replyTo {
+          __typename
+          id
+          threadSummary {
+            __typename
+            id
+            participants {
+              __typename
+              edges {
+                __typename
+                cursor
+                node {
+                  __typename
+                  id
+                }
+              }
+            }
+          }
+        }
+        threadSummary {
+          __typename
+          id
+          participants {
+            __typename
+            edges {
+              __typename
+              cursor
+              node {
+                __typename
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+test("reports a node repeated across items of a single list", () => {
+  const cache = new ForestRun({
+    typePolicies: { ParticipantEdge: { keyFields: ["cursor"] } },
+  });
+  cache.write({
+    query: keyedSummarySeedQuery,
+    result: {
+      summary: keyedSummary("x", [participantEdge("a"), participantEdge("b")]),
+    },
+  });
+
+  // ThreadSummary:x twice, under two different messages of the same list: 4 participants
+  // below `messages.0.replyTo`, 0 below `messages.1`.
+  const feed = {
+    __typename: "Feed",
+    id: "1",
+    messages: [
+      {
+        __typename: "Message",
+        id: "1",
+        replyTo: {
+          __typename: "Message",
+          id: "9",
+          threadSummary: keyedSummary("x", [
+            null,
+            null,
+            participantEdge("a"),
+            participantEdge("b"),
+          ]),
+        },
+        threadSummary: keyedSummary("y", []),
+      },
+      {
+        __typename: "Message",
+        id: "2",
+        replyTo: null,
+        threadSummary: keyedSummary("x", []),
+      },
+    ],
+  };
+
+  let error: Error | undefined;
+  try {
+    cache.write({ query: messageThreadsQuery, result: { feed } });
+    cache.write({ query: messageThreadsQuery, result: { feed } });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  // The messages differ, so the repeat is only visible once the summary is named.
+  expect(error?.message).toContain("Parent node type:  ThreadSummary");
+  expect(error?.message).toContain("Object type:       ParticipantConnection");
+  expect(error?.message).toContain(
+    "Occurrence 1: 4 items at data.feed.messages.0.replyTo.threadSummary.participants.edges",
+  );
+  expect(error?.message).toContain(
+    "Occurrence 2: 0 items at data.feed.messages.1.threadSummary.participants.edges",
+  );
+  expect(error?.message).not.toContain("ThreadSummary:x");
+});
+
 test("properly reads plain objects from nested lists", () => {
   const query1 = gql`
     {

--- a/packages/apollo-forest-run/src/forest/indexTree.ts
+++ b/packages/apollo-forest-run/src/forest/indexTree.ts
@@ -445,7 +445,7 @@ function malformedPayloadError(
 ): string {
   // This runs while asserting, on a tree already known to be broken. A throw in here would
   // replace the invariant with an unrelated error and lose the payload description entirely,
-  // so every lookup below is best effort and the whole thing is guarded.
+  // so the whole description is guarded and degrades to what we can read off the chunk itself.
   try {
     return describeMalformedPayload(context, damaged, parent);
   } catch (e) {
@@ -478,7 +478,7 @@ function describeMalformedPayload(
   // The object owning the list may itself be embedded and keyless (a Relay connection is the
   // common case), and a keyless object cannot be repeated on its own: what occurs multiple
   // times is the closest keyed ancestor, so that is what the occurrence search is scoped to.
-  const node = owner && findClosestNodeSafe(owner.parent, findParent);
+  const node = owner && findClosestNode(owner.parent, findParent);
   const embedded = typeof owner?.parent.key !== "string";
   const objectType = owner?.parent.type || "(unknown type)";
   const nodeType = node?.type || "(unknown type)";
@@ -513,10 +513,7 @@ function describeMalformedPayload(
         ["Field", fieldEntry ? describeFieldEntry(fieldEntry) : fieldName],
         // Where the object sits under the node - the data paths below cross node boundaries
         // without marking them, so this is what ties the two together.
-        [
-          "Path in node",
-          describePath(findParent, damaged, node) || "(unknown)",
-        ],
+        ["Path in node", describePath(findParent, damaged, node)],
       ]
     : [
         ["Operation", damaged.operation.debugName],
@@ -572,7 +569,7 @@ function findOccurrences(
   const found: CompositeListChunk[] = [];
   if (tree && type && fieldEntry && node) {
     for (const chunk of tree.typeMap.get(type) ?? EMPTY_ARRAY) {
-      if (findClosestNodeSafe(chunk, findParent)?.key !== node.key) {
+      if (findClosestNode(chunk, findParent)?.key !== node.key) {
         continue;
       }
       // Matched by normalized entry, so aliases and arguments have to line up.
@@ -592,7 +589,7 @@ function findOccurrences(
   return occurrences.map((list) => ({
     items: list.data.length,
     slots: describeSlots(list),
-    path: describePath(findParent, list) ?? "(unknown path)",
+    path: describePath(findParent, list),
   }));
 }
 
@@ -617,33 +614,16 @@ function describeSlots(list: CompositeListChunk): string {
   })`;
 }
 
-// Runs while reporting an error, on a tree that is known to be broken, so the walk up to the
-// node can hit a missing parent.
-function findClosestNodeSafe(
-  chunk: ObjectChunk | CompositeListChunk,
-  findParent: ParentLocator,
-): NodeChunk | null {
-  try {
-    return findClosestNode(chunk, findParent);
-  } catch (e) {
-    return null;
-  }
-}
-
 // A list of lists has no field of its own: walk up to the field the outermost list is assigned to.
 function findOwningField(
   findParent: ParentLocator,
   parent: GraphChunkReference,
 ): ObjectFieldReference | null {
-  try {
-    let ref = parent;
-    while (isParentListRef(ref)) {
-      ref = findParent(ref.parent);
-    }
-    return isParentObjectRef(ref) ? ref : null;
-  } catch (e) {
-    return null;
+  let ref = parent;
+  while (isParentListRef(ref)) {
+    ref = findParent(ref.parent);
   }
+  return isParentObjectRef(ref) ? ref : null;
 }
 
 function describeFieldEntry(fieldEntry: NormalizedFieldEntry): string {
@@ -657,22 +637,12 @@ function describeFieldEntry(fieldEntry: NormalizedFieldEntry): string {
   return args ? `${fieldEntry.name}(${args})` : fieldEntry.name;
 }
 
-// Absolute when `from` is omitted, node relative otherwise. Returns null when the path cannot
-// be resolved: this runs while reporting an error, on a tree that is known to be broken, and
-// an unresolved path must not be reported as the root path.
+// Absolute when `from` is omitted, node relative otherwise.
 function describePath(
   findParent: ParentLocator,
   list: CompositeListChunk,
   from?: ObjectChunk | CompositeListChunk | null,
-): string | null {
-  try {
-    const path = getDataPathForDebugging(
-      { findParent },
-      list,
-      from ?? undefined,
-    );
-    return from ? path.join(".") : `data${path.map((s) => `.${s}`).join("")}`;
-  } catch (e) {
-    return null;
-  }
+): string {
+  const path = getDataPathForDebugging({ findParent }, list, from ?? undefined);
+  return from ? path.join(".") : `data${path.map((s) => `.${s}`).join("")}`;
 }

--- a/packages/apollo-forest-run/src/forest/indexTree.ts
+++ b/packages/apollo-forest-run/src/forest/indexTree.ts
@@ -25,7 +25,6 @@ import type {
 import type { ForestEnv, IndexedTree } from "./types";
 import { ValueKind } from "../values/types";
 import {
-  fieldEntriesAreEqual,
   getFieldName,
   resolveNormalizedField,
   resolveSelection,
@@ -39,13 +38,16 @@ import {
   createCompositeUndefinedChunk,
   createObjectChunk,
   createParentLocator,
+  findClosestNode,
   getDataPathForDebugging,
+  isCompositeListValue,
   isParentListRef,
   isParentObjectRef,
   isRootRef,
   isSourceCompositeValue,
   isSourceObject,
   markAsPartial,
+  resolveFieldValue,
 } from "../values";
 
 type Context = {
@@ -430,7 +432,7 @@ function reIndexList(
   return recyclable;
 }
 
-type ListFieldOccurrence = { items: number; path: string };
+type ListFieldOccurrence = { items: number; slots: string; path: string };
 
 /**
  * Everything printed here ships to telemetry: schema level names, data paths and item counts
@@ -441,39 +443,103 @@ function malformedPayloadError(
   damaged: CompositeListChunk,
   parent: GraphChunkReference,
 ): string {
+  // This runs while asserting, on a tree already known to be broken. A throw in here would
+  // replace the invariant with an unrelated error and lose the payload description entirely,
+  // so every lookup below is best effort and the whole thing is guarded.
+  try {
+    return describeMalformedPayload(context, damaged, parent);
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    return (
+      `Detected malformed payload written to the cache: a list holds fewer items than the ` +
+      `chunks referencing it.\n\n` +
+      `  Operation:  ${
+        damaged.operation?.debugName ?? "(unknown operation)"
+      }\n` +
+      `  Items:      ${damaged.data?.length ?? "(unknown)"}\n\n` +
+      `  (reporting failed: ${reason})`
+    );
+  }
+}
+
+function describeMalformedPayload(
+  context: Context,
+  damaged: CompositeListChunk,
+  parent: GraphChunkReference,
+): string {
   // The offending payload is still in the tree being recycled, so report that write, not this one.
   const tree = findIndexingTree(context, damaged);
   const findParent = createParentLocator(tree?.dataMap ?? context.dataMap);
   const owner = findOwningField(findParent, parent);
-  const typeName = owner?.parent.type || "(unknown type)";
   const fieldEntry = owner
     ? resolveNormalizedField(owner.parent.selection, owner.field)
     : null;
   const fieldName = fieldEntry ? getFieldName(fieldEntry) : "(unknown field)";
+  // The object owning the list may itself be embedded and keyless (a Relay connection is the
+  // common case), and a keyless object cannot be repeated on its own: what occurs multiple
+  // times is the closest keyed ancestor, so that is what the occurrence search is scoped to.
+  const node = owner && findClosestNodeSafe(owner.parent, findParent);
+  const embedded = typeof owner?.parent.key !== "string";
+  const objectType = owner?.parent.type || "(unknown type)";
+  const nodeType = node?.type || "(unknown type)";
   const occurrences = findOccurrences(
     tree,
-    owner,
+    owner?.parent.type,
     fieldEntry,
+    node,
     damaged,
     findParent,
   );
 
-  return [
-    `Detected malformed payload written to the cache: a "${typeName}" node occurs multiple ` +
-      `times in a single write with a different number of items in the "${fieldName}" list.`,
-    ``,
-    `  Operation:  ${damaged.operation.debugName}`,
-    `  Node type:  ${typeName}`,
+  // The list belongs to the node itself, or to an object embedded under it. Both report the
+  // type actually declaring the field, so the embedded case has to name the node separately -
+  // it is the one repeated, and the one to look for in the payload.
+  const nodeIdRow: [string, string][] =
     // Occurrences are collected by node key, so they are the same entity by construction.
-    ...(occurrences.length > 1
-      ? [`  Node id:    same in both occurrences (not shown)`]
-      : []),
-    `  Field:      ${fieldEntry ? describeFieldEntry(fieldEntry) : fieldName}`,
+    occurrences.length > 1
+      ? [
+          [
+            embedded ? "Parent node id" : "Node id",
+            "same in both occurrences (not shown)",
+          ],
+        ]
+      : [];
+  const rows: [string, string][] = embedded
+    ? [
+        ["Operation", damaged.operation.debugName],
+        ["Object type", objectType],
+        ["Parent node type", nodeType],
+        ...nodeIdRow,
+        ["Field", fieldEntry ? describeFieldEntry(fieldEntry) : fieldName],
+        // Where the object sits under the node - the data paths below cross node boundaries
+        // without marking them, so this is what ties the two together.
+        [
+          "Path in node",
+          describePath(findParent, damaged, node) || "(unknown)",
+        ],
+      ]
+    : [
+        ["Operation", damaged.operation.debugName],
+        ["Node type", nodeType],
+        ...nodeIdRow,
+        ["Field", fieldEntry ? describeFieldEntry(fieldEntry) : fieldName],
+      ];
+  // Two spaces after the longest label, matching the layout the single node branch has always used.
+  const labelWidth = Math.max(...rows.map(([label]) => label.length)) + 3;
+
+  return [
+    `Detected malformed payload written to the cache: a "${objectType}" ` +
+      (embedded ? `object embedded in a "${nodeType}" node ` : `node `) +
+      `occurs multiple times in a single write with a different number of items ` +
+      `in the "${fieldName}" list.`,
+    ``,
+    ...rows.map(([label, value]) => `  ${`${label}:`.padEnd(labelWidth)}${value}`), // prettier-ignore
     ``,
     ...occurrences.map(
       (occurrence, i) =>
         `  Occurrence ${i + 1}: ${occurrence.items} ` +
-        `${occurrence.items === 1 ? "item" : "items"} at ${occurrence.path}`,
+        `${occurrence.items === 1 ? "item" : "items"} at ${occurrence.path}` +
+        occurrence.slots,
     ),
   ].join("\n");
 }
@@ -491,29 +557,28 @@ function findIndexingTree(
   return null;
 }
 
-// The conflicting occurrence is a sibling chunk of the same node with a different item count.
+// Occurrences of the same node holding the same list field. The object owning the list is
+// often keyless (a Relay connection), so it cannot be looked up in `tree.nodes` directly:
+// `typeMap` indexes every chunk by type, keyed or not, and the closest node scopes the hits
+// down to the one entity that is actually repeated.
 function findOccurrences(
   tree: IndexedTree | null,
-  owner: ObjectFieldReference | null,
+  type: ObjectChunk["type"] | undefined,
   fieldEntry: NormalizedFieldEntry | null,
+  node: NodeChunk | null,
   damaged: CompositeListChunk,
   findParent: ParentLocator,
 ): ListFieldOccurrence[] {
-  const key = owner?.parent.key;
   const found: CompositeListChunk[] = [];
-  if (tree && fieldEntry && typeof key === "string") {
-    for (const chunk of tree.nodes.get(key) ?? EMPTY_ARRAY) {
-      for (const ref of chunk.fieldChunks.values()) {
-        const list = ref.value;
-        if (
-          list.kind === ValueKind.CompositeList &&
-          fieldEntriesAreEqual(
-            resolveNormalizedField(chunk.selection, ref.field),
-            fieldEntry,
-          )
-        ) {
-          found.push(list);
-        }
+  if (tree && type && fieldEntry && node) {
+    for (const chunk of tree.typeMap.get(type) ?? EMPTY_ARRAY) {
+      if (findClosestNodeSafe(chunk, findParent)?.key !== node.key) {
+        continue;
+      }
+      // Matched by normalized entry, so aliases and arguments have to line up.
+      const value = resolveFieldValue(chunk, fieldEntry);
+      if (value !== undefined && isCompositeListValue(value)) {
+        found.push(value as CompositeListChunk);
       }
     }
   }
@@ -526,8 +591,43 @@ function findOccurrences(
 
   return occurrences.map((list) => ({
     items: list.data.length,
-    path: describePath(findParent, list, owner),
+    slots: describeSlots(list),
+    path: describePath(findParent, list) ?? "(unknown path)",
   }));
+}
+
+/**
+ * The corruption inflates `itemChunks` past the payload length, so the surplus slots tell us how
+ * long the *other* occurrence was even when the search cannot find it. Contiguous holes from zero
+ * point at an aggregate overrun, sparse or offset ones at a stale layout.
+ */
+function describeSlots(list: CompositeListChunk): string {
+  const slots = list.itemChunks.length;
+  if (slots === list.data.length) {
+    return "";
+  }
+  const holes: number[] = [];
+  for (let i = 0; i < slots; i++) {
+    if (list.itemChunks[i] === undefined) {
+      holes.push(i);
+    }
+  }
+  return ` (${slots} slots, holes at ${
+    holes.length ? holes.join(",") : "none"
+  })`;
+}
+
+// Runs while reporting an error, on a tree that is known to be broken, so the walk up to the
+// node can hit a missing parent.
+function findClosestNodeSafe(
+  chunk: ObjectChunk | CompositeListChunk,
+  findParent: ParentLocator,
+): NodeChunk | null {
+  try {
+    return findClosestNode(chunk, findParent);
+  } catch (e) {
+    return null;
+  }
 }
 
 // A list of lists has no field of its own: walk up to the field the outermost list is assigned to.
@@ -557,16 +657,22 @@ function describeFieldEntry(fieldEntry: NormalizedFieldEntry): string {
   return args ? `${fieldEntry.name}(${args})` : fieldEntry.name;
 }
 
+// Absolute when `from` is omitted, node relative otherwise. Returns null when the path cannot
+// be resolved: this runs while reporting an error, on a tree that is known to be broken, and
+// an unresolved path must not be reported as the root path.
 function describePath(
   findParent: ParentLocator,
   list: CompositeListChunk,
-  owner: ObjectFieldReference | null,
-): string {
-  // Stay defensive: this runs while reporting an error, on a tree that is known to be broken.
+  from?: ObjectChunk | CompositeListChunk | null,
+): string | null {
   try {
-    const path = getDataPathForDebugging({ findParent }, list);
-    return path.length ? `data.${path.join(".")}` : "data";
+    const path = getDataPathForDebugging(
+      { findParent },
+      list,
+      from ?? undefined,
+    );
+    return from ? path.join(".") : `data${path.map((s) => `.${s}`).join("")}`;
   } catch (e) {
-    return `<unknown path>.${owner?.field.dataKey ?? "<unknown field>"}`;
+    return null;
   }
 }


### PR DESCRIPTION
Follow-up to #708. Diagnostics only: the malformed write is still accepted, it is just reported usefully when it is hit.

## The problem

Error for the invariant added in #708 always shows a **single** occurrence for embedded values.

```
  Occurrence 1: 4 items at data.feed.lastMessage.threadSummary.participants.edges
```

## Changes

Report occurrences for embedded values properly + report holes:

```
  Occurrence 1: 4 items at data.feed.lastMessage.threadSummary.participants.edges
  Occurrence 2: 0 items at data.feed.messages.0.threadSummary.participants.edges (4 slots, holes at 0,1)
```
