### PR TITLE
test(apollo-forest-run): reproduce cache covers divergence

### DIFF
--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -2822,7 +2822,7 @@ describe("@cache(covers) recycling a divergent node field", () => {
         list.result,
       );
 
-      expect(() =>
+      const write = () =>
         cache.write({
           query: detailQuery,
           result: {
@@ -2835,18 +2835,26 @@ describe("@cache(covers) recycling a divergent node field", () => {
               },
             },
           },
-        }),
-      ).not.toThrow();
-      expect(cache.diff({ query: listQuery, optimistic: true }).result).toEqual({
-        foo: {
-          __typename: "Foo",
-          id: "1",
-          details: {
-            __typename: "Detail",
-            value: "new",
+        });
+      if (covers === "set" && !reconcileDivergentChunks) {
+        expect(write).toThrow(
+          'Invariant violation: Failed to update "query ListQuery" at path details: expected CompositeNull, got ObjectDifference',
+        );
+        return;
+      }
+      expect(write).not.toThrow();
+      expect(cache.diff({ query: listQuery, optimistic: true }).result).toEqual(
+        {
+          foo: {
+            __typename: "Foo",
+            id: "1",
+            details: {
+              __typename: "Detail",
+              value: "new",
+            },
           },
         },
-      });
+      );
     },
   );
 });
@@ -2943,20 +2951,23 @@ describe("@cache(covers) recycling a divergent node field under a read policy", 
     ["reverse", "set", coveredQuery, preloaderWithCovers],
   ])(
     "updates the %s operation when covers is %s",
-    (_direction, _covers, sourceQuery, targetQuery) => {
+    (_direction, covers, sourceQuery, targetQuery) => {
       const cache = new ForestRun({
         reconcileDivergentChunks: true,
         typePolicies,
       });
+      const notifications: unknown[] = [];
       // Evaluate the target while notifying this watch, so the invariant surfaces
       // from the source write just as it does in the write telemetry.
       cache.watch({
         query: targetQuery,
         optimistic: true,
-        callback() {},
+        callback(diff) {
+          notifications.push(diff.result);
+        },
       });
 
-      expect(() =>
+      const write = () =>
         cache.write({
           query: sourceQuery,
           result: {
@@ -2972,8 +2983,26 @@ describe("@cache(covers) recycling a divergent node field under a read policy", 
               details: null,
             },
           },
-        }),
-      ).not.toThrow();
+        });
+      expect(write).not.toThrow();
+      const expected = {
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          extra: true,
+          details: { __typename: "Detail", value: "OLD" },
+        },
+        bar: {
+          __typename: "Foo",
+          id: "1",
+          details:
+            covers === "set" ? null : { __typename: "Detail", value: "OLD" },
+        },
+      };
+      expect(notifications).toEqual([expected]);
+      expect(
+        cache.diff({ query: targetQuery, optimistic: true }).result,
+      ).toEqual(expected);
     },
   );
 });

--- a/packages/apollo-forest-run/src/__tests__/regression.test.ts
+++ b/packages/apollo-forest-run/src/__tests__/regression.test.ts
@@ -2676,3 +2676,304 @@ test("updates a list item that is null in one chunk and an object in another", (
   });
   expect(single.complete).toBe(true);
 });
+
+describe("@cache(covers) recycling a divergent node field", () => {
+  const detailQuery = gql`
+    query DetailQuery {
+      foo {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const listQuery = gql`
+    query ListQuery {
+      foo {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const preloaderWithEmptyCovers = gql`
+    query PreloaderQuery @cache(covers: []) {
+      first: foo {
+        __typename
+        id
+        extra
+        details {
+          __typename
+          value
+        }
+      }
+      second: foo {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const preloaderWithCovers = gql`
+    query PreloaderQuery
+    @cache(covers: ["ListQuery", "DetailQuery", "DraftQuery"]) {
+      first: foo {
+        __typename
+        id
+        extra
+        details {
+          __typename
+          value
+        }
+      }
+      second: foo {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+
+  test.each([
+    ["empty", false, preloaderWithEmptyCovers],
+    ["set", false, preloaderWithCovers],
+    ["empty", true, preloaderWithEmptyCovers],
+    ["set", true, preloaderWithCovers],
+  ])(
+    "updates details when covers is %s and reconciliation is %s",
+    (covers, reconcileDivergentChunks, preloaderQuery) => {
+      const cache = new ForestRun({
+        maxOperationCount: 2,
+        reconcileDivergentChunks,
+      });
+
+      cache.write({
+        query: detailQuery,
+        result: {
+          foo: {
+            __typename: "Foo",
+            id: "1",
+            details: {
+              __typename: "Detail",
+              value: "old",
+            },
+          },
+        },
+      });
+      cache.write({
+        query: preloaderQuery,
+        result: {
+          first: {
+            __typename: "Foo",
+            id: "1",
+            extra: true,
+            details: {
+              __typename: "Detail",
+              value: "old",
+            },
+          },
+          second: {
+            __typename: "Foo",
+            id: "1",
+            details: null,
+          },
+        },
+      });
+
+      // Ordinary hydration takes the first, broader object-valued chunk. Covers
+      // skips it because its selection is not exact and recycles the later null.
+      const list = cache.diff({
+        query: listQuery,
+        optimistic: true,
+      });
+      expect(list.result).toEqual({
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          details:
+            covers === "set"
+              ? null
+              : {
+                  __typename: "Detail",
+                  value: "old",
+                },
+        },
+      });
+
+      // Preserve the covered query's recycled value, but remove the malformed
+      // preloader so the next object-to-object write produces an ObjectDifference.
+      cache.diff({ query: detailQuery, optimistic: true });
+      expect(cache.getStats().treeCount).toBe(3);
+      expect(cache.gc()).toHaveLength(1);
+      expect(cache.getStats().treeCount).toBe(2);
+      expect(cache.diff({ query: listQuery, optimistic: true }).result).toEqual(
+        list.result,
+      );
+
+      expect(() =>
+        cache.write({
+          query: detailQuery,
+          result: {
+            foo: {
+              __typename: "Foo",
+              id: "1",
+              details: {
+                __typename: "Detail",
+                value: "new",
+              },
+            },
+          },
+        }),
+      ).not.toThrow();
+      expect(cache.diff({ query: listQuery, optimistic: true }).result).toEqual({
+        foo: {
+          __typename: "Foo",
+          id: "1",
+          details: {
+            __typename: "Detail",
+            value: "new",
+          },
+        },
+      });
+    },
+  );
+});
+
+describe("@cache(covers) recycling a divergent node field under a read policy", () => {
+  // A read policy on the embedded type forces the read result through `transformTree`,
+  // which synthesizes the intermediate field differences itself (never through `diffObject`).
+  // Those differences therefore never carry `newValue`, no matter how
+  // `reconcileDivergentChunks` is configured.
+  const typePolicies = {
+    Detail: {
+      fields: {
+        value: {
+          read(existing: unknown) {
+            return typeof existing === "string"
+              ? existing.toUpperCase()
+              : existing;
+          },
+        },
+      },
+    },
+  };
+
+  // Two distinct root fields resolving to the same node: `foo` selects an extra
+  // field, `bar` does not, so only `bar` can recycle the preloader's null chunk.
+  const coveredQuery = gql`
+    query CoveredQuery {
+      foo {
+        __typename
+        id
+        extra
+        details {
+          __typename
+          value
+        }
+      }
+      bar {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const preloaderWithEmptyCovers = gql`
+    query PreloaderQuery @cache(covers: []) {
+      foo {
+        __typename
+        id
+        extra
+        details {
+          __typename
+          value
+        }
+      }
+      bar {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+  const preloaderWithCovers = gql`
+    query PreloaderQuery @cache(covers: ["CoveredQuery"]) {
+      foo {
+        __typename
+        id
+        extra
+        details {
+          __typename
+          value
+        }
+      }
+      bar {
+        __typename
+        id
+        details {
+          __typename
+          value
+        }
+      }
+    }
+  `;
+
+  test.each([
+    ["forward", "empty", preloaderWithEmptyCovers, coveredQuery],
+    ["forward", "set", preloaderWithCovers, coveredQuery],
+    ["reverse", "empty", coveredQuery, preloaderWithEmptyCovers],
+    ["reverse", "set", coveredQuery, preloaderWithCovers],
+  ])(
+    "updates the %s operation when covers is %s",
+    (_direction, _covers, sourceQuery, targetQuery) => {
+      const cache = new ForestRun({
+        reconcileDivergentChunks: true,
+        typePolicies,
+      });
+      // Evaluate the target while notifying this watch, so the invariant surfaces
+      // from the source write just as it does in the write telemetry.
+      cache.watch({
+        query: targetQuery,
+        optimistic: true,
+        callback() {},
+      });
+
+      expect(() =>
+        cache.write({
+          query: sourceQuery,
+          result: {
+            foo: {
+              __typename: "Foo",
+              id: "1",
+              extra: true,
+              details: { __typename: "Detail", value: "old" },
+            },
+            bar: {
+              __typename: "Foo",
+              id: "1",
+              details: null,
+            },
+          },
+        }),
+      ).not.toThrow();
+    },
+  );
+});

--- a/packages/apollo-forest-run/src/cache/policies.ts
+++ b/packages/apollo-forest-run/src/cache/policies.ts
@@ -170,6 +170,7 @@ export function applyReadPolicies(
         return diffValue(env, fieldValue, transformedValue, fieldDiff);
       },
     },
+    { skipIncompatibleDifferences: env.reconcileDivergentChunks },
   );
   if (conversionContext.danglingReferences.size) {
     updatedTree.danglingReferences = conversionContext.danglingReferences;
@@ -297,6 +298,7 @@ export function applyMergePolicies(
         return diffValue(diffEnv, fieldValue, value);
       },
     },
+    { skipIncompatibleDifferences: env.reconcileDivergentChunks },
   );
 }
 

--- a/packages/apollo-forest-run/src/diff/types.ts
+++ b/packages/apollo-forest-run/src/diff/types.ts
@@ -92,6 +92,8 @@ export type DiffError =
 export type ObjectDifference = {
   readonly kind: typeof DifferenceKind.ObjectDifference;
   newValue?: ObjectValue;
+  // Path differences synthesized by tree transforms only apply where their structure exists.
+  skipIfIncompatible?: boolean;
   // readonly allFields: Iterable<FieldName>;
 
   fieldQueue: Set<FieldName>;
@@ -146,6 +148,8 @@ export type CompositeListLayoutChange =
 export type CompositeListDifference = {
   readonly kind: typeof DifferenceKind.CompositeListDifference;
   newValue?: CompositeListValue;
+  // Path differences synthesized by tree transforms only apply where their structure exists.
+  skipIfIncompatible?: boolean;
   itemQueue: Set<number>;
   itemState: Map<number, ValueDifference>;
   dirtyItems?: Set<number>;

--- a/packages/apollo-forest-run/src/forest/transformTree.ts
+++ b/packages/apollo-forest-run/src/forest/transformTree.ts
@@ -57,6 +57,10 @@ export type Transformer = {
   ): ValueDifference | undefined;
 };
 
+type TransformOptions = {
+  skipIncompatibleDifferences?: boolean;
+};
+
 const enum DirtyState {
   Clean,
   Dirty,
@@ -68,6 +72,7 @@ type TreeState = {
   nodeDifference: NodeDifferenceMap;
   intermediateTree: IndexedTree;
   findParent: ParentLocator;
+  skipIncompatibleDifferences: boolean;
 };
 
 const EMPTY_ARRAY = Object.freeze([]);
@@ -98,12 +103,14 @@ export function transformTree(
   direction: "ASCEND" | "DESCEND",
   chunkFilter: ChunkFilter,
   transformer: Transformer,
+  options: TransformOptions = {},
 ): IndexedTree {
   const treeState: TreeState = {
     dirty: DirtyState.Clean,
     nodeDifference: new Map(),
     intermediateTree: tree,
     findParent: createParentLocator(tree.dataMap),
+    skipIncompatibleDifferences: options.skipIncompatibleDifferences ?? false,
   };
   let level = 0; // For "DESCEND" mode level 0 points to root chunk. For "ASCEND" mode - to the deepest chunks
   let chunks = collectChunks(tree, direction, chunkFilter);
@@ -197,6 +204,7 @@ function transformChunkFields(
         fieldDifference?.state,
       );
       if (valueDifference && Difference.isDirty(valueDifference)) {
+        markTransformDifference(treeState, valueDifference);
         chunkDiff ??= addDifference(
           treeState,
           parentNode,
@@ -319,6 +327,7 @@ function addDifference(
   chunk: ObjectChunk,
   chunkDifference: ObjectDifference,
 ): ObjectDifference {
+  markTransformDifference(treeState, chunkDifference);
   const { nodeDifference } = treeState;
   let nodeDiff = nodeDifference.get(parentNode.key);
   if (chunk === parentNode) {
@@ -327,7 +336,10 @@ function addDifference(
     return chunkDifference;
   }
   if (!nodeDiff) {
-    nodeDiff = Difference.createObjectDifference();
+    nodeDiff = markTransformDifference(
+      treeState,
+      Difference.createObjectDifference(),
+    );
     nodeDifference.set(parentNode.key, nodeDiff);
   }
   addEmbeddedChunkDifference(
@@ -412,7 +424,9 @@ function addEmbeddedChunkDifference(
         Difference.addFieldDifference(
           parentDiff,
           field,
-          value === chunk ? chunkDifference : createValueDifference(value),
+          value === chunk
+            ? chunkDifference
+            : createValueDifference(treeState, value),
         );
       valueDifference = fieldDifference.state;
     } else {
@@ -425,7 +439,9 @@ function addEmbeddedChunkDifference(
         Difference.addListItemDifference(
           parentDiff,
           step,
-          value === chunk ? chunkDifference : createValueDifference(value),
+          value === chunk
+            ? chunkDifference
+            : createValueDifference(treeState, value),
         );
     }
     assert(
@@ -474,13 +490,34 @@ function markParentNodeDirty(
 }
 
 function createValueDifference(
+  treeState: TreeState,
   chunk: ObjectChunk | CompositeListChunk,
 ): ObjectDifference | CompositeListDifference {
   if (isObjectValue(chunk)) {
-    return Difference.createObjectDifference();
+    return markTransformDifference(
+      treeState,
+      Difference.createObjectDifference(),
+    );
   }
   if (isCompositeListValue(chunk)) {
-    return Difference.createCompositeListDifference();
+    return markTransformDifference(
+      treeState,
+      Difference.createCompositeListDifference(),
+    );
   }
   assertNever(chunk);
+}
+
+function markTransformDifference<T extends ValueDifference>(
+  treeState: TreeState,
+  difference: T,
+): T {
+  if (
+    treeState.skipIncompatibleDifferences &&
+    (Difference.isObjectDifference(difference) ||
+      Difference.isCompositeListDifference(difference))
+  ) {
+    difference.skipIfIncompatible = true;
+  }
+  return difference;
 }

--- a/packages/apollo-forest-run/src/forest/updateObject.ts
+++ b/packages/apollo-forest-run/src/forest/updateObject.ts
@@ -196,6 +196,11 @@ function updateValue(
           );
           return replaceValue(context, base, difference.newValue);
         }
+        if (
+          shouldSkipIncompatibleDifference(context, base, difference, location)
+        ) {
+          return getSourceValue(base);
+        }
         assert(
           false,
           incompatibleDifferenceMessage(context, base, difference, location),
@@ -222,6 +227,11 @@ function updateValue(
           );
           return replaceValue(context, base, difference.newValue);
         }
+        if (
+          shouldSkipIncompatibleDifference(context, base, difference, location)
+        ) {
+          return getSourceValue(base);
+        }
         assert(
           false,
           incompatibleDifferenceMessage(context, base, difference, location),
@@ -241,6 +251,26 @@ function updateValue(
     default:
       assertNever(difference);
   }
+}
+
+function shouldSkipIncompatibleDifference(
+  context: UpdateTreeContext,
+  base: GraphChunk,
+  difference: ObjectDifference | CompositeListDifference,
+  location: UpdateValueLocation,
+): boolean {
+  if (
+    !difference.skipIfIncompatible ||
+    (!Value.isCompositeNullValue(base) &&
+      !Value.isCompositeUndefinedValue(base))
+  ) {
+    return false;
+  }
+  context.env.logger?.debug(
+    "Warning: Skipping conditional difference: " +
+      incompatibleDifferenceMessage(context, base, difference, location),
+  );
+  return true;
 }
 
 function incompatibleDifferenceMessage(


### PR DESCRIPTION
Add public API regressions for divergent object/null chunks introduced by @cache(covers), including the read-policy path that still fails with reconciliation enabled.