### PR TITLE
Upgrade brace-expansion to fix newer DoS vulnerabilities

### DIFF
--- a/change/@graphitation-apollo-forest-run-d1a77852-4464-497e-a349-e5bc529d9232.json
+++ b/change/@graphitation-apollo-forest-run-d1a77852-4464-497e-a349-e5bc529d9232.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade brace-expansion to 1.1.18 in compat lockfile to fix DoS vulnerabilities",
+  "packageName": "@graphitation/apollo-forest-run",
+  "email": "celiac@microsoft.com_msteamsmdb",
+  "dependentChangeType": "patch"
+}

--- a/packages/apollo-forest-run/compat/package-lock.json
+++ b/packages/apollo-forest-run/compat/package-lock.json
@@ -1492,9 +1492,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6595,9 +6595,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3688,9 +3688,9 @@ boxen@^7.0.0:
     wrap-ansi "^8.1.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8027,21 +8027,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to #715. The `brace-expansion` versions currently on `main` are flagged by **newer** advisories published after #715 was prepared. The original ReDoS fix (GHSA-v6h2-p8h4-qcjw, patched in `1.1.12`) is no longer sufficient — four additional DoS advisories affect the `1.x` line up through `1.1.17`, and the `2.x` line up through `2.1.3`.

## Advisories addressed

| Advisory | Summary | 1.x patched | 2.x patched |
|---|---|---|---|
| GHSA-f886-m6hf-6m8v | Zero-step sequence process hang / OOM | 1.1.13 | 2.0.3 |
| GHSA-3jxr-9vmj-r5cp | Exponential-time expansion of `{}` groups | 1.1.16 | 2.1.2 |
| GHSA-mh99-v99m-4gvg | Unbounded expansion length OOM crash | 1.1.17 | 2.1.3 |
| GHSA-rgw5-rvv9-x895 | Unbounded intermediate arrays DoS | **1.1.18** | **2.1.4** |

Target versions chosen as the highest first-patched per major line: **1.1.18** and **2.1.4**.

## Changes

| Lockfile | Entry | Before | After |
|---|---|---|---|
| `yarn.lock` (root) | `brace-expansion@^1.1.7` | 1.1.16 | **1.1.18** |
| `yarn.lock` (root) | `brace-expansion@^2.0.1, ^2.0.2` | 2.0.2 | **2.1.4** |
| `website/yarn.lock` | `brace-expansion@^1.1.7` | 1.1.12 | **1.1.18** |
| `packages/apollo-forest-run/compat/package-lock.json` | `brace-expansion` (both sections) | 1.1.16 | **1.1.18** |

These are patch releases within each major line — no API changes. Root checksums regenerated via `yarn install --mode=update-lockfile`; website (Yarn v1) and compat (npm) integrity hashes computed directly from the published tarballs (sha1 verified against the registry shasum). A beachball `patch` change file is included for `@graphitation/apollo-forest-run`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>