### PR TITLE
Non mutating resolver merge

### DIFF
--- a/change/@graphitation-supermassive-21234229-4768-48a1-9465-f8a89f50dbf5.json
+++ b/change/@graphitation-supermassive-21234229-4768-48a1-9465-f8a89f50dbf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: do not mutate nested objects on resolver merge",
+  "packageName": "@graphitation/supermassive",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/utilities/__tests__/mergeResolvers.test.ts
+++ b/packages/supermassive/src/utilities/__tests__/mergeResolvers.test.ts
@@ -117,4 +117,42 @@ describe("mergeResolvers", () => {
     expect((mergedResolvers2.MyObjectType as ObjectTypeResolver).foo).toBe(foo);
     expect((mergedResolvers3.MyObjectType as ObjectTypeResolver).foo).toBe(foo);
   });
+
+  it("does not mutate or reuse nested objects from resolver maps", () => {
+    const firstUserResolver = () => ({ name: "John" });
+    const secondUserResolver = () => ({ age: 30 });
+    const firstResolvers = {
+      Query: { user: firstUserResolver },
+      Chat: { with: () => ({ name: "John" }) },
+    };
+    const secondResolvers = {
+      Query: { user: secondUserResolver },
+      Chat: { title: () => "Chat" },
+    };
+
+    const mergedResolvers = mergeResolvers({}, [
+      firstResolvers,
+      secondResolvers,
+    ]);
+
+    expect(mergedResolvers).toEqual({
+      Query: { user: secondUserResolver },
+      Chat: {
+        with: firstResolvers.Chat.with,
+        title: secondResolvers.Chat.title,
+      },
+    });
+    expect(firstResolvers).toEqual({
+      Query: { user: firstUserResolver },
+      Chat: { with: firstResolvers.Chat.with },
+    });
+    expect(secondResolvers).toEqual({
+      Query: { user: secondUserResolver },
+      Chat: { title: secondResolvers.Chat.title },
+    });
+    expect(mergedResolvers.Query).not.toBe(firstResolvers.Query);
+    expect(mergedResolvers.Query).not.toBe(secondResolvers.Query);
+    expect(mergedResolvers.Chat).not.toBe(firstResolvers.Chat);
+    expect(mergedResolvers.Chat).not.toBe(secondResolvers.Chat);
+  });
 });

--- a/packages/supermassive/src/utilities/mergeResolvers.ts
+++ b/packages/supermassive/src/utilities/mergeResolvers.ts
@@ -17,13 +17,17 @@ export function mergeResolvers(
 
 function mergeResolversObjMap(accumulator: Resolvers, resolvers: Resolvers) {
   for (const [typeName, typeResolver] of Object.entries(resolvers)) {
-    const fullTypeResolver = accumulator[typeName];
-    if (typeof fullTypeResolver === "undefined" && typeResolver) {
-      accumulator[typeName] = typeResolver;
+    if (!isObjectLike(typeResolver)) {
+      if (typeof accumulator[typeName] === "undefined") {
+        accumulator[typeName] = typeResolver;
+      }
       continue;
     }
-    if (isObjectLike(fullTypeResolver) && isObjectLike(typeResolver)) {
-      Object.assign(accumulator[typeName], typeResolver);
+
+    if (typeof accumulator[typeName] === "undefined") {
+      accumulator[typeName] = {};
     }
+
+    Object.assign(accumulator[typeName], typeResolver);
   }
 }

--- a/packages/supermassive/src/utilities/mergeResolvers.ts
+++ b/packages/supermassive/src/utilities/mergeResolvers.ts
@@ -5,27 +5,48 @@ export function mergeResolvers(
   accumulator: Resolvers,
   resolvers: (Resolvers | Resolvers[])[],
 ): Resolvers {
+  return mergeResolversRecursive(accumulator, resolvers, new Set());
+}
+
+function mergeResolversRecursive(
+  accumulator: Resolvers,
+  resolvers: (Resolvers | Resolvers[])[],
+  owned: Set<string>,
+): Resolvers {
   for (const entry of resolvers) {
     if (Array.isArray(entry)) {
-      mergeResolvers(accumulator, entry);
+      mergeResolversRecursive(accumulator, entry, owned);
     } else {
-      mergeResolversObjMap(accumulator, entry);
+      mergeResolversObjMap(accumulator, entry, owned);
     }
   }
   return accumulator;
 }
 
-function mergeResolversObjMap(accumulator: Resolvers, resolvers: Resolvers) {
+function mergeResolversObjMap(
+  accumulator: Resolvers,
+  resolvers: Resolvers,
+  owned: Set<string>,
+) {
   for (const [typeName, typeResolver] of Object.entries(resolvers)) {
-    if (!isObjectLike(typeResolver)) {
-      if (typeof accumulator[typeName] === "undefined") {
+    const existing = accumulator[typeName];
+    if (existing === undefined) {
+      if (typeResolver) {
         accumulator[typeName] = typeResolver;
       }
       continue;
     }
 
-    if (typeof accumulator[typeName] === "undefined") {
-      accumulator[typeName] = {};
+    if (!isObjectLike(existing) || !isObjectLike(typeResolver)) {
+      continue;
+    }
+
+    if (!owned.has(typeName)) {
+      accumulator[typeName] = Object.assign(
+        Object.create(Object.getPrototypeOf(existing)),
+        existing,
+      );
+      owned.add(typeName);
     }
 
     Object.assign(accumulator[typeName], typeResolver);


### PR DESCRIPTION
This fixes an issue, where mutation of nested level objects (i.e. `resolvers.Query`, `resolvers.Mutation`) was causing resolvers leaking into modules they don't belong in TMP.