### PR TITLE
Fragment loader support for variables

### DIFF
--- a/change/@graphitation-supermassive-0d03cda0-deb3-42ef-9e1d-4f9104649e72.json
+++ b/change/@graphitation-supermassive-0d03cda0-deb3-42ef-9e1d-4f9104649e72.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add schemaFragmentLoader support for input variable types",
+  "packageName": "@graphitation/supermassive",
+  "email": "dsamsonov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/supermassive/src/__tests__/execute.test.ts
+++ b/packages/supermassive/src/__tests__/execute.test.ts
@@ -677,4 +677,127 @@ describe("executeWithoutSchema - regression tests", () => {
     const events = await drainExecution(result);
     expect(events).toMatchSnapshot();
   });
+
+  interface MissingInputTypeTestCase {
+    name: string;
+    document: string;
+    vars?: Record<string, unknown>;
+    partialSchema: string;
+    fullSchema: string;
+  }
+
+  const partialDownloadFileSchema = `
+    type Mutation { 
+      downloadFile(input: FileCoordinates!): DownloadFileResult
+    }
+
+    type DownloadFileResult {
+      downloadUrl: String!
+    }`;
+
+  const fullDownloadFileSchema = `
+    type Mutation { 
+      downloadFile(input: FileCoordinates!): DownloadFileResult
+    }
+
+    input FileCoordinates { 
+      name: String!
+      options: FileDownloadOptions
+    }
+    
+    input FileDownloadOptions {
+      compression: CompressionMode
+    }
+
+    enum CompressionMode {
+      NONE
+      RAR
+      ZIP
+    }
+
+    type DownloadFileResult {
+      downloadUrl: String!
+    }`;
+
+  const missingInputTypeCases: MissingInputTypeTestCase[] = [
+    {
+      name: "missing input variable type",
+      document: `mutation DownloadFile($input: FileCoordinates!) {
+        downloadFile(input: $input) { downloadUrl }
+      }`,
+      vars: { input: { name: "test-file" } },
+      partialSchema: partialDownloadFileSchema,
+      fullSchema: fullDownloadFileSchema,
+    },
+    {
+      name: "missing nested input variable type",
+      document: `mutation DownloadFile($input: FileCoordinates!) {
+        downloadFile(input: $input) { downloadUrl }
+      }`,
+      vars: { input: { name: "test-file", options: { compression: "NONE" } } },
+      partialSchema: `
+        type Mutation { 
+          downloadFile(input: FileCoordinates!): DownloadFileResult
+        }
+
+        input FileCoordinates { 
+          name: String!
+          options: FileDownloadOptions
+        }
+
+        type DownloadFileResult {
+          downloadUrl: String!
+        }`,
+      fullSchema: fullDownloadFileSchema,
+    },
+    // TODO: argument type support will be implemented separately
+    // {
+    //   name: "missing inline argument type",
+    //   document: `mutation DownloadFile {
+    //     downloadFile(input: {name: "bar-file", options:{ compression: "RAR" }}) { downloadUrl }
+    //   }`,
+    //   partialSchema: partialDownloadFileSchema,
+    //   fullSchema: fullDownloadFileSchema,
+    // },
+  ];
+
+  test.each(missingInputTypeCases)(
+    "$name",
+    async ({
+      document,
+      vars,
+      fullSchema,
+      partialSchema,
+    }: MissingInputTypeTestCase) => {
+      expect.assertions(1);
+
+      const fullDefinitions = encodeASTSchema(parse(fullSchema))[0];
+      const partialDefinitions = encodeASTSchema(parse(partialSchema))[0];
+
+      const schemaFragment = {
+        schemaId: "test",
+        definitions: partialDefinitions,
+        resolvers: {
+          Mutation: {
+            downloadFile: () => {
+              return { downloadUrl: "hi" };
+            },
+          },
+        },
+      };
+
+      const parsedDocument = parse(document);
+      const result = await executeWithoutSchema({
+        document: parsedDocument,
+        variableValues: vars,
+        schemaFragment,
+        schemaFragmentLoader: (currentFragment, _context, _req) => {
+          currentFragment.definitions = fullDefinitions;
+          return Promise.resolve({ mergedFragment: currentFragment });
+        },
+      });
+
+      expect(result).toEqual({ data: { downloadFile: { downloadUrl: "hi" } } });
+    },
+  );
 });

--- a/packages/supermassive/src/executeWithoutSchema.ts
+++ b/packages/supermassive/src/executeWithoutSchema.ts
@@ -48,6 +48,7 @@ import {
   getArgumentValues,
   getVariableValues,
   getDirectiveValues,
+  getMissingVariableTypes,
 } from "./values";
 import type { ExecutionHooks } from "./hooks/types";
 import { arraysAreEqual } from "./utilities/array";
@@ -115,7 +116,7 @@ export interface ExecutionContext {
   contextValue: unknown;
   buildContextValue?: (contextValue?: unknown) => unknown;
   operation: OperationDefinitionNode;
-  variableValues: { [variable: string]: unknown };
+  variableValues: VariableValues;
   fieldResolver: FunctionFieldResolver<unknown, unknown>;
   typeResolver: TypeResolver<unknown, unknown>;
   subscribeFieldResolver: FunctionFieldResolver<unknown, unknown>;
@@ -125,6 +126,8 @@ export interface ExecutionContext {
   enablePerEventContext: boolean;
   enableEarlyExecution: boolean;
 }
+
+type VariableValues = { [variable: string]: unknown };
 
 /**
  * Implements the "Executing requests" section of the GraphQL specification.
@@ -139,16 +142,31 @@ export interface ExecutionContext {
 export function executeWithoutSchema(
   args: ExecutionWithoutSchemaArgs,
 ): PromiseOrValue<ExecutionResult> {
-  // If a valid execution context cannot be created due to incorrect arguments,
-  // a "Response" with only errors is returned.
-  const exeContext = buildExecutionContext(args);
+  const { document, variableValues } = args;
+  assertValidExecutionArguments(document, variableValues);
 
-  // Return early errors if execution context failed.
-  if (!("schemaFragment" in exeContext)) {
+  const exeContext = buildExecutionContext(args);
+  if (Array.isArray(exeContext)) {
     return { errors: exeContext };
-  } else {
-    return executeOperationWithBeforeHook(exeContext);
   }
+
+  const coersionResult = populateVariableValuesInContext(
+    exeContext,
+    variableValues,
+  );
+
+  const handleCoersionResult = (coersionErrors: Array<GraphQLError> | void) => {
+    if (Array.isArray(coersionErrors)) {
+      return { errors: coersionErrors };
+    }
+    return executeOperationWithBeforeHook(exeContext);
+  };
+
+  if (isPromise(coersionResult)) {
+    return coersionResult.then(handleCoersionResult);
+  }
+
+  return handleCoersionResult(coersionResult);
 }
 
 /**
@@ -157,9 +175,9 @@ export function executeWithoutSchema(
  *
  * @internal
  */
-export function assertValidExecutionArguments(
+function assertValidExecutionArguments(
   document: DocumentNode,
-  rawVariableValues: Maybe<{ [variable: string]: unknown }>,
+  rawVariableValues: Maybe<VariableValues>,
 ): void {
   devAssert(document, "Must provide document.");
 
@@ -170,17 +188,58 @@ export function assertValidExecutionArguments(
   );
 }
 
+function populateVariableValuesInContext(
+  exeContext: ExecutionContext,
+  rawVariableValues: Maybe<VariableValues>,
+): PromiseOrValue<Array<GraphQLError> | void> {
+  // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
+  const { operation, schemaFragment } = exeContext;
+  const variableDefinitions = operation.variableDefinitions ?? [];
+  const missingTypes = getMissingVariableTypes(
+    variableDefinitions,
+    schemaFragment,
+  );
+
+  const coerce = () => {
+    const coercedVariableValues = getVariableValues(
+      schemaFragment,
+      variableDefinitions,
+      rawVariableValues ?? {},
+      { maxErrors: 50 },
+    );
+
+    if (coercedVariableValues.errors) {
+      return coercedVariableValues.errors;
+    }
+
+    exeContext.variableValues = coercedVariableValues.coerced;
+  };
+
+  if (missingTypes.length) {
+    const pendingSchemaLoad = requestSchemaFragment(exeContext, {
+      kind: "InputVariables",
+      typeNames: missingTypes,
+    });
+
+    if (isPromise(pendingSchemaLoad)) {
+      return pendingSchemaLoad.then(coerce);
+    }
+  }
+
+  return coerce();
+}
+
 /**
  * Constructs a ExecutionContext object from the arguments passed to
  * execute, which we will pass throughout the other execution methods.
  *
- * Throws a GraphQLError if a valid execution context cannot be created.
+ * returns GraphQLError if a valid execution context cannot be created.
  *
  * @internal
  */
 function buildExecutionContext(
   args: ExecutionWithoutSchemaArgs,
-): Array<GraphQLError> | ExecutionContext {
+): ExecutionContext | GraphQLError[] {
   const {
     schemaFragment,
     schemaFragmentLoader,
@@ -188,7 +247,6 @@ function buildExecutionContext(
     rootValue,
     contextValue,
     buildContextValue,
-    variableValues,
     operationName,
     fieldResolver,
     typeResolver,
@@ -197,8 +255,6 @@ function buildExecutionContext(
     enablePerEventContext,
     enableEarlyExecution,
   } = args;
-
-  assertValidExecutionArguments(document, variableValues);
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
@@ -233,20 +289,6 @@ function buildExecutionContext(
     return [locatedError("Must provide an operation.", [])];
   }
 
-  // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
-  const variableDefinitions = operation.variableDefinitions ?? [];
-
-  const coercedVariableValues = getVariableValues(
-    schemaFragment,
-    variableDefinitions,
-    variableValues ?? {},
-    { maxErrors: 50 },
-  );
-
-  if (coercedVariableValues.errors) {
-    return coercedVariableValues.errors;
-  }
-
   return {
     schemaFragment,
     schemaFragmentLoader,
@@ -257,7 +299,7 @@ function buildExecutionContext(
       : contextValue,
     buildContextValue,
     operation,
-    variableValues: coercedVariableValues.coerced,
+    variableValues: {},
     fieldResolver: fieldResolver ?? defaultFieldResolver,
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
@@ -665,8 +707,14 @@ function executeField(
   });
 }
 
-function requestSchemaFragment(
-  exeContext: ExecutionContext,
+export interface SchemaFragmentLoaderContext {
+  contextValue: unknown;
+  schemaFragment: SchemaFragment;
+  schemaFragmentLoader?: SchemaFragmentLoader;
+}
+
+export function requestSchemaFragment(
+  exeContext: SchemaFragmentLoaderContext,
   request: SchemaFragmentRequest,
 ): PromiseOrValue<void> {
   if (!exeContext.schemaFragmentLoader) {

--- a/packages/supermassive/src/types.ts
+++ b/packages/supermassive/src/types.ts
@@ -278,6 +278,10 @@ export type SchemaFragment = {
   operationTypes?: OperationTypes;
 };
 
+export type SchemaFragmentForInputVariablesRequest = {
+  kind: "InputVariables";
+  typeNames: string[];
+};
 export type SchemaFragmentForReturnTypeRequest = {
   kind: "ReturnType";
   parentTypeName: TypeName;
@@ -290,6 +294,7 @@ export type SchemaFragmentForRuntimeTypeRequest = {
 };
 
 export type SchemaFragmentRequest =
+  | SchemaFragmentForInputVariablesRequest
   | SchemaFragmentForReturnTypeRequest
   | SchemaFragmentForRuntimeTypeRequest;
 

--- a/packages/supermassive/src/values.ts
+++ b/packages/supermassive/src/values.ts
@@ -20,6 +20,8 @@ import {
   isDefined,
   isInputType,
   getDirectiveDefinitionArgs,
+  getInputObjectType,
+  getInputObjectFields,
 } from "./schema/definition";
 import { valueFromAST } from "./utilities/valueFromAST";
 import { coerceInputValue } from "./utilities/coerceInputValue";
@@ -27,6 +29,7 @@ import {
   inspectTypeReference,
   isNonNullType,
   typeReferenceFromNode,
+  typeNameFromReference,
 } from "./schema/reference";
 import type { SchemaFragment } from "./types";
 
@@ -79,6 +82,47 @@ export function getVariableValues(
   return { errors: errors };
 }
 
+export function getMissingVariableTypes(
+  varDefNodes: ReadonlyArray<VariableDefinitionNode>,
+  schemaFragment: SchemaFragment,
+) {
+  const missingTypeReferences = [];
+  const typeReferencesToValidate = varDefNodes.map((varDefNode) =>
+    typeReferenceFromNode(varDefNode.type),
+  );
+  const queuedForValidation = new Set(typeReferencesToValidate);
+
+  let index = 0;
+  while (index < typeReferencesToValidate.length) {
+    const varTypeReference = typeReferencesToValidate[index++];
+    if (!isInputType(schemaFragment.definitions, varTypeReference)) {
+      missingTypeReferences.push(typeNameFromReference(varTypeReference));
+      continue;
+    }
+
+    const inputObjectDef = getInputObjectType(
+      schemaFragment.definitions,
+      varTypeReference,
+    );
+    if (inputObjectDef) {
+      for (const maybeTypeReference of Object.values(
+        getInputObjectFields(inputObjectDef),
+      )) {
+        const typeReference = Array.isArray(maybeTypeReference)
+          ? maybeTypeReference[0]
+          : maybeTypeReference;
+
+        if (!queuedForValidation.has(typeReference)) {
+          queuedForValidation.add(typeReference);
+          typeReferencesToValidate.push(typeReference);
+        }
+      }
+    }
+  }
+
+  return missingTypeReferences;
+}
+
 function coerceVariableValues(
   schemaFragment: SchemaFragment,
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
@@ -93,13 +137,18 @@ function coerceVariableValues(
     if (!isInputType(schemaFragment.definitions, varTypeReference)) {
       // Must use input types for variables. This should be caught during
       // validation, however is checked again here for safety.
-      const varTypeStr = inspectTypeReference(varTypeReference);
-      onError(
-        locatedError(
-          `Variable "$${varName}" expected value of type "${varTypeStr}" which cannot be used as an input type.`,
-          [varDefNode.type],
-        ),
-      );
+      const errorMessage = !isDefined(
+        schemaFragment.definitions,
+        varTypeReference,
+      )
+        ? `Missing definition for input type "${typeNameFromReference(
+            varTypeReference,
+          )}"`
+        : `Variable "$${varName}" expected value of type "${inspectTypeReference(
+            varTypeReference,
+          )}" which cannot be used as an input type.`;
+
+      onError(locatedError(errorMessage, [varDefNode.type]));
       continue;
     }
 


### PR DESCRIPTION
Enables schemaFragmentLoader support during variables processing. Before it would hard fail if required input types were missing in current schema fragment.

support for argument processing (`getArgumentValues`) is out of the scope for this PR.

