### PR TITLE
chore(immutable): set resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cross-spawn": "^7.0.5",
     "serialize-javascript": "^7.0.4",
     "webpack": "^5.105.4",
-    "immutable": "~3.8.3",
+    "immutable": "~4.3.9",
     "lodash": "^4.18.1"
   }
 }

--- a/patches/@ardatan+relay-compiler+12.0.0.patch
+++ b/patches/@ardatan+relay-compiler+12.0.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@ardatan/relay-compiler/lib/codegen/CodegenRunner.js b/node_modules/@ardatan/relay-compiler/lib/codegen/CodegenRunner.js
+index 2433448..cae724d 100644
+--- a/node_modules/@ardatan/relay-compiler/lib/codegen/CodegenRunner.js
++++ b/node_modules/@ardatan/relay-compiler/lib/codegen/CodegenRunner.js
+@@ -280,7 +280,7 @@ var CodegenRunner = /*#__PURE__*/function () {
+         var documents = _this5.parsers[_parser2].documents();
+ 
+         var schema = Profiler.run('getSchema', function () {
+-          return createSchema(_this5.parserConfigs[_parser2].getSchemaSource(), baseDocuments.toArray(), _this5.parserConfigs[_parser2].schemaExtensions);
++          return createSchema(_this5.parserConfigs[_parser2].getSchemaSource(), baseDocuments.valueSeq().toArray(), _this5.parserConfigs[_parser2].schemaExtensions);
+         });
+         var outputDirectories = yield writeFiles({
+           onlyValidate: _this5.onlyValidate,
+diff --git a/node_modules/@ardatan/relay-compiler/lib/core/CompilerContext.js b/node_modules/@ardatan/relay-compiler/lib/core/CompilerContext.js
+index a066fda..09c6c26 100644
+--- a/node_modules/@ardatan/relay-compiler/lib/core/CompilerContext.js
++++ b/node_modules/@ardatan/relay-compiler/lib/core/CompilerContext.js
+@@ -41,7 +41,7 @@ var CompilerContext = /*#__PURE__*/function () {
+   var _proto = CompilerContext.prototype;
+ 
+   _proto.documents = function documents() {
+-    return this._documents.toArray();
++    return this._documents.valueSeq().toArray();
+   };
+ 
+   _proto.forEachDocument = function forEachDocument(fn) {

--- a/patches/relay-compiler+12.0.0.patch
+++ b/patches/relay-compiler+12.0.0.patch
@@ -11,3 +11,29 @@ index 3aa2c30..315444a 100644
        } else if (definition.kind === 'DirectiveDefinition') {
          _this9._parseDirective(definition, true
          /* client directive */
+diff --git a/node_modules/relay-compiler/lib/codegen/CodegenRunner.js b/node_modules/relay-compiler/lib/codegen/CodegenRunner.js
+index 2433448..cae724d 100644
+--- a/node_modules/relay-compiler/lib/codegen/CodegenRunner.js
++++ b/node_modules/relay-compiler/lib/codegen/CodegenRunner.js
+@@ -280,7 +280,7 @@ var CodegenRunner = /*#__PURE__*/function () {
+         var documents = _this5.parsers[_parser2].documents();
+ 
+         var schema = Profiler.run('getSchema', function () {
+-          return createSchema(_this5.parserConfigs[_parser2].getSchemaSource(), baseDocuments.toArray(), _this5.parserConfigs[_parser2].schemaExtensions);
++          return createSchema(_this5.parserConfigs[_parser2].getSchemaSource(), baseDocuments.valueSeq().toArray(), _this5.parserConfigs[_parser2].schemaExtensions);
+         });
+         var outputDirectories = yield writeFiles({
+           onlyValidate: _this5.onlyValidate,
+diff --git a/node_modules/relay-compiler/lib/core/CompilerContext.js b/node_modules/relay-compiler/lib/core/CompilerContext.js
+index a066fda..09c6c26 100644
+--- a/node_modules/relay-compiler/lib/core/CompilerContext.js
++++ b/node_modules/relay-compiler/lib/core/CompilerContext.js
+@@ -41,7 +41,7 @@ var CompilerContext = /*#__PURE__*/function () {
+   var _proto = CompilerContext.prototype;
+ 
+   _proto.documents = function documents() {
+-    return this._documents.toArray();
++    return this._documents.valueSeq().toArray();
+   };
+ 
+   _proto.forEachDocument = function forEachDocument(fn) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11826,10 +11826,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:~3.8.3":
-  version: 3.8.3
-  resolution: "immutable@npm:3.8.3"
-  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
+"immutable@npm:~4.3.9":
+  version: 4.3.9
+  resolution: "immutable@npm:4.3.9"
+  checksum: 10c0/394faa90ac8f2f62824e6c639705efdb8313787d6bc7864e28a48ee36aa2ba4b724eaf54a701ad991c278967a412b09143dd24fd19e3e2b0204eb481a5afa6ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Root cause
List stores its values in a 32-wide trie (SHIFT = 5, so each level addresses 5 more bits) and uses signed 32-bit bitwise arithmetic throughout setListBounds() (src/List.js):

Infinite loop (the hang / OOM). The level-raising loop
while (newTailOffset >= 1 << (newLevel + SHIFT)) {
  newRoot = new VNode(
    newRoot && newRoot.array.length ? [newRoot] : [],
    owner
  );
  newLevel += SHIFT;
}
relies on 1 << (newLevel + SHIFT). A JavaScript shift count is taken mod 32, so once newLevel + SHIFT reaches 31 the term goes negative (1 << 31 === -2147483648) and at 32 wraps to 1 (1 << 35 === 8). The comparison then stays true forever and the loop never terminates. On a populated List, each iteration retains a new VNode ([newRoot]), so the heap fills and V8 aborts; on an empty List it spins on CPU without allocating.

Silent wraparound (the setSize corruption). The begin |= 0 / end |= 0 coercion (ToInt32) silently wraps large finite values ((2 ** 31) | 0 === -2147483648, (2 ** 32 + 5) | 0 === 5), producing a wrong resulting size instead of an error.
The threshold is 2 ** 30: that is the largest size for which 1 << (newLevel + SHIFT) stays a valid positive 32-bit integer throughout the loops (newLevel + SHIFT stays ≤ 30).