### PR TITLE
fix(apollo-forest-run): gate divergent chunk reconciliation behind a flag

### DIFF
--- a/change/@graphitation-apollo-forest-run-3c1f0a17-9b6d-4a2b-8f0e-2d5c6a1b7e94.json
+++ b/change/@graphitation-apollo-forest-run-3c1f0a17-9b6d-4a2b-8f0e-2d5c6a1b7e94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(apollo-forest-run): gate divergent chunk reconciliation behind the reconcileDivergentChunks flag (disabled by default)",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "vrazuvaev@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -2385,7 +2385,7 @@ test("merge policy on embedded object must not crash when a prior null operation
 });
 
 test("updates a node field that is null in one chunk and an object in another", () => {
-  const cache = new ForestRun();
+  const cache = new ForestRun({ reconcileDivergentChunks: true });
   const aliasedQuery = gql`
     query Aliased {
       x: foo {
@@ -2463,7 +2463,7 @@ test("updates a node field that is null in one chunk and an object in another", 
 });
 
 test("updates repeated node ids with divergent object and null fields", () => {
-  const cache = new ForestRun();
+  const cache = new ForestRun({ reconcileDivergentChunks: true });
   const listQuery = gql`
     query List {
       foos {
@@ -2536,7 +2536,7 @@ test("updates repeated node ids with divergent object and null fields", () => {
 });
 
 test("updates a list item that is null in one chunk and an object in another", () => {
-  const cache = new ForestRun();
+  const cache = new ForestRun({ reconcileDivergentChunks: true });
   const aliasedQuery = gql`
     query Aliased {
       x: foo {

--- a/packages/apollo-forest-run/src/cache/env.ts
+++ b/packages/apollo-forest-run/src/cache/env.ts
@@ -50,6 +50,7 @@ export function createCacheEnvironment(config?: CacheConfig): CacheEnv {
     optimizeFragmentReads: config?.optimizeFragmentReads ?? false,
     cleanupNonCacheableOperations:
       config?.cleanupNonCacheableOperations ?? false,
+    reconcileDivergentChunks: config?.reconcileDivergentChunks ?? false,
     nonEvictableQueries: config?.nonEvictableQueries ?? new Set(),
     partitionConfig: resolvePartitionConfig(
       {

--- a/packages/apollo-forest-run/src/cache/types.ts
+++ b/packages/apollo-forest-run/src/cache/types.ts
@@ -197,6 +197,7 @@ export type ForestRunAdditionalConfig<
   logStaleOperations?: boolean;
   optimizeFragmentReads?: boolean;
   cleanupNonCacheableOperations?: boolean;
+  reconcileDivergentChunks?: boolean;
 
   historyConfig?: HistoryConfig<TPartitions>;
 };
@@ -280,6 +281,14 @@ export type CacheEnv<TPartitions extends HistoryPartitions = any> = {
    * `store.operations` for the lifetime of the cache.
    */
   cleanupNonCacheableOperations: boolean;
+  /**
+   * When enabled, object and list differences carry their model value, so updates can
+   * reconcile chunks of the same node that diverged into `null` or missing values
+   * (instead of failing update invariants and leaving stale chunks behind).
+   *
+   * Disabled by default: it adds work on the common diffing path.
+   */
+  reconcileDivergentChunks: boolean;
   historyConfig?: HistoryConfig<TPartitions>;
 };
 

--- a/packages/apollo-forest-run/src/diff/__tests__/diffObject.test.ts
+++ b/packages/apollo-forest-run/src/diff/__tests__/diffObject.test.ts
@@ -12,6 +12,7 @@ import {
   DiffEnv,
   FieldEntryDifference,
   CompositeListDifference,
+  ObjectDifference,
 } from "../types";
 import {
   completeObject,
@@ -1736,7 +1737,7 @@ describe("kitchen-sink", () => {
 
   test("detects list item changes when base chunks have different selections", () => {
     const forestEnv = { objectKey: (obj: any) => obj.id };
-    const diffEnv = {};
+    const diffEnv = { reconcileDivergentChunks: true };
 
     // Op1: narrow selection on list items (only foo)
     const doc1 = gql`
@@ -1832,6 +1833,49 @@ describe("kitchen-sink", () => {
     }
     // Item 1's bar change should also be dirty (missed due to enqueueListItem bug)
     expect(listDiff.dirtyItems?.has(1)).toBe(true);
+  });
+});
+
+describe("reconcileDivergentChunks", () => {
+  const base = () =>
+    completeObject({ plainObject: plainObjectFoo({ foo: "foo" }) });
+  const model = () =>
+    completeObject({ plainObject: plainObjectFoo({ foo: "updated" }) });
+
+  const getPlainObjectDiff = (difference: ObjectDifference) => {
+    const fieldDiff = difference.fieldState.get(
+      "plainObject",
+    ) as FieldEntryDifference;
+    assert(fieldDiff);
+    const state = fieldDiff.state;
+    assert(isObjectDifference(state));
+    return state;
+  };
+
+  test("does not carry model values when disabled (default)", () => {
+    const { result } = diff(base(), model());
+    const difference = result.difference;
+    assert(difference);
+
+    expect(difference.newValue).toBeUndefined();
+    expect(getPlainObjectDiff(difference).newValue).toBeUndefined();
+  });
+
+  test("carries model values when enabled", () => {
+    const { result, model: modelValue } = diff(
+      base(),
+      model(),
+      undefined,
+      undefined,
+      { reconcileDivergentChunks: true },
+    );
+    const difference = result.difference;
+    assert(difference);
+
+    expect(difference.newValue).toBe(modelValue);
+    expect(getPlainObjectDiff(difference).newValue?.data).toEqual(
+      plainObjectFoo({ foo: "updated" }),
+    );
   });
 });
 

--- a/packages/apollo-forest-run/src/diff/diffObject.ts
+++ b/packages/apollo-forest-run/src/diff/diffObject.ts
@@ -127,7 +127,9 @@ function diffPlainObjectValue(
     diff = diffObjectChunk(context, base, model, diff);
   }
   if (diff && (Difference.isDirty(diff) || !Difference.isComplete(diff))) {
-    diff.newValue = model;
+    if (context.env.reconcileDivergentChunks) {
+      diff.newValue = model;
+    }
     return diff;
   }
   return undefined;
@@ -493,7 +495,9 @@ function diffCompositeListValue(
     }
   }
   if (diff && (Difference.isDirty(diff) || !Difference.isComplete(diff))) {
-    diff.newValue = model;
+    if (context.env.reconcileDivergentChunks) {
+      diff.newValue = model;
+    }
     return diff;
   }
   return undefined;

--- a/packages/apollo-forest-run/src/diff/types.ts
+++ b/packages/apollo-forest-run/src/diff/types.ts
@@ -18,6 +18,14 @@ import * as ChangeKind from "./itemChangeKind";
 export type DiffEnv = {
   allowMissingFields?: boolean;
 
+  /**
+   * When enabled, object and list differences carry their model value (`newValue`),
+   * allowing updates to reconcile chunks that diverged into `null` or missing values.
+   *
+   * Disabled by default: carrying the model value adds work on the common diffing path.
+   */
+  reconcileDivergentChunks?: boolean;
+
   listItemKey?: (
     item: SourceObject | SourceCompositeList,
     index: number,

--- a/packages/apollo-forest-run/src/forest/__tests__/updateTree.test.ts
+++ b/packages/apollo-forest-run/src/forest/__tests__/updateTree.test.ts
@@ -1878,18 +1878,37 @@ describe("changed and affected nodes detection", () => {
 describe("inconsistent state", () => {
   // Note: this can happen if previous operation update failed and operation result is now stale.
   //   It is still possible to update _some_ "nodes", but others may be in a permanent stale state.
-  test("replaces null values from structural differences", () => {
-    const diffBase = completeObject({
+  const diffBase = () =>
+    completeObject({
       completeObject: completeObject({
         plainObject: plainObjectFoo({ foo: "foo" }),
       }),
     });
-    const model = completeObject({
+  const model = () =>
+    completeObject({
       completeObject: completeObject({
         plainObject: plainObjectFoo({ foo: "updated" }),
       }),
     });
-    const { difference } = diff(diffBase, model);
+
+  test("does not update missing values when reconcileDivergentChunks is disabled", () => {
+    // Assuming it will trigger re-fetching anyway, given it already has missing field
+    const { difference } = diff(diffBase(), model());
+
+    const updatedBase = completeObject({
+      completeObject: completeObject({
+        plainObject: undefined,
+      }),
+    });
+    const { data } = update(updatedBase, difference);
+
+    expect(data).toBe(updatedBase);
+  });
+
+  test("replaces null values from structural differences", () => {
+    const { difference } = diff(diffBase(), model(), {
+      reconcileDivergentChunks: true,
+    });
 
     const updatedBase = completeObject({
       completeObject: completeObject({
@@ -1904,17 +1923,9 @@ describe("inconsistent state", () => {
   });
 
   test("fills missing values from structural differences", () => {
-    const diffBase = completeObject({
-      completeObject: completeObject({
-        plainObject: plainObjectFoo({ foo: "foo" }),
-      }),
+    const { difference } = diff(diffBase(), model(), {
+      reconcileDivergentChunks: true,
     });
-    const model = completeObject({
-      completeObject: completeObject({
-        plainObject: plainObjectFoo({ foo: "updated" }),
-      }),
-    });
-    const { difference } = diff(diffBase, model);
 
     const updatedBase = completeObject({
       completeObject: completeObject({

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -86,10 +86,12 @@ function updateObjectValue(
       const value = Value.resolveFieldChunk(base, fieldInfo);
       const valueIsMissing = Value.isMissingValue(value);
       // A structural difference carrying its model value can recover this inconsistent state.
+      // `newValue` is probed first: it is absent on the common path (and always when the
+      // `reconcileDivergentChunks` flag is disabled), so the kind checks are usually skipped.
       const isRecoverableMissingValue =
+        fieldDiff.newValue !== undefined &&
         (Difference.isObjectDifference(fieldDiff) ||
-          Difference.isCompositeListDifference(fieldDiff)) &&
-        fieldDiff.newValue;
+          Difference.isCompositeListDifference(fieldDiff));
 
       if (
         valueIsMissing &&


### PR DESCRIPTION
PR #695 fixed a real correctness issue, but it is a suspect in increased cache misses. 

This PR hides that behavior behind a feature flag so it can be enabled selectively and A/B'd against the ForestRun benchmark, without reverting the fix.